### PR TITLE
feat(propertiesPanel): Add support for properties with tabular fields

### DIFF
--- a/lib/PropertiesPanel.js
+++ b/lib/PropertiesPanel.js
@@ -16,7 +16,7 @@ var forEach = require('lodash/collection/forEach'),
     xor = require('lodash/array/xor'),
     debounce = require('lodash/function/debounce');
 
-var updateSelection = require('selection-update');
+var calculateSelectionUpdate = require('./util/StringUtils').calculateSelectionUpdate;
 
 
 var DEBOUNCE_DELAY = 300;
@@ -77,7 +77,7 @@ function getFormControlValuesInScope(entryNode) {
  * @param  {DOMElement} entryNode
  * @returns {Object}
  */
-function getFormControlValues(entryNode) {
+/*function getFormControlValues(entryNode) {
 
   var values;
 
@@ -90,6 +90,52 @@ function getFormControlValues(entryNode) {
     });
   }
   else {
+    values = getFormControlValuesInScope(entryNode);
+  }
+
+  return values;
+}*/
+function getFormControlValues(entryNode) {
+
+  var values;
+
+  var listContainer = domQuery('[data-list-entry-container]', entryNode);
+  var tableListContainer = domQuery('[data-list-table-container]', entryNode);
+
+  if(!!listContainer) {
+    values = [];
+    var listNodes = domQuery.all('[data-list-entry-container] > div', entryNode);
+    forEach(listNodes, function(listNode) {
+      values.push(getFormControlValuesInScope(listNode));
+    });
+  }
+  else if(!!tableListContainer) {
+    values = [];    
+    var tableListNodes = domQuery.all('[data-list-table-container] > div', entryNode);
+    forEach(tableListNodes, function(tableListNode) {
+      var value = {};
+      var headNode = domQuery.all('[data-list-table-head-container]', tableListNode);
+      if(!!headNode && headNode.length > 0){
+          value = getFormControlValuesInScope(headNode[0]);        
+      }  
+      var tableNodes = domQuery.all('[data-list-table-rows-container]', tableListNode);
+      forEach(tableNodes, function(tableNode) { 
+        var name = domAttr(tableNode, 'name');
+        if(value[name]===undefined){
+          value[name] = [];
+        }
+        var rowNodes = domQuery.all('[data-list-table-rows-sub-container] > div', tableNode);
+        forEach(rowNodes,function(rowNode){
+          var tempValue = getFormControlValuesInScope(rowNode);
+          if(Object.getOwnPropertyNames(tempValue).length > 0){
+              value[name].push(tempValue);              
+          }
+        });
+      });
+      values.push(value);
+    });
+  }
+  else{
     values = getFormControlValuesInScope(entryNode);
   }
 
@@ -616,7 +662,6 @@ PropertiesPanel.prototype.applyChanges = function(entry, values, containerElemen
   }
 
   entry.oldValues = values;
-  this._updateGroupVisibility();
 };
 
 PropertiesPanel.prototype.applyValidationErrors = function(validationErrors, entryNode) {
@@ -670,19 +715,50 @@ PropertiesPanel.prototype.validate = function(entry, values) {
 
   if(values instanceof Array) {
     var listEntryNodes = domQuery.all('[data-list-entry-container] > div', entryNode);
+    if(!!listEntryNodes && listEntryNodes.length>0){
+      // create new elements
+      for(var i = 0; i < values.length; i++) {
+        var listValue = values[i];
 
-    // create new elements
-    for(var i = 0; i < values.length; i++) {
-      var listValue = values[i];
+        if(entry.validateListItem) {
+          var validationErrors = entry.validateListItem(current.element, listValue);
+          var listEntryNode = listEntryNodes[i];
 
-      if(entry.validateListItem) {
-        var validationErrors = entry.validateListItem(current.element, listValue);
-        var listEntryNode = listEntryNodes[i];
-
-        valid = self.applyValidationErrors(validationErrors, listEntryNode) && valid;
+          valid = self.applyValidationErrors(validationErrors, listEntryNode) && valid;
+        }
       }
     }
+    var tableListEntryNodes = domQuery.all('[data-list-table-container] > div', entryNode);
+    if(!!tableListEntryNodes && tableListEntryNodes.length>0){
+      // create new elements
+      for(var ii = 0; ii < values.length; ii++) {
+        var tableListValue = values[ii];
 
+        if(entry.validateListItem) {
+          var tableValidationErrors = entry.validateListItem(current.element, tableListValue);
+          var tableListEntryNode = tableListEntryNodes[j];
+
+          var head = domQuery.all('[data-list-table-head-container]', tableListEntryNode)[0];
+          for(var name in tableValidationErrors){
+            if(!tableValidationErrors[name] instanceof Array){
+                valid = self.applyValidationErrors(tableValidationErrors[name], head) && valid;                    
+            }
+          }
+          var tables = domQuery.all('[data-list-table-rows-container]', tableListEntryNode);
+          for(var j=0; j<tables.length; j++){
+            var table = tables[j];
+            var tableName = domAttr(table, 'name');
+            var validationError = tableValidationErrors[tableName];
+            if(!!validationError){
+              var rows = domQuery.all('[data-list-table-rows-sub-container] > div', table);
+              for(var k=0;k<validationError.length && k<rows.length;k++){
+                valid = self.applyValidationErrors(validationError[k], rows[k]) && valid;                    
+              }
+            }
+          }
+        }
+      }
+    }
   }
   else {
 
@@ -772,22 +848,111 @@ PropertiesPanel.prototype._bindTemplate = function(element, entry, values, entry
   });
 };
 
-PropertiesPanel.prototype._updateGroupVisibility = function() {
-  var element = this._current.element;
-  var groups = this._current.groups;
-  var panelNode = this._current.panel;
+PropertiesPanel.prototype._bindTableTemplate = function(element, entry, values, entryNode) {
 
-  forEach(groups, function(group) {
-    var groupVisible = group.entries && group.entries.length > 0;
+  var eventBus = this._eventBus;
 
-    if( typeof group.enabled === 'function' ) {
-      groupVisible = group.enabled(element);
-    }
+  function isPropertyEditable(entry, propertyName) {
+    return eventBus.fire('propertiesPanel.isPropertyEditable', {
+      entry: entry,
+      propertyName: propertyName,
+      element: element
+    });
+  }
 
-    var groupNode = domQuery('[data-group='+group.id+']', panelNode);
-    domClasses(groupNode).toggle('hidden', !groupVisible);
-  });
+  var entryNodeHead = domQuery.all('[data-list-table-head-container]', entryNode);
+  if(!!entryNodeHead && entryNodeHead.length > 0){
+      var inputNodes = getPropertyPlaceholders(entryNodeHead[0]);
 
+      forEach(inputNodes, function(node) {
+
+        var name,
+            value,
+            editable;
+
+        // we deal with an input element
+        if ('value' in node) {
+          name = domAttr(node, 'name');
+          value = values[name];
+          editable = isPropertyEditable(entry, name);
+
+          domAttr(node, 'readonly', editable ? null : '');
+          domAttr(node, 'disabled', editable ? null : '');
+
+          if (isToggle(node)) {
+            node.checked = !!(node.value == value || (!domAttr(node, 'value') && value));
+
+          } else if (isSelect(node)) {
+            if(values[name] !== undefined) {
+              node.value = values[name];
+            }
+
+          } else {
+            // prevents input fields from having the value 'undefined'
+            node.value = (values[name] !== undefined) ? values[name] : '';
+          }
+        }
+
+        // we deal with some non-editable html element
+        else {
+          name = domAttr(node, 'data-value');
+          node.textContent = values[name];
+        }
+      });
+  }
+
+  var entryNodeTables = domQuery.all('[data-list-table-rows-container]', entryNode);
+  forEach(entryNodeTables, function(entryNodeTable){
+      var entryNodeRows = domQuery('[data-list-table-rows-sub-container]', entryNodeTable);
+      var existingEntryNodeRows = domQuery.all('[data-list-table-rows-sub-container] > div', entryNodeTable);
+      var tableName = domAttr(entryNodeTable, 'name');
+      if(values[tableName]!==undefined){
+        var entryPropertyName = tableName;
+        for(var i=0; i<values[tableName].length; i++) {
+          var nodeTemplate = existingEntryNodeRows[i];
+          if(!nodeTemplate){
+            nodeTemplate = domify(entry[entryPropertyName].createListEntryTemplate(values[tableName][i], i));
+            entryNodeRows.appendChild(nodeTemplate);
+          }
+          var inputNodes = getPropertyPlaceholders(nodeTemplate);
+          for(var j=0; j<inputNodes.length; j++) {
+            var node = inputNodes[j];
+            var name,
+                value,
+                editable;
+
+            // we deal with an input element
+            if ('value' in node) {
+              name = domAttr(node, 'name');
+              value = values[tableName][i][name];
+              editable = isPropertyEditable(entry, name);
+
+              domAttr(node, 'readonly', editable ? null : '');
+              domAttr(node, 'disabled', editable ? null : '');
+
+              if (isToggle(node)) {
+                node.checked = !!(node.value == value || (!domAttr(node, 'value') && value));
+
+              } else if (isSelect(node)) {
+                if(values[tableName][i][name] !== undefined) {
+                  node.value = values[tableName][i][name];
+                }
+
+              } else {
+                // prevents input fields from having the value 'undefined'
+                node.value = (values[tableName][i][name] !== undefined) ? values[tableName][i][name] : '';
+              }
+            }
+
+            // we deal with some non-editable html element
+            else {
+              name = domAttr(node, 'data-value');
+              node.textContent = values[tableName][i][name];
+            }
+          }
+        }
+      }
+  });  
 };
 
 PropertiesPanel.prototype._updateActivation = function(current) {
@@ -827,25 +992,48 @@ PropertiesPanel.prototype._updateActivation = function(current) {
 
       if (values instanceof Array) {
         var listEntryContainer = domQuery('[data-list-entry-container]', entryNode);
-        var existingElements = domQuery.all('[data-list-entry-container] > div', entryNode);
+        if(!!listEntryContainer){
+              var existingElements = domQuery.all('[data-list-entry-container] > div', entryNode);
 
-        for (var i = 0; i < values.length; i++) {
-          var listValue = values[i];
-          var listItemNode = existingElements[i];
-          if (!listItemNode) {
-            listItemNode = domify(entry.createListEntryTemplate(listValue, i));
-            listEntryContainer.appendChild(listItemNode);
-          }
-          self._bindTemplate(element, entry, listValue, listItemNode);
+              for(var i = 0; i < values.length; i++) {
+              var listValue = values[i];
+              var listItemNode = existingElements[i];
+              if(!listItemNode) {
+                listItemNode = domify(entry.createListEntryTemplate(listValue, i));
+					listEntryContainer.appendChild(listItemNode);
+              }
+              self._bindTemplate(element, entry, listValue, listItemNode);
+            }
+
+            var entriesToRemove = existingElements.length - values.length;
+
+            for(var j = 0; j < entriesToRemove; j++) {
+              // remove orphaned element
+              listEntryContainer.removeChild(listEntryContainer.lastChild);
+            }
         }
 
-        var entriesToRemove = existingElements.length - values.length;
+        var tableListEntryContainer = domQuery('[data-list-table-container]', entryNode);
+        if(!!tableListEntryContainer){
+            var tableExistingElements = domQuery.all('[data-list-table-container] > div', entryNode);
+        
+            for(var ii = 0; ii < values.length; ii++) {
+              var tableListValue = values[ii];
+              var tableListItemNode = tableExistingElements[ii];
+              if(!tableListItemNode) {
+                tableListItemNode = domify(entry.createListEntryTemplate(tableListValue, ii));
+                tableListEntryContainer.appendChild(tableListItemNode);
+              }
+              self._bindTableTemplate(element, entry, tableListValue, tableListItemNode);
+            }
 
-        for (var j = 0; j < entriesToRemove; j++) {
-          // remove orphaned element
-          listEntryContainer.removeChild(listEntryContainer.lastChild);
+            var tableEntriesToRemove = tableExistingElements.length - values.length;
+
+            for(var jj = 0; jj < tableEntriesToRemove; jj++) {
+              // remove orphaned element
+              tableListEntryContainer.removeChild(tableListEntryContainer.lastChild);
+            }
         }
-
       } else {
         self._bindTemplate(element, entry, values, entryNode);
       }
@@ -857,11 +1045,6 @@ PropertiesPanel.prototype._updateActivation = function(current) {
       // remember initial state for later dirty checking
       entry.oldValues = getFormControlValues(entryNode);
     });
-
-    // check whether group provides custom enabled function
-    if(typeof group.enabled === 'function') {
-      groupVisible = group.enabled(element);
-    }
 
     domClasses(groupNode).toggle('hidden', !groupVisible);
   });
@@ -962,7 +1145,7 @@ function setInputValue(node, value) {
 
   // update selection on undo/redo
   if (document.activeElement === node) {
-    selection = updateSelection(getSelection(node), node.value, value);
+    selection = calculateSelectionUpdate(getSelection(node), node.value, value);
   }
 
   node.value = value;

--- a/lib/PropertiesPanel.js
+++ b/lib/PropertiesPanel.js
@@ -850,59 +850,32 @@ PropertiesPanel.prototype._bindTableTemplate = function(element, entry, values, 
       forEach(inputNodes, function(node) {
 
         var name,
-            value,
+            newValue,
             editable;
 
         // we deal with an input element
-        /*if ('value' in node) {
+	if ('value' in node) {
           name = domAttr(node, 'name');
-          value = values[name];
           editable = isPropertyEditable(entry, name);
+          newValue = values[name];
 
           domAttr(node, 'readonly', editable ? null : '');
           domAttr(node, 'disabled', editable ? null : '');
 
           if (isToggle(node)) {
-            node.checked = !!(node.value == value || (!domAttr(node, 'value') && value));
-
+            setToggleValue(node, newValue);
           } else if (isSelect(node)) {
-            if(values[name] !== undefined) {
-              node.value = values[name];
-            }
-
+            setSelectValue(node, newValue);
           } else {
-            // prevents input fields from having the value 'undefined'
-            node.value = (values[name] !== undefined) ? values[name] : '';
+            setInputValue(node, newValue);
           }
         }
 
         // we deal with some non-editable html element
         else {
           name = domAttr(node, 'data-value');
-          node.textContent = values[name];
-        }*/
-		if ('value' in node) {
-      name = domAttr(node, 'name');
-      editable = isPropertyEditable(entry, name);
-      newValue = values[name];
-
-      domAttr(node, 'readonly', editable ? null : '');
-      domAttr(node, 'disabled', editable ? null : '');
-
-      if (isToggle(node)) {
-        setToggleValue(node, newValue);
-      } else if (isSelect(node)) {
-        setSelectValue(node, newValue);
-      } else {
-        setInputValue(node, newValue);
-      }
-    }
-
-    // we deal with some non-editable html element
-    else {
-      name = domAttr(node, 'data-value');
-      setTextValue(node, values[name]);
-    }
+          setTextValue(node, values[name]);
+        }
 
       });
   }
@@ -924,7 +897,7 @@ PropertiesPanel.prototype._bindTableTemplate = function(element, entry, values, 
           for(var j=0; j<inputNodes.length; j++) {
             var node = inputNodes[j];
             var name,
-                value,
+                newValue,
                 editable;
 
             // we deal with an input element
@@ -936,25 +909,13 @@ PropertiesPanel.prototype._bindTableTemplate = function(element, entry, values, 
               domAttr(node, 'readonly', editable ? null : '');
               domAttr(node, 'disabled', editable ? null : '');
 
-              /*if (isToggle(node)) {
-                node.checked = !!(node.value == value || (!domAttr(node, 'value') && value));
-
+              if (isToggle(node)) {
+                    setToggleValue(node, newValue);
               } else if (isSelect(node)) {
-                if(values[tableName][i][name] !== undefined) {
-                  node.value = values[tableName][i][name];
-                }
-
+                setSelectValue(node, newValue);
               } else {
-                // prevents input fields from having the value 'undefined'
-                node.value = (values[tableName][i][name] !== undefined) ? values[tableName][i][name] : '';
-              }*/
-			  if (isToggle(node)) {
-        setToggleValue(node, newValue);
-      } else if (isSelect(node)) {
-        setSelectValue(node, newValue);
-      } else {
-        setInputValue(node, newValue);
-      }
+                setInputValue(node, newValue);
+              }
             }
 
             // we deal with some non-editable html element

--- a/lib/PropertiesPanel.js
+++ b/lib/PropertiesPanel.js
@@ -16,7 +16,7 @@ var forEach = require('lodash/collection/forEach'),
     xor = require('lodash/array/xor'),
     debounce = require('lodash/function/debounce');
 
-var calculateSelectionUpdate = require('./util/StringUtils').calculateSelectionUpdate;
+var updateSelection = require('selection-update');
 
 
 var DEBOUNCE_DELAY = 300;
@@ -77,24 +77,6 @@ function getFormControlValuesInScope(entryNode) {
  * @param  {DOMElement} entryNode
  * @returns {Object}
  */
-/*function getFormControlValues(entryNode) {
-
-  var values;
-
-  var listContainer = domQuery('[data-list-entry-container]', entryNode);
-  if(!!listContainer) {
-    values = [];
-    var listNodes = domQuery.all('[data-list-entry-container] > div', entryNode);
-    forEach(listNodes, function(listNode) {
-      values.push(getFormControlValuesInScope(listNode));
-    });
-  }
-  else {
-    values = getFormControlValuesInScope(entryNode);
-  }
-
-  return values;
-}*/
 function getFormControlValues(entryNode) {
 
   var values;
@@ -662,6 +644,7 @@ PropertiesPanel.prototype.applyChanges = function(entry, values, containerElemen
   }
 
   entry.oldValues = values;
+  this._updateGroupVisibility();
 };
 
 PropertiesPanel.prototype.applyValidationErrors = function(validationErrors, entryNode) {
@@ -955,6 +938,24 @@ PropertiesPanel.prototype._bindTableTemplate = function(element, entry, values, 
   });  
 };
 
+PropertiesPanel.prototype._updateGroupVisibility = function() {
+  var element = this._current.element;
+  var groups = this._current.groups;
+  var panelNode = this._current.panel;
+
+  forEach(groups, function(group) {
+    var groupVisible = group.entries && group.entries.length > 0;
+
+    if( typeof group.enabled === 'function' ) {
+      groupVisible = group.enabled(element);
+    }
+
+    var groupNode = domQuery('[data-group='+group.id+']', panelNode);
+    domClasses(groupNode).toggle('hidden', !groupVisible);
+  });
+
+};
+
 PropertiesPanel.prototype._updateActivation = function(current) {
   var self = this;
 
@@ -1145,7 +1146,7 @@ function setInputValue(node, value) {
 
   // update selection on undo/redo
   if (document.activeElement === node) {
-    selection = calculateSelectionUpdate(getSelection(node), node.value, value);
+    selection = updateSelection(getSelection(node), node.value, value);
   }
 
   node.value = value;

--- a/lib/PropertiesPanel.js
+++ b/lib/PropertiesPanel.js
@@ -854,7 +854,7 @@ PropertiesPanel.prototype._bindTableTemplate = function(element, entry, values, 
             editable;
 
         // we deal with an input element
-        if ('value' in node) {
+        /*if ('value' in node) {
           name = domAttr(node, 'name');
           value = values[name];
           editable = isPropertyEditable(entry, name);
@@ -880,7 +880,30 @@ PropertiesPanel.prototype._bindTableTemplate = function(element, entry, values, 
         else {
           name = domAttr(node, 'data-value');
           node.textContent = values[name];
-        }
+        }*/
+		if ('value' in node) {
+      name = domAttr(node, 'name');
+      editable = isPropertyEditable(entry, name);
+      newValue = values[name];
+
+      domAttr(node, 'readonly', editable ? null : '');
+      domAttr(node, 'disabled', editable ? null : '');
+
+      if (isToggle(node)) {
+        setToggleValue(node, newValue);
+      } else if (isSelect(node)) {
+        setSelectValue(node, newValue);
+      } else {
+        setInputValue(node, newValue);
+      }
+    }
+
+    // we deal with some non-editable html element
+    else {
+      name = domAttr(node, 'data-value');
+      setTextValue(node, values[name]);
+    }
+
       });
   }
 
@@ -907,13 +930,13 @@ PropertiesPanel.prototype._bindTableTemplate = function(element, entry, values, 
             // we deal with an input element
             if ('value' in node) {
               name = domAttr(node, 'name');
-              value = values[tableName][i][name];
+              newValue = values[tableName][i][name];
               editable = isPropertyEditable(entry, name);
 
               domAttr(node, 'readonly', editable ? null : '');
               domAttr(node, 'disabled', editable ? null : '');
 
-              if (isToggle(node)) {
+              /*if (isToggle(node)) {
                 node.checked = !!(node.value == value || (!domAttr(node, 'value') && value));
 
               } else if (isSelect(node)) {
@@ -924,13 +947,21 @@ PropertiesPanel.prototype._bindTableTemplate = function(element, entry, values, 
               } else {
                 // prevents input fields from having the value 'undefined'
                 node.value = (values[tableName][i][name] !== undefined) ? values[tableName][i][name] : '';
-              }
+              }*/
+			  if (isToggle(node)) {
+        setToggleValue(node, newValue);
+      } else if (isSelect(node)) {
+        setSelectValue(node, newValue);
+      } else {
+        setInputValue(node, newValue);
+      }
             }
 
             // we deal with some non-editable html element
             else {
               name = domAttr(node, 'data-value');
-              node.textContent = values[tableName][i][name];
+              //node.textContent = values[tableName][i][name];
+              setTextValue(node, values[tableName][i][name]);
             }
           }
         }
@@ -1046,6 +1077,11 @@ PropertiesPanel.prototype._updateActivation = function(current) {
       // remember initial state for later dirty checking
       entry.oldValues = getFormControlValues(entryNode);
     });
+	
+	// check whether group provides custom enabled function
+    if(typeof group.enabled === 'function') {
+      groupVisible = group.enabled(element);
+    }
 
     domClasses(groupNode).toggle('hidden', !groupVisible);
   });

--- a/lib/provider/camunda/CamundaPropertiesProvider.js
+++ b/lib/provider/camunda/CamundaPropertiesProvider.js
@@ -21,9 +21,9 @@ var serviceTaskDelegateProps = require('./parts/ServiceTaskDelegateProps'),
     jobRetryTimeCycle = require('./parts/JobRetryTimeCycle'),
     sequenceFlowProps = require('./parts/SequenceFlowProps'),
     executionListenerProps = require('./parts/ExecutionListenerProps'),
-    inputParameterProps = require('./parts/InputParameterProps'),
-    outputParameterProps = require('./parts/OutputParameterProps'),
-    formFieldProps = require('./parts/FormFieldProps'),
+    inputParameterProps = require('./parts/InputParameterProps'),    
+    outputParameterProps = require('./parts/OutputParameterProps'),    
+    formFieldProps = require('./parts/FormFieldProps'),    
     scriptProps = require('./parts/ScriptTaskProps'),
     taskListenerProps = require('./parts/TaskListenerProps'),
     startEventFormKey = require('./parts/StartEventFormKey'),
@@ -122,7 +122,7 @@ function CamundaPropertiesProvider(eventBus, bpmnFactory, elementRegistry) {
     };
     executionListenerProps(listenerGroup, element, bpmnFactory);
     taskListenerProps(listenerGroup, element, bpmnFactory);
-
+    
     var parameterGroup = {
       id : 'parameter',
       label: 'Parameter',
@@ -130,7 +130,7 @@ function CamundaPropertiesProvider(eventBus, bpmnFactory, elementRegistry) {
     };
     inputParameterProps(parameterGroup, element, bpmnFactory);
     outputParameterProps(parameterGroup, element, bpmnFactory);
-
+    
     var formGroup = {
       id : 'form',
       label: 'Form',

--- a/lib/provider/camunda/CamundaPropertiesProvider.js
+++ b/lib/provider/camunda/CamundaPropertiesProvider.js
@@ -21,6 +21,9 @@ var serviceTaskDelegateProps = require('./parts/ServiceTaskDelegateProps'),
     jobRetryTimeCycle = require('./parts/JobRetryTimeCycle'),
     sequenceFlowProps = require('./parts/SequenceFlowProps'),
     executionListenerProps = require('./parts/ExecutionListenerProps'),
+    inputParameterProps = require('./parts/InputParameterProps'),
+    outputParameterProps = require('./parts/OutputParameterProps'),
+    formFieldProps = require('./parts/FormFieldProps'),
     scriptProps = require('./parts/ScriptTaskProps'),
     taskListenerProps = require('./parts/TaskListenerProps'),
     startEventFormKey = require('./parts/StartEventFormKey'),
@@ -120,6 +123,21 @@ function CamundaPropertiesProvider(eventBus, bpmnFactory, elementRegistry) {
     executionListenerProps(listenerGroup, element, bpmnFactory);
     taskListenerProps(listenerGroup, element, bpmnFactory);
 
+    var parameterGroup = {
+      id : 'parameter',
+      label: 'Parameter',
+      entries: []
+    };
+    inputParameterProps(parameterGroup, element, bpmnFactory);
+    outputParameterProps(parameterGroup, element, bpmnFactory);
+
+    var formGroup = {
+      id : 'form',
+      label: 'Form',
+      entries: []
+    };
+    formFieldProps(formGroup, element, bpmnFactory);
+
     var documentationGroup = {
       id: 'documentation',
       label: 'Documentation',
@@ -134,6 +152,8 @@ function CamundaPropertiesProvider(eventBus, bpmnFactory, elementRegistry) {
       asyncGroup,
       jobConfigurationGroup,
       listenerGroup,
+      parameterGroup,
+      formGroup,
       documentationGroup
     ];
   };

--- a/lib/provider/camunda/parts/FormFieldProps.js
+++ b/lib/provider/camunda/parts/FormFieldProps.js
@@ -218,25 +218,12 @@ module.exports = function(group, element, bpmnFactory) {
           }
         });
         if(foundFormData){
-            // remove all existing form fields
-            var objectsToRemove = [];
-            forEach(extensionElements.get('values'), function(extensionElement) {
-              if (is(extensionElement, 'camunda:FormData')) {
-                forEach(extensionElement.get('fields'), function(extensionSubElement) {
-                  if (is(extensionSubElement, 'camunda:FormField')) {
-                    objectsToRemove.push(extensionSubElement);
-                  }
-                });
-              }
-            });
-
-            // add all the fields
-            var objectsToAdd = [];
-            createFormField(element, values, formData, objectsToAdd, bpmnFactory);
-            cmd = cmdHelper.addAndRemoveElementsFromList(element, formData, 
-                                                      'fields', 'fields',
-                                                      objectsToAdd, objectsToRemove);
-        
+            formData.fields = [];
+            createFormField(element, values, formData,
+                                    formData.get('fields'), bpmnFactory);
+            cmd =  {
+              extensionElements: extensionElements
+            };
         }
         else{
             formData = elementHelper.createElement('camunda:FormData',

--- a/lib/provider/camunda/parts/FormFieldProps.js
+++ b/lib/provider/camunda/parts/FormFieldProps.js
@@ -1,0 +1,327 @@
+'use strict';
+
+var is = require('bpmn-js/lib/util/ModelUtil').is,
+  getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject,
+  domQuery = require('min-dom/lib/query'),
+  cmdHelper = require('../../../helper/CmdHelper'),
+  elementHelper = require('../../../helper/ElementHelper'),
+  forEach = require('lodash/collection/forEach'),
+  domify = require('min-dom/lib/domify'),
+  
+  constraint = require('./implementation/Constraint')('constraint'),
+  property = require('./implementation/Property')('property');
+
+function createFormTemplate(id) {
+  return '<div class="djs-form-area" data-scope>' +
+            '<button data-action="removeForm"><span>X</span></button>' +
+            '<div data-list-table-head-container>' +                        
+
+              '<div class="pp-row">' +
+                '<label for="cam-form-id-'+id+'">Form ID</label>' +
+                  '<div class="field-wrapper">' +
+                    '<input id="camunda-form-id-'+id+'" type="text" name="formID" />' +
+                    '<button data-action="clearFormID" data-show="canClearFormID">' +
+                      '<span>X</span>' +
+                    '</button>' +
+                  '</div>' +
+              '</div>' +
+
+              '<div class="pp-row">' +
+                '<label for="cam-form-label-'+id+'">Form Label</label>' +
+                '<div class="field-wrapper">' +
+                  '<input id="camunda-form-label-'+id+'" type="text" name="formLabel" />' +
+                  '<button data-action="clearFormLabel" data-show="canClearFormLabel">' +
+                    '<span>X</span>' +
+                  '</button>' +
+                '</div>' +
+              '</div>' +
+
+              '<div class="pp-row">' +
+                '<label for="cam-form-default-'+id+'">Form Default Value</label>' +
+                  '<div class="field-wrapper">' +
+                    '<input id="camunda-form-default-'+id+'" type="text" name="formDefault" />' +
+                    '<button data-action="clearFormDefault" data-show="canClearFormDefault">' +
+                      '<span>X</span>' +
+                    '</button>' +
+                  '</div>' +
+              '</div>' +
+
+              '<div class="pp-row">' +
+                '<label for="cam-form-type-'+id+'">Form Type</label>' +
+                '<div class="field-wrapper">' +
+                  '<select id="cam-form-type-'+id+'" name="formType" data-value>' +
+                    '<option value="string">string</option>' +
+                    '<option value="long">long</option>' +
+                    '<option value="boolean">boolean</option>' +
+                    '<option value="date">date</option>' +
+                    '<option value="enum">enum</option>' +
+                  '</select>' +
+                '</div>' +
+              '</div>' +
+
+            '</div>'+           
+            '<div data-list-table-rows-container name="constraint">' +
+              constraint.template +
+            '</div>'+            
+            '<div data-list-table-rows-container name="property">' +
+              property.template +
+            '</div>'+            
+
+         '</div>';
+}
+
+function getItem(element, bo) {
+  var values = {};
+  
+  // read values from xml:
+  values.formID = bo.get('id');
+  values.formLabel = bo.get('label');
+  values.formDefault = bo.get('defaultValue');
+  values.formType = bo.get('type');
+  
+  var boValidation = bo.get('validation');
+  values.constraint = [];
+  if(boValidation.constraints instanceof Array && boValidation.constraints.length>0){
+    for(var i=0; i<boValidation.constraints.length; i++){
+      values.constraint[i] = constraint.get(element, boValidation.constraints[i]);
+    }
+  }
+
+  var boProperties = bo.get('properties');
+  values.property = [];
+  if(boProperties.values instanceof Array && boProperties.values.length>0){
+    for(var ii=0; ii<boProperties.values.length; ii++){
+      values.property[ii] = property.get(element, boProperties.values[ii]);
+    }
+  }
+
+  return values;
+}
+
+function createFormField(element, values, extensionElements, formFieldList, bpmnFactory) {
+  // add form field values to extension elements values
+  forEach(values, function(value) {
+    var formField = elementHelper.createElement('camunda:FormField',
+                                                     {}, extensionElements, bpmnFactory);
+    formField.id = value.formID;
+    formField.label = value.formLabel;
+    formField.defaultValue = value.formDefault;
+    formField.type = value.formType;
+    
+    formField.validation = elementHelper.createElement('camunda:Validation',
+                                                     {constraints:[]}, formField, bpmnFactory);
+    for(var i=0; i<value.constraint.length; i++){
+      var constraintProps = constraint.set(element, value.constraint[i]);
+      var constraintElement = elementHelper.createElement('camunda:Constraint',
+                                                       constraintProps,
+                                                       formField.validation, bpmnFactory);
+      var constraintKeys = Object.keys(constraintProps);
+      for(var key in constraintKeys){
+          constraintElement[constraintKeys[key]] = constraintProps[constraintKeys[key]];
+      }                                                 
+      formField.validation.constraints.push(constraintElement);
+    }
+    
+    formField.properties = elementHelper.createElement('camunda:Properties',
+                                                     {values:[]}, formField, bpmnFactory);
+    for(var iii=0; iii<value.property.length; iii++){
+      var propertyProps = property.set(element, value.property[iii]);
+      var propertyElement = elementHelper.createElement('camunda:Property',
+                                                       {},formField.properties, bpmnFactory);
+      var propertyKeys = Object.keys(propertyProps);
+      for(var prop in propertyKeys){
+          propertyElement[propertyKeys[prop]] = propertyProps[propertyKeys[prop]];
+      }
+      formField.properties.values.push(propertyElement);
+    }
+    
+    formFieldList.push(formField);
+  });
+
+}
+
+module.exports = function(group, element, bpmnFactory) {
+
+  var bo;
+  var lastIdx = 0;
+
+  if (is(element, 'camunda:FormSupported')) {
+    bo = getBusinessObject(element);
+  }
+
+  if (!bo) {
+    return;
+  }
+
+  group.entries.push({
+    'id': 'formField',
+    'description': 'Configure form field.',
+    'label': 'Form',
+    'html': '<div class="cam-add-form">' +
+              '<label for="addForm">Add Form Fields </label>' +
+              '<button id="addForm" data-action="addForm"><span>+</span></button>' +
+            '</div>' +
+            '<div data-list-table-container></div>',
+
+    createListEntryTemplate: function(value, idx) {
+      lastIdx = idx;
+      return createFormTemplate(idx);
+    },
+
+    get: function (element, propertyName) {
+      var values = [];
+
+      if (!!bo.extensionElements) {
+        var extensionElementsValues = getBusinessObject(element).extensionElements.values;
+        forEach(extensionElementsValues, function(extensionElement) {
+          if (typeof extensionElement.$instanceOf === 'function' &&
+                  is(extensionElement, 'camunda:FormData')) {
+                var extensionElementValues = extensionElement.fields;
+                forEach(extensionElementValues,function(extensionSubElement){
+                if (typeof extensionSubElement.$instanceOf === 'function' &&
+                        is(extensionSubElement, 'camunda:FormField')) {
+                  values.push(getItem(element, extensionSubElement));
+                }      
+            });
+          }
+        });
+      }
+
+      return values;
+    },
+
+    set: function (element, values, containerElement) {
+      var cmd;
+
+      var extensionElements = bo.extensionElements;
+      var formData;
+
+      if (!extensionElements) {
+        extensionElements = elementHelper.createElement('bpmn:ExtensionElements',
+                                                        { values: [] }, bo, bpmnFactory);
+        formData = elementHelper.createElement('camunda:FormData',
+                                                        { fields: [] }, 
+                                                        extensionElements, bpmnFactory);
+        createFormField(element, values, formData, formData.get('fields'), bpmnFactory);
+        extensionElements.get('values').push(formData);
+
+        cmd =  {
+          extensionElements: extensionElements
+        };
+      }   
+      else {
+        var foundFormData = false;
+        forEach(extensionElements.get('values'), function(extensionElement) {
+          if (is(extensionElement, 'camunda:FormData')) {
+            foundFormData = true;
+            formData = extensionElement;
+          }
+        });
+        if(foundFormData){
+            // remove all existing form fields
+            var objectsToRemove = [];
+            forEach(extensionElements.get('values'), function(extensionElement) {
+              if (is(extensionElement, 'camunda:FormData')) {
+                forEach(extensionElement.get('fields'), function(extensionSubElement) {
+                  if (is(extensionSubElement, 'camunda:FormField')) {
+                    objectsToRemove.push(extensionSubElement);
+                  }
+                });
+              }
+            });
+
+            // add all the fields
+            var objectsToAdd = [];
+            createFormField(element, values, formData, objectsToAdd, bpmnFactory);
+            cmd = cmdHelper.addAndRemoveElementsFromList(element, formData, 'fields',
+                                                      objectsToAdd, objectsToRemove);
+        
+        }
+        else{
+            formData = elementHelper.createElement('camunda:FormData',
+                                                        { fields: [] }, bo, bpmnFactory);
+            var extensionValues = extensionElements.get('values');
+            var formDataValues = formData.get('fields');
+            createFormField(element, values, formData, formDataValues, bpmnFactory);
+            extensionValues.push(formData);
+            cmd =  {
+              extensionElements: extensionElements
+            };
+        }
+      }
+
+      return cmd;
+    },
+
+    validateListItem: function(element, values) {
+      var validationResult = {};
+
+      if(!values.formID) {
+        validationResult.formID = "Must provide a value";
+      }
+      validationResult.constraint = [];
+      for(var i=0; values.constraint !== undefined && i<values.constraint.length; i++){
+        validationResult.constraint[i] = constraint.validate(element,
+                                                   values.constraint[i]);          
+      }
+      validationResult.property = [];
+      for(var ii=0; values.property !== undefined && ii<values.property.length; ii++){
+        validationResult.property[ii] = property.validate(element,
+                                                   values.property[ii]);          
+      }
+      return validationResult;
+    },
+
+    addForm: function(element, inputNode) {
+      var formContainer = domQuery('[data-list-table-container]', inputNode);
+      lastIdx++;
+      var template = domify(createFormTemplate(lastIdx));
+      formContainer.appendChild(template);
+      return true;
+    },
+
+    removeForm: function(element, entryNode, btnNode, scopeNode) {
+      scopeNode.parentElement.removeChild(scopeNode);
+      return true;
+    },
+
+    clearFormID:  function(element, entryNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=formID]', scopeNode);
+      input.value = '';
+      return true;
+    },
+
+    canClearFormID: function(element, entryNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=formID]', scopeNode);
+      return input.value !== '';
+    },
+
+    clearFormLabel:  function(element, entryNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=formLabel]', scopeNode);
+      input.value = '';
+      return true;
+    },
+
+    canClearFormLabel: function(element, entryNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=formLabel]', scopeNode);
+      return input.value !== '';
+    },
+
+    clearFormDefault:  function(element, entryNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=formDefault]', scopeNode);
+      input.value = '';
+      return true;
+    },
+
+    canClearFormDefault: function(element, entryNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=formDefault]', scopeNode);
+      return input.value !== '';
+    },
+
+    constraint: constraint,
+    property: property,
+    
+    cssClasses: ['textfield']
+   });
+
+};

--- a/lib/provider/camunda/parts/FormFieldProps.js
+++ b/lib/provider/camunda/parts/FormFieldProps.js
@@ -3,7 +3,6 @@
 var is = require('bpmn-js/lib/util/ModelUtil').is,
   getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject,
   domQuery = require('min-dom/lib/query'),
-  cmdHelper = require('../../../helper/CmdHelper'),
   elementHelper = require('../../../helper/ElementHelper'),
   forEach = require('lodash/collection/forEach'),
   domify = require('min-dom/lib/domify'),

--- a/lib/provider/camunda/parts/FormFieldProps.js
+++ b/lib/provider/camunda/parts/FormFieldProps.js
@@ -233,7 +233,8 @@ module.exports = function(group, element, bpmnFactory) {
             // add all the fields
             var objectsToAdd = [];
             createFormField(element, values, formData, objectsToAdd, bpmnFactory);
-            cmd = cmdHelper.addAndRemoveElementsFromList(element, formData, 'fields',
+            cmd = cmdHelper.addAndRemoveElementsFromList(element, formData, 
+                                                      'fields', 'fields',
                                                       objectsToAdd, objectsToRemove);
         
         }

--- a/lib/provider/camunda/parts/InputParameterProps.js
+++ b/lib/provider/camunda/parts/InputParameterProps.js
@@ -1,0 +1,359 @@
+'use strict';
+
+var is = require('bpmn-js/lib/util/ModelUtil').is,
+  getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject,
+  domQuery = require('min-dom/lib/query'),
+  cmdHelper = require('../../../helper/CmdHelper'),
+  elementHelper = require('../../../helper/ElementHelper'),
+  forEach = require('lodash/collection/forEach'),
+  domify = require('min-dom/lib/domify'),
+  utils = require('../../../Utils'),
+
+  script = require('./implementation/Script')('scriptFormat', 'value', true),
+  map = require('./implementation/Entry')('map'),
+  list = require('./implementation/InputOutputParameter')('list');
+
+function createParameterTemplate(id) {
+  return '<div class="djs-parameter-area" data-scope>' +
+            '<button data-action="removeParameter"><span>X</span></button>' +
+            '<div data-list-table-head-container>' +            
+
+              '<div class="pp-row">' +
+                '<label for="cam-parameter-name-'+id+'">Parameter Name</label>' +
+                '<div class="field-wrapper">' +
+                  '<input id="cam-parameter-name-'+id+'" type="text" name="parameterName" />' +
+                  '<button data-action="clearParameterName" data-show="canClearParameterName">' +
+                    '<span>X</span>' +
+                  '</button>' +
+                '</div>' +
+              '</div>' +
+
+              '<div class="pp-row">' +
+                '<label for="cam-parameter-type-'+id+'">Parameter Type</label>' +
+                '<div class="field-wrapper">' +
+                  '<select id="cam-parameter-type-'+id+'" name="parameterType" data-value>' +
+                    '<option value="text">Text</option>' +
+                    '<option value="map">Map</option>' +
+                    '<option value="list">List</option>' +
+                    '<option value="script">Script</option>' +
+                  '</select>' +
+                '</div>' +
+              '</div>' +
+
+              '<div class="pp-row" data-show="isText">' +
+                '<label for="cam-parameter-val-'+id+'">Value</label>' +
+                '<div class="field-wrapper">' +
+                  '<input id="cam-parameter-val-'+id+'" type="text" name="parameterValue" />' +
+                  '<button data-action="clearParameterValue" data-show="canClearParameterValue">' +
+                    '<span>X</span>' +
+                  '</button>' +
+                '</div>' +
+              '</div>' +
+
+              '<div data-show="isScript">' +
+                script.template +
+              '</div>'+
+              
+            '</div>'+           
+            '<div data-list-table-rows-container data-show="isMap" name="map">' +
+              map.template +
+            '</div>'+            
+            '<div data-list-table-rows-container data-show="isList" name="list">' +
+              list.template +
+            '</div>'+            
+
+          '</div>';
+}
+
+function getItem(element, bo) {    
+  // read values from xml:
+  var boText = bo.get('value');
+  var boDefinition = bo.definition;
+
+  var values = {};
+  if(!!boText){
+      values.parameterType = 'text';
+      values.parameterValue = boText;
+  } else if(!!boDefinition) {
+      if(boDefinition.entries!==undefined){
+            values.parameterType = 'map';
+            values.map = [];
+            if(boDefinition.entries instanceof Array && boDefinition.entries.length>0){
+                for(var i=0; i<boDefinition.entries.length; i++){
+                    values.map[i] = map.get(element, boDefinition.entries[i]);
+                }
+            }
+      } else if(boDefinition.items!==undefined){
+            values.parameterType = 'list';
+            values.list = [];
+            if(boDefinition.items instanceof Array && boDefinition.items.length>0){
+                for(var ii=0; ii<boDefinition.items.length; ii++){
+                    values.list[ii] = list.get(element, boDefinition.items[ii]);
+                }
+            }            
+      } else {
+        values = script.get(element, boDefinition);
+        values.parameterType = 'script';  
+      }
+  } else{
+      values.parameterType = 'text';  
+      values.parameterValue = '';
+  }  
+  values.parameterName = bo.get('name');
+  return values;
+}
+
+function createInputParameter(element, values, extensionElements, inputParameterList, bpmnFactory) {
+  // add input parameter values to extension elements values
+  forEach(values, function(value) {  
+    var inputParameter = elementHelper.createElement('camunda:InputParameter',
+                                                     {}, extensionElements, bpmnFactory);
+    inputParameter.name = value.parameterName;
+    if (value.parameterType === 'script') {
+      var scriptProps = script.set(element, value);
+      inputParameter.definition = elementHelper.createElement('camunda:Script',
+                                                     scriptProps, inputParameter, bpmnFactory);
+    }
+    else if (value.parameterType === 'text') {
+      inputParameter.value = value.parameterValue;
+    } 
+    else if (value.parameterType === 'map') {
+      inputParameter.definition = elementHelper.createElement('camunda:Map',
+                                                     {entries:[]}, inputParameter, bpmnFactory);
+      for(var i=0; i<value.map.length; i++){
+        var mapProps = map.set(element, value.map[i]);
+        var mapElement = elementHelper.createElement('camunda:Entry',
+                                                         {},inputParameter.definition, bpmnFactory);
+        var mapKeys = Object.keys(mapProps);
+        for(var mapProp in mapKeys){
+            mapElement[mapKeys[mapProp]] = mapProps[mapKeys[mapProp]];
+        }
+        inputParameter.definition.entries.push(mapElement);
+      }
+    }
+    else if (value.parameterType === 'list') {
+      inputParameter.definition = elementHelper.createElement('camunda:List',
+                                                     {items:[]}, inputParameter, bpmnFactory);
+      for(var ii=0; ii<value.list.length; ii++){
+        var listProps = list.set(element, value.list[ii]);
+        var listElement = elementHelper.createElement('camunda:Value',
+                                                         {},inputParameter.definition, bpmnFactory);
+        var listKeys = Object.keys(listProps);
+        for(var listProp in listKeys){
+            listElement[listKeys[listProp]] = listProps[listKeys[listProp]];
+        }
+        inputParameter.definition.items.push(listElement);
+      }      
+    }
+
+    inputParameterList.push(inputParameter);
+  });
+
+}
+
+module.exports = function(group, element, bpmnFactory) {
+
+  var bo;
+  var lastIdx = 0;
+
+  if (is(element, 'camunda:InputParameterSupported')) {
+    bo = getBusinessObject(element);
+  }
+
+  if (!bo) {
+    return;
+  }
+
+  group.entries.push({
+    'id': 'inputParameters',
+    'description': 'Configure input parameter.',
+    'label': 'Parameter',
+    'html': '<div class="cam-add-parameter">' +
+              '<label for="addParameter">Add Input Parameter </label>' +
+              '<button id="addParameter" data-action="addParameter"><span>+</span></button>' +
+            '</div>' +
+            '<div data-list-table-container></div>',
+
+    createListEntryTemplate: function(value, idx) {
+      lastIdx = idx;
+      return createParameterTemplate(idx);
+    },
+        
+    get: function (element, propertyName) {
+      var values = [];
+
+      if (!!bo.extensionElements) {
+        var extensionElementsValues = getBusinessObject(element).extensionElements.values;
+        forEach(extensionElementsValues, function(extensionElement) {
+          if (typeof extensionElement.$instanceOf === 'function' && is(extensionElement, 'camunda:InputOutput')) {
+                var extensionElementValues = extensionElement.inputParameters;
+                forEach(extensionElementValues,function(extensionSubElement){
+                if (typeof extensionSubElement.$instanceOf === 'function' &&
+                        is(extensionSubElement, 'camunda:InputParameter')) {
+                  values.push(getItem(element, extensionSubElement));
+                }      
+            });
+          }
+        });
+      }
+
+      return values;
+    },
+
+    set: function (element, values, containerElement) {
+      var cmd;
+
+      var extensionElements = bo.extensionElements;
+      var inputOutput;
+
+      if (!extensionElements) {
+        extensionElements = elementHelper.createElement('bpmn:ExtensionElements',
+                                                        { values: [] }, bo, bpmnFactory);
+        inputOutput = elementHelper.createElement('camunda:InputOutput',
+                                                        { inputParameters: [] }, extensionElements, bpmnFactory);
+        createInputParameter(element, values, inputOutput, inputOutput.get('inputParameters'), bpmnFactory);
+        extensionElements.get('values').push(inputOutput);
+
+        cmd =  {
+          extensionElements: extensionElements
+        };
+      }   
+      else {
+        var foundInputOutput = false;
+        forEach(extensionElements.get('values'), function(extensionElement) {
+          if (is(extensionElement, 'camunda:InputOutput')) {
+            foundInputOutput = true;
+            inputOutput = extensionElement;
+          }
+        });
+        if(foundInputOutput){
+            // remove all existing input parameters
+            var objectsToRemove = [];
+            forEach(extensionElements.get('values'), function(extensionElement) {
+              if (is(extensionElement, 'camunda:InputOutput')) {
+                forEach(extensionElement.get('inputParameters'), function(extensionSubElement) {
+                  if (is(extensionSubElement, 'camunda:InputParameter')) {
+                    objectsToRemove.push(extensionSubElement);
+                  }
+                });
+              }
+            });
+
+            // add all the parameters
+            var objectsToAdd = [];
+            createInputParameter(element, values, inputOutput, objectsToAdd, bpmnFactory);
+            cmd = cmdHelper.addAndRemoveElementsFromList(element, inputOutput, 'inputParameters',
+                                                      objectsToAdd, objectsToRemove);
+        
+        }
+        else{
+            inputOutput = elementHelper.createElement('camunda:InputOutput',
+                                                        { inputParameters: [] }, bo, bpmnFactory);
+            var extensionValues = extensionElements.get('values');
+            var inputOutputValues = inputOutput.get('inputParameters');
+            createInputParameter(element, values, inputOutput, inputOutputValues, bpmnFactory);
+            extensionValues.push(inputOutput);
+            cmd =  {
+              extensionElements: extensionElements
+            };
+        }
+      }
+
+      return cmd;
+    },
+
+    validateListItem: function(element, values) {
+      var validationResult = {};
+
+      if(values.parameterType === 'script') {
+        validationResult = script.validate(element, values);
+      }
+      else if(values.parameterType === 'map'){
+        validationResult.map = [];
+        for(var i=0; values.map !== undefined && i<values.map.length; i++){
+            validationResult.map[i] = map.validate(element,
+                                                            values.map[i]);          
+        }
+      }      
+      else if(values.parameterType === 'list'){
+        validationResult.list = [];
+        for(var ii=0; values.list !== undefined && ii<values.list.length; ii++){
+            validationResult.list[ii] = list.validate(element,
+                                                            values.list[ii]);          
+        }
+      }
+      else if(values.parameterType === 'text' && !values.parameterValue) {
+        validationResult.parameterValue = "Must provide a value";
+      }
+
+      return validationResult;
+    },
+
+    addParameter: function(element, inputNode) {
+      var parameterContainer = domQuery('[data-list-table-container]', inputNode);
+      lastIdx++;
+      var template = domify(createParameterTemplate(lastIdx));
+      parameterContainer.appendChild(template);
+      return true;
+    },
+
+    removeParameter: function(element, entryNode, btnNode, scopeNode) {
+      scopeNode.parentElement.removeChild(scopeNode);
+      return true;
+    },
+
+    clearParameterName:  function(element, entryNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=parameterName]', scopeNode);
+      input.value = '';
+      return true;
+    },
+
+    canClearParameterName: function(element, entryNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=parameterName]', scopeNode);
+      return input.value !== '';
+    },
+
+    clearParameterValue:  function(element, entryNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=parameterValue]', scopeNode);
+      input.value = '';
+      return true;
+    },
+
+    canClearParameterValue: function(element, entryNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=parameterValue]', scopeNode);
+      return input.value !== '';
+    },
+
+    isText: function(element, entryNode, btnNode, scopeNode) {
+      var type = utils.selectedType('select[name=parameterType]', scopeNode);
+      return type === 'text';
+    },
+
+    isMap: function(element, entryNode, btnNode, scopeNode) {
+      var type = utils.selectedType('select[name=parameterType]', scopeNode);
+      return type === 'map';
+    },
+
+    isList: function(element, entryNode, btnNode, scopeNode) {
+      var type = utils.selectedType('select[name=parameterType]', scopeNode);
+      return type === 'list';
+    },
+
+    isScript: function(element, entryNode, btnNode, scopeNode) {
+      var type = utils.selectedType('select[name=parameterType]', scopeNode);
+      return type === 'script';
+    },
+
+    isNotScript: function(element, entryNode, btnNode, scopeNode) {
+      var type = utils.selectedType('select[name=parameterType]', scopeNode);
+      return type !== 'script';
+    },
+
+    script: script,
+    map: map,
+    list: list,
+
+    cssClasses: ['textfield']
+   });
+
+};

--- a/lib/provider/camunda/parts/InputParameterProps.js
+++ b/lib/provider/camunda/parts/InputParameterProps.js
@@ -242,7 +242,8 @@ module.exports = function(group, element, bpmnFactory) {
             // add all the parameters
             var objectsToAdd = [];
             createInputParameter(element, values, inputOutput, objectsToAdd, bpmnFactory);
-            cmd = cmdHelper.addAndRemoveElementsFromList(element, inputOutput, 'inputParameters',
+            cmd = cmdHelper.addAndRemoveElementsFromList(element, inputOutput, 
+                                                      'inputParameters', 'inputParameters',
                                                       objectsToAdd, objectsToRemove);
         
         }

--- a/lib/provider/camunda/parts/InputParameterProps.js
+++ b/lib/provider/camunda/parts/InputParameterProps.js
@@ -15,7 +15,7 @@ var is = require('bpmn-js/lib/util/ModelUtil').is,
 
 function createParameterTemplate(id) {
   return '<div class="djs-parameter-area" data-scope>' +
-            '<button data-action="removeParameter"><span>X</span></button>' +
+            '<button data-action="removeInputParameter"><span>X</span></button>' +
             '<div data-list-table-head-container>' +            
 
               '<div class="pp-row">' +
@@ -169,8 +169,8 @@ module.exports = function(group, element, bpmnFactory) {
     'description': 'Configure input parameter.',
     'label': 'Parameter',
     'html': '<div class="cam-add-parameter">' +
-              '<label for="addParameter">Add Input Parameter </label>' +
-              '<button id="addParameter" data-action="addParameter"><span>+</span></button>' +
+              '<label for="addInputParameter">Add Input Parameter </label>' +
+              '<button id="addInputParameter" data-action="addInputParameter"><span>+</span></button>' +
             '</div>' +
             '<div data-list-table-container></div>',
 
@@ -227,25 +227,12 @@ module.exports = function(group, element, bpmnFactory) {
           }
         });
         if(foundInputOutput){
-            // remove all existing input parameters
-            var objectsToRemove = [];
-            forEach(extensionElements.get('values'), function(extensionElement) {
-              if (is(extensionElement, 'camunda:InputOutput')) {
-                forEach(extensionElement.get('inputParameters'), function(extensionSubElement) {
-                  if (is(extensionSubElement, 'camunda:InputParameter')) {
-                    objectsToRemove.push(extensionSubElement);
-                  }
-                });
-              }
-            });
-
-            // add all the parameters
-            var objectsToAdd = [];
-            createInputParameter(element, values, inputOutput, objectsToAdd, bpmnFactory);
-            cmd = cmdHelper.addAndRemoveElementsFromList(element, inputOutput, 
-                                                      'inputParameters', 'inputParameters',
-                                                      objectsToAdd, objectsToRemove);
-        
+            inputOutput.inputParameters = [];
+            createInputParameter(element, values, inputOutput, 
+                            inputOutput.get('inputParameters'), bpmnFactory);
+            cmd =  {
+              extensionElements: extensionElements
+            };            
         }
         else{
             inputOutput = elementHelper.createElement('camunda:InputOutput',
@@ -290,7 +277,7 @@ module.exports = function(group, element, bpmnFactory) {
       return validationResult;
     },
 
-    addParameter: function(element, inputNode) {
+    addInputParameter: function(element, inputNode) {
       var parameterContainer = domQuery('[data-list-table-container]', inputNode);
       lastIdx++;
       var template = domify(createParameterTemplate(lastIdx));
@@ -298,7 +285,7 @@ module.exports = function(group, element, bpmnFactory) {
       return true;
     },
 
-    removeParameter: function(element, entryNode, btnNode, scopeNode) {
+    removeInputParameter: function(element, entryNode, btnNode, scopeNode) {
       scopeNode.parentElement.removeChild(scopeNode);
       return true;
     },

--- a/lib/provider/camunda/parts/InputParameterProps.js
+++ b/lib/provider/camunda/parts/InputParameterProps.js
@@ -3,7 +3,6 @@
 var is = require('bpmn-js/lib/util/ModelUtil').is,
   getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject,
   domQuery = require('min-dom/lib/query'),
-  cmdHelper = require('../../../helper/CmdHelper'),
   elementHelper = require('../../../helper/ElementHelper'),
   forEach = require('lodash/collection/forEach'),
   domify = require('min-dom/lib/domify'),

--- a/lib/provider/camunda/parts/OutputParameterProps.js
+++ b/lib/provider/camunda/parts/OutputParameterProps.js
@@ -241,7 +241,8 @@ module.exports = function(group, element, bpmnFactory) {
             // add all the parameters
             var objectsToAdd = [];
             createOutputParameter(element, values, inputOutput, objectsToAdd, bpmnFactory);
-            cmd = cmdHelper.addAndRemoveElementsFromList(element, inputOutput, 'outputParameters',
+            cmd = cmdHelper.addAndRemoveElementsFromList(element, inputOutput,
+                                                      'outputParameters', 'outputParameters',
                                                       objectsToAdd, objectsToRemove);
         
         }

--- a/lib/provider/camunda/parts/OutputParameterProps.js
+++ b/lib/provider/camunda/parts/OutputParameterProps.js
@@ -1,0 +1,358 @@
+'use strict';
+
+var is = require('bpmn-js/lib/util/ModelUtil').is,
+  getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject,
+  domQuery = require('min-dom/lib/query'),
+  cmdHelper = require('../../../helper/CmdHelper'),
+  elementHelper = require('../../../helper/ElementHelper'),
+  forEach = require('lodash/collection/forEach'),
+  domify = require('min-dom/lib/domify'),
+  utils = require('../../../Utils'),
+
+  script = require('./implementation/Script')('scriptFormat', 'value', true),
+  map = require('./implementation/Entry')('map'),
+  list = require('./implementation/InputOutputParameter')('list');
+
+function createParameterTemplate(id) {
+  return '<div class="djs-parameter-area" data-scope>' +
+            '<button data-action="removeParameter"><span>X</span></button>' +
+            '<div data-list-table-head-container>' +            
+
+              '<div class="pp-row">' +
+                '<label for="cam-parameter-name-'+id+'">Parameter Name</label>' +
+                  '<div class="field-wrapper">' +
+                    '<input id="cam-parameter-name-'+id+'" type="text" name="parameterName" />' +
+                    '<button data-action="clearParameterName" data-show="canClearParameterName">' +
+                      '<span>X</span>' +
+                    '</button>' +
+                  '</div>' +
+              '</div>' +
+
+              '<div class="pp-row">' +
+                '<label for="cam-parameter-type-'+id+'">Parameter Type</label>' +
+                '<div class="field-wrapper">' +
+                  '<select id="cam-parameter-type-'+id+'" name="parameterType" data-value>' +
+                    '<option value="text">Text</option>' +
+                    '<option value="map">Map</option>' +
+                    '<option value="list">List</option>' +
+                    '<option value="script">Script</option>' +
+                  '</select>' +
+                '</div>' +
+              '</div>' +
+
+              '<div class="pp-row" data-show="isText">' +
+                  '<label for="cam-parameter-val-'+id+'">Value</label>' +
+                  '<div class="field-wrapper">' +
+                    '<input id="cam-parameter-val-'+id+'" type="text" name="parameterValue" />' +
+                    '<button data-action="clearParameterValue" data-show="canClearParameterValue">' +
+                      '<span>X</span>' +
+                    '</button>' +
+                  '</div>' +
+              '</div>' +
+
+              '<div data-show="isScript">' +
+                script.template +
+              '</div>'+
+                
+            '</div>'+           
+            '<div data-list-table-rows-container data-show="isMap" name="map">' +
+              map.template +
+            '</div>'+            
+            '<div data-list-table-rows-container data-show="isList" name="list">' +
+              list.template +
+            '</div>'+            
+
+          '</div>';
+}
+
+function getItem(element, bo) {    
+  // read values from xml:
+  var boText = bo.get('value');
+  var boDefinition = bo.definition;
+
+  var values = {};
+  if(!!boText){
+      values.parameterType = 'text';
+      values.parameterValue = boText;
+  } else if(!!boDefinition) {
+      if(boDefinition.entries!==undefined){
+          values.parameterType = 'map';
+          values.map = [];
+          if(boDefinition.entries instanceof Array && boDefinition.entries.length>0){
+              for(var i=0; i<boDefinition.entries.length; i++){
+                  values.map[i] = map.get(element, boDefinition.entries[i]);
+              }
+          }
+      } else if(boDefinition.items!==undefined){
+          values.parameterType = 'list';
+          values.list = [];
+          if(boDefinition.items instanceof Array && boDefinition.items.length>0){
+            for(var ii=0; ii<boDefinition.items.length; ii++){
+                values.list[ii] = list.get(element, boDefinition.items[ii]);
+            }
+          }            
+      } else {
+          values = script.get(element, boDefinition);
+          values.parameterType = 'script';  
+      }
+  } else {
+      values.parameterType = 'text';  
+      values.parameterValue = '';
+  }  
+  values.parameterName = bo.get('name');
+  return values;
+}
+
+function createOutputParameter(element, values, extensionElements, outputParameterList, bpmnFactory) {
+  // add output parameter values to extension elements values
+  forEach(values, function(value) { 
+    var outputParameter = elementHelper.createElement('camunda:OutputParameter',
+                                                     {}, extensionElements, bpmnFactory);
+    outputParameter.name = value.parameterName;
+    if (value.parameterType === 'script') {
+      var scriptProps = script.set(element, value);
+      outputParameter.definition = elementHelper.createElement('camunda:Script',
+                                                     scriptProps, outputParameter, bpmnFactory);
+    }
+    else if (value.parameterType === 'text') {
+      outputParameter.value = value.parameterValue;
+    } 
+    else if (value.parameterType === 'map') {
+      outputParameter.definition = elementHelper.createElement('camunda:Map',
+                                                     {entries:[]}, outputParameter, bpmnFactory);
+      for(var i=0; i<value.map.length; i++){
+        var mapProps = map.set(element, value.map[i]);
+        var mapElement = elementHelper.createElement('camunda:Entry',
+                                                         {},outputParameter.definition, bpmnFactory);
+        var mapKeys = Object.keys(mapProps);
+        for(var mapProp in mapKeys){
+            mapElement[mapKeys[mapProp]] = mapProps[mapKeys[mapProp]];
+        }
+        outputParameter.definition.entries.push(mapElement);
+      }
+    }
+    else if (value.parameterType === 'list') {
+      outputParameter.definition = elementHelper.createElement('camunda:List',
+                                                     {items:[]}, outputParameter, bpmnFactory);
+      for(var ii=0; ii<value.list.length; ii++){
+        var listProps = list.set(element, value.list[ii]);
+        var listElement = elementHelper.createElement('camunda:Value',
+                                                         {},outputParameter.definition, bpmnFactory);
+        var listKeys = Object.keys(listProps);
+        for(var listProp in listKeys){
+            listElement[listKeys[listProp]] = listProps[listKeys[listProp]];
+        }
+        outputParameter.definition.items.push(listElement);
+      }      
+    }
+    outputParameterList.push(outputParameter);
+  });
+
+}
+
+module.exports = function(group, element, bpmnFactory) {
+
+  var bo;
+  var lastIdx = 0;
+
+  if (is(element, 'camunda:OutputParameterSupported')) {
+    bo = getBusinessObject(element);
+  }
+
+  if (!bo) {
+    return;
+  }
+
+  group.entries.push({
+    'id': 'outputParameters',
+    'description': 'Configure output parameter.',
+    'label': 'Parameter',
+    'html': '<div class="cam-add-parameter">' +
+              '<label for="addParameter">Add Output Parameter </label>' +
+              '<button id="addParameter" data-action="addParameter"><span>+</span></button>' +
+            '</div>' +
+            '<div data-list-table-container></div>',
+
+    createListEntryTemplate: function(value, idx) {
+      lastIdx = idx;
+      return createParameterTemplate(idx);
+    },
+        
+    get: function (element, propertyName) {
+      var values = [];
+
+      if (!!bo.extensionElements) {
+        var extensionElementsValues = getBusinessObject(element).extensionElements.values;
+        forEach(extensionElementsValues, function(extensionElement) {
+          if (typeof extensionElement.$instanceOf === 'function' && is(extensionElement, 'camunda:InputOutput')) {
+                var extensionElementValues = extensionElement.outputParameters;
+                forEach(extensionElementValues,function(extensionSubElement){
+                if (typeof extensionSubElement.$instanceOf === 'function' &&
+                        is(extensionSubElement, 'camunda:OutputParameter')) {
+                  values.push(getItem(element, extensionSubElement));
+                }      
+            });
+          }
+        });
+      }
+
+      return values;
+    },
+
+    set: function (element, values, containerElement) {
+      var cmd;
+
+      var extensionElements = bo.extensionElements;
+      var inputOutput;
+
+      if (!extensionElements) {
+        extensionElements = elementHelper.createElement('bpmn:ExtensionElements',
+                                                        { values: [] }, bo, bpmnFactory);
+        inputOutput = elementHelper.createElement('camunda:InputOutput',
+                                                        { outputParameters: [] }, extensionElements, bpmnFactory);
+        createOutputParameter(element, values, inputOutput, inputOutput.get('outputParameters'), bpmnFactory);
+        extensionElements.get('values').push(inputOutput);
+
+        cmd =  {
+          extensionElements: extensionElements
+        };
+      }   
+      else {
+        var foundInputOutput = false;
+        forEach(extensionElements.get('values'), function(extensionElement) {
+          if (is(extensionElement, 'camunda:InputOutput')) {
+            foundInputOutput = true;
+            inputOutput = extensionElement;
+          }
+        });
+        if(foundInputOutput){
+            // remove all existing output parameters
+            var objectsToRemove = [];
+            forEach(extensionElements.get('values'), function(extensionElement) {
+              if (is(extensionElement, 'camunda:InputOutput')) {
+                forEach(extensionElement.get('outputParameters'), function(extensionSubElement) {
+                  if (is(extensionSubElement, 'camunda:OutputParameter')) {
+                    objectsToRemove.push(extensionSubElement);
+                  }
+                });
+              }
+            });
+
+            // add all the parameters
+            var objectsToAdd = [];
+            createOutputParameter(element, values, inputOutput, objectsToAdd, bpmnFactory);
+            cmd = cmdHelper.addAndRemoveElementsFromList(element, inputOutput, 'outputParameters',
+                                                      objectsToAdd, objectsToRemove);
+        
+        }
+        else{
+            inputOutput = elementHelper.createElement('camunda:InputOutput',
+                                                        { outputParameters: [] }, bo, bpmnFactory);
+            var extensionValues = extensionElements.get('values');
+            var inputOutputValues = inputOutput.get('outputParameters');
+            createOutputParameter(element, values, inputOutput, inputOutputValues, bpmnFactory);
+            extensionValues.push(inputOutput);
+            cmd =  {
+              extensionElements: extensionElements
+            };
+        }
+      }
+
+      return cmd;
+    },
+
+    validateListItem: function(element, values) {
+      var validationResult = {};
+
+      if(values.parameterType === 'script') {
+        validationResult = script.validate(element, values);
+      }
+      else if(values.parameterType === 'map'){
+        validationResult.map = [];
+        for(var i=0; values.map !== undefined && i<values.map.length; i++){
+            validationResult.map[i] = map.validate(element,
+                                                            values.map[i]);          
+        }
+      }      
+      else if(values.parameterType === 'list'){
+        validationResult.list = [];
+        for(var ii=0; values.list !== undefined && ii<values.list.length; ii++){
+            validationResult.list[ii] = list.validate(element,
+                                                            values.list[ii]);          
+        }
+      }
+      else if(values.parameterType === 'text' && !values.parameterValue) {
+        validationResult.parameterValue = "Must provide a value";
+      }
+
+      return validationResult;
+    },
+
+    addParameter: function(element, outputNode) {
+      var parameterContainer = domQuery('[data-list-table-container]', outputNode);
+      lastIdx++;
+      var template = domify(createParameterTemplate(lastIdx));
+      parameterContainer.appendChild(template);
+      return true;
+    },
+
+    removeParameter: function(element, entryNode, btnNode, scopeNode) {
+      scopeNode.parentElement.removeChild(scopeNode);
+      return true;
+    },
+
+    clearParameterName:  function(element, entryNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=parameterName]', scopeNode);
+      input.value = '';
+      return true;
+    },
+
+    canClearParameterName: function(element, entryNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=parameterName]', scopeNode);
+      return input.value !== '';
+    },
+
+    clearParameterValue:  function(element, entryNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=parameterValue]', scopeNode);
+      input.value = '';
+      return true;
+    },
+
+    canClearParameterValue: function(element, entryNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=parameterValue]', scopeNode);
+      return input.value !== '';
+    },
+
+    isText: function(element, entryNode, btnNode, scopeNode) {
+      var type = utils.selectedType('select[name=parameterType]', scopeNode);
+      return type === 'text';
+    },
+
+    isMap: function(element, entryNode, btnNode, scopeNode) {
+      var type = utils.selectedType('select[name=parameterType]', scopeNode);
+      return type === 'map';
+    },
+
+    isList: function(element, entryNode, btnNode, scopeNode) {
+      var type = utils.selectedType('select[name=parameterType]', scopeNode);
+      return type === 'list';
+    },
+
+    isScript: function(element, entryNode, btnNode, scopeNode) {
+      var type = utils.selectedType('select[name=parameterType]', scopeNode);
+      return type === 'script';
+    },
+
+    isNotScript: function(element, entryNode, btnNode, scopeNode) {
+      var type = utils.selectedType('select[name=parameterType]', scopeNode);
+      return type !== 'script';
+    },
+
+    script: script,
+    map: map,
+    list: list,
+
+    cssClasses: ['textfield']
+   });
+
+};

--- a/lib/provider/camunda/parts/OutputParameterProps.js
+++ b/lib/provider/camunda/parts/OutputParameterProps.js
@@ -15,7 +15,7 @@ var is = require('bpmn-js/lib/util/ModelUtil').is,
 
 function createParameterTemplate(id) {
   return '<div class="djs-parameter-area" data-scope>' +
-            '<button data-action="removeParameter"><span>X</span></button>' +
+            '<button data-action="removeOutputParameter"><span>X</span></button>' +
             '<div data-list-table-head-container>' +            
 
               '<div class="pp-row">' +
@@ -168,8 +168,8 @@ module.exports = function(group, element, bpmnFactory) {
     'description': 'Configure output parameter.',
     'label': 'Parameter',
     'html': '<div class="cam-add-parameter">' +
-              '<label for="addParameter">Add Output Parameter </label>' +
-              '<button id="addParameter" data-action="addParameter"><span>+</span></button>' +
+              '<label for="addOutputParameter">Add Output Parameter </label>' +
+              '<button id="addOutputParameter" data-action="addOutputParameter"><span>+</span></button>' +
             '</div>' +
             '<div data-list-table-container></div>',
 
@@ -226,25 +226,12 @@ module.exports = function(group, element, bpmnFactory) {
           }
         });
         if(foundInputOutput){
-            // remove all existing output parameters
-            var objectsToRemove = [];
-            forEach(extensionElements.get('values'), function(extensionElement) {
-              if (is(extensionElement, 'camunda:InputOutput')) {
-                forEach(extensionElement.get('outputParameters'), function(extensionSubElement) {
-                  if (is(extensionSubElement, 'camunda:OutputParameter')) {
-                    objectsToRemove.push(extensionSubElement);
-                  }
-                });
-              }
-            });
-
-            // add all the parameters
-            var objectsToAdd = [];
-            createOutputParameter(element, values, inputOutput, objectsToAdd, bpmnFactory);
-            cmd = cmdHelper.addAndRemoveElementsFromList(element, inputOutput,
-                                                      'outputParameters', 'outputParameters',
-                                                      objectsToAdd, objectsToRemove);
-        
+            inputOutput.outputParameters = [];
+            createOutputParameter(element, values, inputOutput, 
+                        inputOutput.get('outputParameters'), bpmnFactory);
+            cmd =  {
+              extensionElements: extensionElements
+            };
         }
         else{
             inputOutput = elementHelper.createElement('camunda:InputOutput',
@@ -289,7 +276,7 @@ module.exports = function(group, element, bpmnFactory) {
       return validationResult;
     },
 
-    addParameter: function(element, outputNode) {
+    addOutputParameter: function(element, outputNode) {
       var parameterContainer = domQuery('[data-list-table-container]', outputNode);
       lastIdx++;
       var template = domify(createParameterTemplate(lastIdx));
@@ -297,7 +284,7 @@ module.exports = function(group, element, bpmnFactory) {
       return true;
     },
 
-    removeParameter: function(element, entryNode, btnNode, scopeNode) {
+    removeOutputParameter: function(element, entryNode, btnNode, scopeNode) {
       scopeNode.parentElement.removeChild(scopeNode);
       return true;
     },

--- a/lib/provider/camunda/parts/OutputParameterProps.js
+++ b/lib/provider/camunda/parts/OutputParameterProps.js
@@ -3,7 +3,6 @@
 var is = require('bpmn-js/lib/util/ModelUtil').is,
   getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject,
   domQuery = require('min-dom/lib/query'),
-  cmdHelper = require('../../../helper/CmdHelper'),
   elementHelper = require('../../../helper/ElementHelper'),
   forEach = require('lodash/collection/forEach'),
   domify = require('min-dom/lib/domify'),

--- a/lib/provider/camunda/parts/implementation/Constraint.js
+++ b/lib/provider/camunda/parts/implementation/Constraint.js
@@ -1,0 +1,120 @@
+'use strict';
+
+var domQuery = require('min-dom/lib/query');
+var domify = require('min-dom/lib/domify');
+
+module.exports = function(identifier) {
+  var lastIdx = 0;
+  
+function createEntryTemplate(id) {
+  return '<div class="djs-constraint-area" data-scope>' +
+            '<button data-action="' + identifier + '.removeConstraint"><span>X</span></button>' +
+
+            '<div class="pp-row">' +
+              '<label for="camunda-constraint-name-'+id+'">Name</label>' +
+              '<div class="field-wrapper">' +
+                '<input id="camunda-constraint-name-'+id+'" type="text" name="constraintName" />' +
+                '<button data-action="' + identifier + 
+                  '.clearConstraintName" data-show="' + identifier + '.canClearConstraintName">' +
+                    '<span>X</span>' +
+                '</button>' +
+              '</div>' +
+            '</div>' +
+
+            '<div class="pp-row">' +
+              '<label for="camunda-constraint-config-'+id+'">Config</label>' +
+              '<div class="field-wrapper">' +
+                '<input id="camunda-constraint-config-'+id+'" type="text" name="constraintConfig" />' +
+                '<button data-action="' + identifier + 
+                  '.clearConstraintConfig" data-show="' + identifier + '.canClearConstraintConfig">' +
+                    '<span>X</span>' +
+                '</button>' +
+              '</div>' +
+            '</div>' +
+
+         '</div>';
+  }
+
+  return {
+    template:
+    '<div data-scope>' +
+      '<div class="cam-add-constraint">' +
+        '<label for="addConstraint">Add Constraint </label>' +
+        '<button id="addConstraint" data-action="' + identifier + '.addConstraint"><span>+</span></button>' +
+      '</div>' +
+      '<div data-list-table-rows-sub-container></div>' +
+    '</div>',
+    
+    createListEntryTemplate: function(value, idx) {
+      lastIdx = idx;
+      return createEntryTemplate(idx);
+    },
+
+    get: function (element, bo) {
+      var values = {};
+      
+      values.constraintName = bo.get('name'); 
+      values.constraintConfig = bo.get('config'); 
+      return values;
+    },
+
+    set: function(element, values, containerElement) {
+      return {
+        "name": values.constraintName,
+        "config": values.constraintConfig
+      };
+    },
+
+    validate: function(element, values) {
+      var validationResult = {};
+      
+      if (!values.constraintName) {
+        validationResult.constraintName = "Must provide a value";
+      }
+      if (!values.constraintConfig) {
+        validationResult.constraintConfig = "Must provide a value";
+      }
+      
+      return validationResult;
+    },
+
+    clearConstraintName: function(element, inputNode, btnNode, scopeNode) {
+      domQuery('input[name=constraintName]', scopeNode).value='';
+
+      return true;
+    },
+
+    canClearConstraintName: function(element, inputNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=constraintName]', scopeNode);
+
+      return input.value !== '';
+    },
+    
+    clearConstraintConfig: function(element, inputNode, btnNode, scopeNode) {
+      domQuery('input[name=constraintConfig]', scopeNode).value='';
+
+      return true;
+    },
+
+    canClearConstraintConfig: function(element, inputNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=constraintConfig]', scopeNode);
+
+      return input.value !== '';
+    },
+    
+    addConstraint: function(element, inputNode, event, scopeNode) {
+      var constraintContainer = domQuery('[data-list-table-rows-sub-container]', scopeNode);
+      lastIdx++;
+      var template = domify(createEntryTemplate(lastIdx));
+      constraintContainer.appendChild(template);
+      return true;
+    },
+
+    removeConstraint: function(element, entryNode, btnNode, scopeNode) {
+      scopeNode.parentElement.removeChild(scopeNode);
+      return true;
+    }
+
+  };
+
+};

--- a/lib/provider/camunda/parts/implementation/Entry.js
+++ b/lib/provider/camunda/parts/implementation/Entry.js
@@ -1,0 +1,117 @@
+'use strict';
+
+var domQuery = require('min-dom/lib/query');
+var domify = require('min-dom/lib/domify');
+
+module.exports = function(identifier) {
+  var lastIdx = 0;
+
+  function createEntryTemplate(id) {
+  return '<div class="djs-entry-area" data-scope>' +
+            '<button data-action="' + identifier + '.removeEntry"><span>X</span></button>' +
+
+            '<div class="pp-row">' +
+              '<label for="camunda-entry-key-'+id+'">Key</label>' +
+                '<div class="field-wrapper">' +
+                  '<input id="camunda-entry-key-'+id+'" type="text" name="entryKey" />' +
+                  '<button data-action="' + identifier +
+                    '.clearEntryKey" data-show="' + identifier + '.canClearEntryKey">' +
+                      '<span>X</span>' +
+                  '</button>' +
+                '</div>' +
+            '</div>' +
+
+            '<div class="pp-row">' +
+                '<label for="camunda-entry-val-'+id+'">Value</label>' +
+                '<div class="field-wrapper">' +
+                  '<input id="camunda-entry-val-'+id+'" type="text" name="entryValue" />' +
+                  '<button data-action="' + identifier +
+                    '.clearEntryValue" data-show="' + identifier + '.canClearEntryValue">' +
+                      '<span>X</span>' +
+                  '</button>' +
+                '</div>' +
+            '</div>' +
+
+          '</div>';
+  }
+  
+  return {
+    template:
+      '<div data-scope>' +
+        '<div class="cam-add-entry">' +
+          '<label for="addEntry">Add Entry </label>' +
+          '<button id="addEntry" data-action="' + identifier + '.addEntry"><span>+</span></button>' +
+        '</div>' +
+        '<div data-list-table-rows-sub-container></div>' +    
+      '</div>',
+    
+    createListEntryTemplate: function(value, idx) {
+      lastIdx = idx;
+      return createEntryTemplate(idx);
+    },
+
+    get: function (element, bo) {
+      var values = {};      
+      values.entryKey = bo.get('key');
+      values.entryValue = bo.get('value'); 
+      return values;
+    },
+
+    set: function(element, values, containerElement) {
+      return {
+        "key": values.entryKey,
+        "value": values.entryValue
+      };
+    },
+
+    validate: function(element, values) {
+      var validationResult = {};
+      if (!values.entryKey) {
+        validationResult.entryKey = "Must provide a value";
+      }      
+      if (!values.entryValue) {
+        validationResult.entryValue = "Must provide a value";
+      }      
+      return validationResult;
+    },
+
+    clearEntryKey: function(element, inputNode, btnNode, scopeNode) {
+      domQuery('input[name=entryKey]', scopeNode).value='';
+
+      return true;
+    },
+
+    canClearEntryKey: function(element, inputNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=entryKey]', scopeNode);
+
+      return input.value !== '';
+    },
+
+    clearEntryValue: function(element, inputNode, btnNode, scopeNode) {
+      domQuery('input[name=entryValue]', scopeNode).value='';
+
+      return true;
+    },
+
+    canClearEntryValue: function(element, inputNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=entryValue]', scopeNode);
+
+      return input.value !== '';
+    },
+    
+    addEntry: function(element, inputNode, event, scopeNode) {
+      var entryContainer = domQuery('[data-list-table-rows-sub-container]', scopeNode);
+      lastIdx++;
+      var template = domify(createEntryTemplate(lastIdx));
+      entryContainer.appendChild(template);
+      return true;
+    },
+
+    removeEntry: function(element, entryNode, btnNode, scopeNode) {
+      scopeNode.parentElement.removeChild(scopeNode);
+      return true;
+    }
+
+  };
+
+};

--- a/lib/provider/camunda/parts/implementation/InputOutputParameter.js
+++ b/lib/provider/camunda/parts/implementation/InputOutputParameter.js
@@ -1,0 +1,92 @@
+'use strict';
+
+var domQuery = require('min-dom/lib/query');
+var domify = require('min-dom/lib/domify');
+
+module.exports = function(identifier) {
+  var lastIdx = 0;
+
+  function createEntryTemplate(id) {
+    return '<div class="djs-item-area" data-scope>' +
+                '<button data-action="' + identifier + '.removeItem"><span>X</span></button>' +
+
+                '<div class="pp-row">' +
+                  '<label for="camunda-list-val-'+id+'">Value</label>' +
+                  '<div class="field-wrapper">' +
+                    '<input id="camunda-list-val-'+id+'" type="text" name="itemValue" />' +
+                    '<button data-action="' + identifier + '.clearItemValue" data-show="' +
+                      identifier + '.canClearItemValue">' +
+                        '<span>X</span>' +
+                    '</button>' +
+                  '</div>' +
+                '</div>' +
+
+           '</div>';
+  }
+  
+  return {
+    template:
+      '<div data-scope>' +
+        '<div class="cam-add-item">' +
+          '<label for="addItem">Add List Item </label>' +
+          '<button id="addItem" data-action="' + identifier + '.addItem"><span>+</span></button>' +
+        '</div>' +
+        '<div data-list-table-rows-sub-container></div>' +
+      '</div>',
+    
+    createListEntryTemplate: function(value, idx) {
+      lastIdx = idx;
+      return createEntryTemplate(idx);
+    },
+
+    get: function (element, bo) {
+      var values = {};
+      
+      values.itemValue = bo.get('value'); 
+      return values;
+    },
+
+    set: function(element, values, containerElement) {
+      return {
+        "value": values.itemValue
+      };
+    },
+
+    validate: function(element, values) {
+      var validationResult = {};
+      
+      if (!values.itemValue) {
+        validationResult.itemValue = "Must provide a value";
+      }
+      
+      return validationResult;
+    },
+
+    clearItemValue: function(element, inputNode, btnNode, scopeNode) {
+      domQuery('input[name=itemValue]', scopeNode).value='';
+
+      return true;
+    },
+
+    canClearItemValue: function(element, inputNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=itemValue]', scopeNode);
+
+      return input.value !== '';
+    },
+    
+    addItem: function(element, inputNode, event, scopeNode) {
+      var itemContainer = domQuery('[data-list-table-rows-sub-container]', scopeNode);
+      lastIdx++;
+      var template = domify(createEntryTemplate(lastIdx));
+      itemContainer.appendChild(template);
+      return true;
+    },
+
+    removeItem: function(element, entryNode, btnNode, scopeNode) {
+      scopeNode.parentElement.removeChild(scopeNode);
+      return true;
+    }
+
+  };
+
+};

--- a/lib/provider/camunda/parts/implementation/Property.js
+++ b/lib/provider/camunda/parts/implementation/Property.js
@@ -1,0 +1,143 @@
+'use strict';
+
+var domQuery = require('min-dom/lib/query');
+var domify = require('min-dom/lib/domify');
+
+module.exports = function(identifier) {
+  var lastIdx = 0;
+  
+  function createEntryTemplate(id) {
+    return '<div class="djs-property-area" data-scope>' +
+                '<button data-action="' + identifier + '.removeProperty"><span>X</span></button>' +
+
+                '<div class="pp-row">' +
+                  '<label for="camunda-property-id-'+id+'">ID</label>' +
+                  '<div class="field-wrapper">' +
+                    '<input id="camunda-property-id-'+id+'" type="text" name="propertyID" />' +
+                    '<button data-action="' + identifier + 
+                      '.clearPropertyID" data-show="' + identifier + '.canClearPropertyID">' +
+                        '<span>X</span>' +
+                    '</button>' +
+                  '</div>' +
+                '</div>' +
+
+                '<div class="pp-row">' +
+                  '<label for="camunda-property-name-'+id+'">Name</label>' +
+                  '<div class="field-wrapper">' +
+                    '<input id="camunda-property-name-'+id+'" type="text" name="propertyName" />' +
+                    '<button data-action="' + identifier +
+                      '.clearPropertyName" data-show="' + identifier + '.canClearPropertyName">' +
+                        '<span>X</span>' +
+                    '</button>' +
+                  '</div>' +
+                '</div>' +
+
+                '<div class="pp-row">' +
+                  '<label for="camunda-property-value-'+id+'">Value</label>' +
+                  '<div class="field-wrapper">' +
+                    '<input id="camunda-property-value-'+id+'" type="text" name="propertyValue" />' +
+                    '<button data-action="' + identifier +
+                      '.clearPropertyValue" data-show="' + identifier + '.canClearPropertyValue">' +
+                        '<span>X</span>' +
+                    '</button>' +
+                  '</div>' +
+                '</div>' +
+
+           '</div>';
+  }
+  
+  return {
+    template:
+      '<div data-scope>' +
+        '<div class="cam-add-property">' +
+          '<label for="addProperty">Add Property </label>' +
+          '<button id="addProperty" data-action="' + identifier + '.addProperty"><span>+</span></button>' +
+        '</div>' +
+        '<div data-list-table-rows-sub-container></div>' +
+      '</div>',
+    
+    createListEntryTemplate: function(value, idx) {
+      lastIdx = idx;
+      return createEntryTemplate(idx);
+    },
+
+    get: function (element, bo) {
+      var values = {};
+      
+      values.propertyID = bo.get('id'); 
+      values.propertyName = bo.get('name'); 
+      values.propertyValue = bo.get('value'); 
+      
+      return values;
+    },
+
+    set: function(element, values, containerElement) {
+      return {
+        "id": values.propertyID,
+        "name": values.propertyName,
+        "value": values.propertyValue
+      };
+    },
+
+    validate: function(element, values) {
+      var validationResult = {};
+      
+      if (!values.propertyID) {
+        validationResult.propertyID = "Must provide a value";
+      }
+
+      return validationResult;
+    },
+
+    clearPropertyID: function(element, inputNode, btnNode, scopeNode) {
+      domQuery('input[name=propertyID]', scopeNode).value='';
+
+      return true;
+    },
+
+    canClearPropertyID: function(element, inputNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=propertyID]', scopeNode);
+
+      return input.value !== '';
+    },
+    
+    clearPropertyName: function(element, inputNode, btnNode, scopeNode) {
+      domQuery('input[name=propertyName]', scopeNode).value='';
+
+      return true;
+    },
+
+    canClearPropertyName: function(element, inputNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=propertyName]', scopeNode);
+
+      return input.value !== '';
+    },
+    
+    clearPropertyValue: function(element, inputNode, btnNode, scopeNode) {
+      domQuery('input[name=propertyValue]', scopeNode).value='';
+
+      return true;
+    },
+
+    canClearPropertyValue: function(element, inputNode, btnNode, scopeNode) {
+      var input = domQuery('input[name=propertyValue]', scopeNode);
+
+      return input.value !== '';
+    },
+    
+    addProperty: function(element, inputNode, event, scopeNode) {
+      var propertyContainer = domQuery('[data-list-table-rows-sub-container]', scopeNode);
+      lastIdx++;
+      var template = domify(createEntryTemplate(lastIdx));
+      propertyContainer.appendChild(template);
+      return true;
+    },
+
+    removeProperty: function(element, entryNode, btnNode, scopeNode) {
+      scopeNode.parentElement.removeChild(scopeNode);
+      return true;
+    }
+
+  };
+
+};

--- a/styles/properties.less
+++ b/styles/properties.less
@@ -494,6 +494,192 @@ label.djs-properties-hide {
   margin-top: 20px;
 }
 
+.cam-add-parameter {
+  > button {
+    position: relative;
+    margin-left: 10px;
+    &:before {
+      content: '\E803';
+    }
+  }
+}
+
+[data-list-table-container] > .djs-parameter-area {
+  border: 1px solid @gray-light;
+  margin: 10px 1px;
+  padding: 10px;
+}
+
+.djs-parameter-area {
+  position: relative;
+  > button {
+    position: absolute;
+    top: -12px;
+    right: -12px;
+    &:before {
+      content: '\E802';
+    }
+  }
+}
+.djs-parameter-area + .djs-parameter-area {
+  margin-top: 20px;
+}
+
+.cam-add-form {
+  > button {
+    position: relative;
+    margin-left: 10px;
+    &:before {
+      content: '\E803';
+    }
+  }
+}
+
+[data-list-table-container] > .djs-form-area {
+  border: 1px solid @gray-light;
+  margin: 10px 1px;
+  padding: 10px;
+}
+
+.djs-form-area {
+  position: relative;
+  > button {
+    position: absolute;
+    top: -12px;
+    right: -12px;
+    &:before {
+      content: '\E802';
+    }
+  }
+}
+.djs-form-area + .djs-form-area {
+  margin-top: 20px;
+}
+
+.cam-add-entry {
+  > button {
+    position: relative;
+    margin-left: 10px;
+    &:before {
+      content: '\E803';
+    }
+  }
+}
+
+[data-list-table-rows-sub-container] > .djs-entry-area {
+  border: 1px solid @gray-light;
+  margin: 10px 1px;
+  padding: 10px;
+}
+
+.djs-entry-area {
+  position: relative;
+  > button {
+    position: absolute;
+    top: -12px;
+    right: -12px;
+    &:before {
+      content: '\E802';
+    }
+  }
+}
+.djs-entry-area + .djs-entry-area {
+  margin-top: 20px;
+}
+
+.cam-add-item {
+  > button {
+    position: relative;
+    margin-left: 10px;
+    &:before {
+      content: '\E803';
+    }
+  }
+}
+
+[data-list-table-rows-sub-container] > .djs-item-area {
+  border: 1px solid @gray-light;
+  margin: 10px 1px;
+  padding: 10px;
+}
+
+.djs-item-area {
+  position: relative;
+  > button {
+    position: absolute;
+    top: -12px;
+    right: -12px;
+    &:before {
+      content: '\E802';
+    }
+  }
+}
+.djs-item-area + .djs-item-area {
+  margin-top: 20px;
+}
+
+.cam-add-constraint {
+  > button {
+    position: relative;
+    margin-left: 10px;
+    &:before {
+      content: '\E803';
+    }
+  }
+}
+
+[data-list-table-rows-sub-container] > .djs-constraint-area {
+  border: 1px solid @gray-light;
+  margin: 10px 1px;
+  padding: 10px;
+}
+
+.djs-constraint-area {
+  position: relative;
+  > button {
+    position: absolute;
+    top: -12px;
+    right: -12px;
+    &:before {
+      content: '\E802';
+    }
+  }
+}
+.djs-constraint-area + .djs-constraint-area {
+  margin-top: 20px;
+}
+
+.cam-add-property {
+  > button {
+    position: relative;
+    margin-left: 10px;
+    &:before {
+      content: '\E803';
+    }
+  }
+}
+
+[data-list-table-rows-sub-container] > .djs-property-area {
+  border: 1px solid @gray-light;
+  margin: 10px 1px;
+  padding: 10px;
+}
+
+.djs-property-area {
+  position: relative;
+  > button {
+    position: absolute;
+    top: -12px;
+    right: -12px;
+    &:before {
+      content: '\E802';
+    }
+  }
+}
+.djs-property-area + .djs-property-area {
+  margin-top: 20px;
+}
+
 .djs-properties-static {
   margin-bottom: 0;
   margin-top: 0;


### PR DESCRIPTION
1. The Input Parameter, Output Parameter and Form Field contain fields which are tabular in nature(Map, List, Validation Constraints and Properties, for example)
2. Changed the PropertiesPanel.js to allow for such fields
3. Added InputParameterProps.js, OutputParameterProps.js and FormFieldProps.js under lib\provider\camunda\parts - these add additional property boxes to the property panel
4. Added Constraint.js, Entry.js, InputOutputParameter.js and Property.js - lib\provider\camunda\parts\implementation to support the newly added property boxes
5. Also, since only certain bpmn elements need these property boxes, the Camunda moddle file - camunda.json - needs to be modified to add abstract types that point to the appropriate bpmn elements. Have sent a separate pull request to accommodate same at camunda-bpmn-moddle