### PR TITLE
chore(project): unify entry ids

### DIFF
--- a/lib/provider/camunda/CamundaPropertiesProvider.js
+++ b/lib/provider/camunda/CamundaPropertiesProvider.js
@@ -121,7 +121,7 @@ function createGeneralTabGroups(element, bpmnFactory, elementRegistry, elementTe
   elementTemplateChooserProps(generalGroup, element, elementTemplates);
 
   var customFieldsGroup = {
-    id: 'custom-field',
+    id: 'customField',
     label: 'Custom Fields',
     entries: []
   };
@@ -142,7 +142,7 @@ function createGeneralTabGroups(element, bpmnFactory, elementRegistry, elementTe
   startEventInitiator(detailsGroup, element); // this must be the last element of the details group!
 
   var multiInstanceGroup = {
-    id: 'multi-instance',
+    id: 'multiInstance',
     label: 'Multi Instance',
     entries: []
   };
@@ -156,20 +156,20 @@ function createGeneralTabGroups(element, bpmnFactory, elementRegistry, elementTe
   asynchronousContinuationProps(asyncGroup, element, bpmnFactory);
 
   var jobConfigurationGroup = {
-    id : 'job-configuration',
+    id : 'jobConfiguration',
     label : 'Job Configuration',
     entries : [],
     enabled: isJobConfigEnabled
   };
   jobConfiguration(jobConfigurationGroup, element, bpmnFactory);
 
-  var externalTaskConfigurationGroup = {
-    id : 'externalTaskConfigurationGroup',
+  var externalTaskGroup = {
+    id : 'externalTaskConfiguration',
     label : 'External Task Configuration',
     entries : [],
     enabled: isExternalTaskPriorityEnabled
   };
-  externalTaskConfiguration(externalTaskConfigurationGroup, element, bpmnFactory);
+  externalTaskConfiguration(externalTaskGroup, element, bpmnFactory);
 
   var documentationGroup = {
     id: 'documentation',
@@ -182,7 +182,7 @@ function createGeneralTabGroups(element, bpmnFactory, elementRegistry, elementTe
     generalGroup,
     customFieldsGroup,
     detailsGroup,
-    externalTaskConfigurationGroup,
+    externalTaskGroup,
     multiInstanceGroup,
     asyncGroup,
     jobConfigurationGroup,
@@ -220,14 +220,14 @@ function createFormsTabGroups(element, bpmnFactory, elementRegistry) {
 function createListenersTabGroups(element, bpmnFactory, elementRegistry) {
 
   var executionListenersGroup = {
-    id : 'execution-listeners',
+    id : 'executionListeners',
     label: 'Execution Listeners',
     entries: []
   };
   executionListenerProps(executionListenersGroup, element, bpmnFactory);
 
   var taskListenersGroup = {
-    id : 'task-listeners',
+    id : 'taskListeners',
     label: 'Task Listeners',
     entries: []
   };
@@ -310,7 +310,7 @@ function createConnectorTabGroups(element, bpmnFactory, elementRegistry) {
 function createExtensionElementsGroups(element, bpmnFactory, elementRegistry) {
 
   var propertiesGroup = {
-    id : 'extension-elements-properties',
+    id : 'extensionElements-properties',
     label: 'Properties',
     entries: []
   };
@@ -381,7 +381,7 @@ function CamundaPropertiesProvider(eventBus, bpmnFactory, elementRegistry, eleme
     };
 
     var extensionsTab = {
-      id: 'extension-elements',
+      id: 'extensionElements',
       label: 'Extensions',
       groups: createExtensionElementsGroups(element, bpmnFactory, elementRegistry)
     };

--- a/lib/provider/camunda/element-templates/CustomElementsPropertiesActivator.js
+++ b/lib/provider/camunda/element-templates/CustomElementsPropertiesActivator.js
@@ -60,7 +60,7 @@ function isEntryVisible(entry, template) {
 
   var id = entry.id;
 
-  if (id === 'element-template-chooser' || CUSTOM_PROPERTIES_PATTERN.test(id)) {
+  if (id === 'elementTemplate-chooser' || CUSTOM_PROPERTIES_PATTERN.test(id)) {
     return true;
   }
 

--- a/lib/provider/camunda/element-templates/parts/ChooserProps.js
+++ b/lib/provider/camunda/element-templates/parts/ChooserProps.js
@@ -26,7 +26,7 @@ module.exports = function(group, element, elementTemplates) {
   // select element template (via dropdown)
 
   group.entries.push(entryFactory.selectBox({
-    id: 'element-template-chooser',
+    id: 'elementTemplate-chooser',
     label: 'Element Template',
     modelProperty: 'camunda:modelerTemplate',
     selectOptions: options,

--- a/lib/provider/camunda/parts/ConnectorDetailProps.js
+++ b/lib/provider/camunda/parts/ConnectorDetailProps.js
@@ -25,7 +25,7 @@ function isConnector(element) {
 module.exports = function(group, element, bpmnFactory) {
 
   group.entries.push(entryFactory.textField({
-    id: 'connector-id',
+    id: 'connectorId',
     label: 'Connector Id',
     modelProperty: 'connectorId',
 

--- a/lib/provider/camunda/parts/ExecutionListenerProps.js
+++ b/lib/provider/camunda/parts/ExecutionListenerProps.js
@@ -149,7 +149,7 @@ module.exports = function(group, element, bpmnFactory) {
   var isSequenceFlow = is(element, 'bpmn:SequenceFlow');
 
   group.entries.push({
-    id: 'execution-listeners',
+    id: 'executionListeners',
     description: 'Configure execution listener.',
     label: 'Listener',
     html: '<div class="cam-add-listener">' +

--- a/lib/provider/camunda/parts/FormProps.js
+++ b/lib/provider/camunda/parts/FormProps.js
@@ -107,11 +107,11 @@ module.exports = function(group, element, bpmnFactory) {
 
   // form type select box
   group.entries.push({
-    id: 'form-type',
+    id: 'formType',
     html: '<div class="pp-row">' +
-            '<label for="camunda-form-type">Form Type</label>' +
+            '<label for="camunda-formType">Form Type</label>' +
             '<div class="pp-field-wrapper">' +
-              '<select id="camunda-form-type" name="formType" data-value>' +
+              '<select id="camunda-formType" name="formType" data-value>' +
                 '<option value="form-key">Form Key</option>' +
                 '<option value="form-data">Form Data</option>' +
               '</select>' +

--- a/lib/provider/camunda/parts/MultiInstanceLoopProps.js
+++ b/lib/provider/camunda/parts/MultiInstanceLoopProps.js
@@ -32,7 +32,7 @@ module.exports = function(group, element, bpmnFactory) {
   // async continuation ///////////////////////////////////////////////////////
   group.entries = group.entries.concat(asyncContinuation(element, bpmnFactory, {
     getBusinessObject: getLoopCharacteristics,
-    idPrefix: 'multi-instance-',
+    idPrefix: 'multiInstance-',
     labelPrefix: 'Multi Instance '
   }));
 
@@ -40,7 +40,7 @@ module.exports = function(group, element, bpmnFactory) {
   // retry time cycle //////////////////////////////////////////////////////////
   group.entries = group.entries.concat(jobRetryTimeCycle(element, bpmnFactory, {
     getBusinessObject: getLoopCharacteristics,
-    idPrefix: 'multi-instance-',
+    idPrefix: 'multiInstance-',
     labelPrefix: 'Multi Instance '
   }));
 };

--- a/lib/provider/camunda/parts/ServiceTaskDelegateProps.js
+++ b/lib/provider/camunda/parts/ServiceTaskDelegateProps.js
@@ -99,7 +99,7 @@ module.exports = function(group, element, bpmnFactory) {
   };
 
   group.entries.push(entryFactory.link({
-    id: 'configure-connector-link',
+    id: 'configureConnectorLink',
     label: 'Configure Connector',
     getClickableElement: function(element, node) {
       var panel = domClosest(node, 'div.djs-properties-panel');

--- a/lib/provider/camunda/parts/TaskListenerProps.js
+++ b/lib/provider/camunda/parts/TaskListenerProps.js
@@ -143,7 +143,7 @@ module.exports = function(group, element, bpmnFactory) {
   }
 
   group.entries.push({
-    id: 'task-listeners',
+    id: 'taskListeners',
     description: 'Configure task listener.',
     label: 'Listener',
     html: '<div class="cam-add-listener">' +

--- a/lib/provider/camunda/parts/VariableMappingProps.js
+++ b/lib/provider/camunda/parts/VariableMappingProps.js
@@ -88,7 +88,7 @@ module.exports = function(group, element, bpmnFactory) {
       parameter = getVariableMappings(element, CAMUNDA_OUT_EXTENSION_ELEMENT)[selection.idx];
     }
     return parameter;
-  };  
+  };
 
   var setOptionLabelValue = function(type) {
     return function(element, node, option, property, value, idx) {
@@ -135,7 +135,7 @@ module.exports = function(group, element, bpmnFactory) {
   // in mapping for source and sourceExpression ///////////////////////////////////////////////////////////////
 
   var inEntry = extensionElementsEntry(element, bpmnFactory, {
-    id: 'in-mapping',
+    id: 'variableMapping-in',
     label: 'In Mapping',
     modelProperty: 'source',
     prefix: 'In',
@@ -160,7 +160,7 @@ module.exports = function(group, element, bpmnFactory) {
   // out mapping for source and sourceExpression ///////////////////////////////////////////////////////
 
   var outEntry = extensionElementsEntry(element, bpmnFactory, {
-    id: 'out-mapping',
+    id: 'variableMapping-out',
     label: 'Out Mapping',
     modelProperty: 'source',
     prefix: 'Out',
@@ -185,7 +185,7 @@ module.exports = function(group, element, bpmnFactory) {
   // label for selected mapping ///////////////////////////////////////////////////////
 
   group.entries.push(entryFactory.label({
-    id: 'mapping-type-label',
+    id: 'variableMapping-typeLabel',
     get: function (element, node) {
       var mapping = getSelected(element, node);
 
@@ -209,7 +209,7 @@ module.exports = function(group, element, bpmnFactory) {
 
 
   group.entries.push(entryFactory.selectBox({
-    id: 'in-out-type',
+    id: 'variableMapping-inOutType',
     label: 'Type',
     selectOptions: inOutTypeOptions,
     modelProperty: 'inOutType',
@@ -244,12 +244,12 @@ module.exports = function(group, element, bpmnFactory) {
     disabled: function(element, node) {
       return !isSelected(element, node);
     }
-    
+
   }));
 
 
   group.entries.push(entryFactory.textField({
-    id: 'source',
+    id: 'variableMapping-source',
     dataValueLabel: 'sourceLabel',
     modelProperty: 'source',
     get: function(element, node) {
@@ -303,7 +303,7 @@ module.exports = function(group, element, bpmnFactory) {
 
 
   group.entries.push(entryFactory.textField({
-    id: 'target',
+    id: 'variableMapping-target',
     label: 'Target',
     modelProperty: 'target',
     get: function(element, node) {
@@ -337,7 +337,7 @@ module.exports = function(group, element, bpmnFactory) {
 
 
   group.entries.push(entryFactory.checkbox({
-    id: 'local',
+    id: 'variableMapping-local',
     label: 'Local',
     modelProperty: 'local',
     get: function(element, node) {

--- a/lib/provider/camunda/parts/implementation/AsyncContinuation.js
+++ b/lib/provider/camunda/parts/implementation/AsyncContinuation.js
@@ -32,7 +32,7 @@ module.exports = function(element, bpmnFactory, options) {
 
 
   var asyncBeforeEntry = entryFactory.checkbox({
-    id: idPrefix + 'async-before',
+    id: idPrefix + 'asyncBefore',
     label: labelPrefix + 'Asynchronous Before',
     modelProperty: 'asyncBefore',
 
@@ -65,7 +65,7 @@ module.exports = function(element, bpmnFactory, options) {
 
 
   var asyncAfterEntry = entryFactory.checkbox({
-    id: idPrefix + 'async-after',
+    id: idPrefix + 'asyncAfter',
     label: labelPrefix + 'Asynchronous After',
     modelProperty: 'asyncAfter',
 

--- a/lib/provider/camunda/parts/implementation/Callable.js
+++ b/lib/provider/camunda/parts/implementation/Callable.js
@@ -306,14 +306,14 @@ module.exports = function (element, bpmnFactory, options) {
 
 
   entries = entries.concat(resultVariable(element, bpmnFactory, {
-    id: 'dmn-result-variable',
+    id: 'dmn-resultVariable',
     getBusinessObject: getBusinessObject,
     getImplementationType: getCallableType,
     hideResultVariable: function(element, node) {
       return getCallableType(element) !== 'dmn';
     }
   }));
-  
+
 
   entries.push(entryFactory.selectBox({
     id: 'dmn-map-decision-result',

--- a/lib/provider/camunda/parts/implementation/ExtensionElements.js
+++ b/lib/provider/camunda/parts/implementation/ExtensionElements.js
@@ -13,7 +13,7 @@ var elementHelper = require('../../../../helper/ElementHelper'),
 
 function getSelectBox(node, id) {
   var currentTab = domClosest(node, 'div.djs-properties-tab');
-  var query = 'select[name=selectedExtensionElement]' + (id ? '[id=cam-extension-elements-' + id + ']' : '');
+  var query = 'select[name=selectedExtensionElement]' + (id ? '[id=cam-extensionElements-' + id + ']' : '');
   return domQuery(query, currentTab);
 }
 
@@ -80,21 +80,21 @@ module.exports = function (element, bpmnFactory, options) {
     id: id,
     html: '<div class="pp-row pp-element-list" ' +
             (canBeHidden ? 'data-show="hideElements"' : '') + '>' +
-            '<label for="cam-extension-elements-' + id + '">' + label + '</label>' +
+            '<label for="cam-extensionElements-' + id + '">' + label + '</label>' +
             '<div class="pp-field-wrapper">' +
-              '<select id="cam-extension-elements-' + id + '"' +
+              '<select id="cam-extensionElements-' + id + '"' +
                       'name="selectedExtensionElement" ' +
                       'size="' + defaultSize + '" ' +
                       'data-list-entry-container ' +
                       'data-on-change="selectElement">' +
               '</select>' +
               (canCreate ? '<button class="add" ' +
-                                   'id="cam-extension-elements-create-' + id + '" ' +
+                                   'id="cam-extensionElements-create-' + id + '" ' +
                                    'data-action="createElement">' +
                              '<span>+</span>' +
                            '</button>' : '') +
               (canRemove ? '<button class="clear" ' +
-                                   'id="cam-extension-elements-remove-' + id + '" ' +
+                                   'id="cam-extensionElements-remove-' + id + '" ' +
                                    'data-action="removeElement" ' +
                                    'data-disable="disableRemove">' +
                              '<span>-</span>' +

--- a/lib/provider/camunda/parts/implementation/External.js
+++ b/lib/provider/camunda/parts/implementation/External.js
@@ -13,7 +13,7 @@ module.exports = function(element, bpmnFactory, options) {
   }
 
   var topicEntry = entryFactory.textField({
-    id: 'external-topic',
+    id: 'externalTopic',
     label: 'Topic',
     modelProperty: 'externalTopic',
 

--- a/lib/provider/camunda/parts/implementation/ExternalTaskPriority.js
+++ b/lib/provider/camunda/parts/implementation/ExternalTaskPriority.js
@@ -9,7 +9,7 @@ module.exports = function(element, bpmnFactory, options) {
   var getBusinessObject = options.getBusinessObject;
 
   var externalTaskPriorityEntry = entryFactory.textField({
-    id: 'task-priority',
+    id: 'externalTaskPriority',
     description: 'The attribute specifies the initial priority of an External Task when it is created.',
     label: 'Task Priority',
     modelProperty: 'taskPriority',

--- a/lib/provider/camunda/parts/implementation/InputOutputParameter.js
+++ b/lib/provider/camunda/parts/implementation/InputOutputParameter.js
@@ -69,7 +69,7 @@ module.exports = function(element, bpmnFactory, options) {
   // parameter name ////////////////////////////////////////////////////////
 
   entries.push(entryFactory.validationAwareTextField({
-    id: idPrefix + 'parameter-name',
+    id: idPrefix + 'parameterName',
     label: 'Name',
     modelProperty: 'name',
 
@@ -118,7 +118,7 @@ module.exports = function(element, bpmnFactory, options) {
   ];
 
   entries.push(entryFactory.selectBox({
-    id : idPrefix + 'parameter-type',
+    id : idPrefix + 'parameterType',
     label: 'Type',
     selectOptions: selectOptions,
     modelProperty: 'parameterType',
@@ -178,7 +178,7 @@ module.exports = function(element, bpmnFactory, options) {
   // parameter value (type = text) ///////////////////////////////////////////////////////
 
   entries.push(entryFactory.textArea({
-    id : idPrefix + 'parameter-type-text',
+    id : idPrefix + 'parameterType-text',
     label : 'Value',
     modelProperty: 'value',
     get: function(element, node) {
@@ -204,7 +204,7 @@ module.exports = function(element, bpmnFactory, options) {
   // parameter value (type = script) ///////////////////////////////////////////////////////
 
   entries.push({
-    id: idPrefix + 'parameter-type-script',
+    id: idPrefix + 'parameterType-script',
     html: '<div data-show="isScript">' +
             script.template +
           '</div>',
@@ -237,7 +237,7 @@ module.exports = function(element, bpmnFactory, options) {
   // parameter value (type = list) ///////////////////////////////////////////////////////
 
   entries.push(entryFactory.table({
-    id: idPrefix + 'parameter-type-list',
+    id: idPrefix + 'parameterType-list',
     modelProperties: [ 'value' ],
     labels: [ 'Value' ],
 
@@ -297,7 +297,7 @@ module.exports = function(element, bpmnFactory, options) {
   // parameter value (type = map) ///////////////////////////////////////////////////////
 
   entries.push(entryFactory.table({
-    id: idPrefix + 'parameter-type-map',
+    id: idPrefix + 'parameterType-map',
     modelProperties: [ 'key', 'value' ],
     labels: [ 'Key', 'Value' ],
     addLabel: 'Add Entry',

--- a/lib/provider/camunda/parts/implementation/JobPriority.js
+++ b/lib/provider/camunda/parts/implementation/JobPriority.js
@@ -9,7 +9,7 @@ module.exports = function(element, bpmnFactory, options) {
   var getBusinessObject = options.getBusinessObject;
 
   var jobPriorityEntry = entryFactory.textField({
-    id: 'job-priority',
+    id: 'jobPriority',
     description: 'Priority of a job',
     label: 'Job Priority',
     modelProperty: 'jobPriority',

--- a/lib/provider/camunda/parts/implementation/JobRetryTimeCycle.js
+++ b/lib/provider/camunda/parts/implementation/JobRetryTimeCycle.js
@@ -42,7 +42,7 @@ module.exports = function(element, bpmnFactory, options) {
       labelPrefix = options.labelPrefix || '';
 
   var retryTimeCycleEntry = entryFactory.textField({
-    id: idPrefix + 'retry-time-cycle',
+    id: idPrefix + 'retryTimeCycle',
     label: labelPrefix + 'Retry Time Cycle',
     modelProperty: 'cycle',
 

--- a/lib/provider/camunda/parts/implementation/MultiInstanceLoopCharacteristics.js
+++ b/lib/provider/camunda/parts/implementation/MultiInstanceLoopCharacteristics.js
@@ -169,7 +169,7 @@ module.exports = function(element, bpmnFactory) {
   // error message /////////////////////////////////////////////////////////////////
 
   entries.push({
-    id: 'multi-instance-error-message',
+    id: 'multiInstance-errorMessage',
     html: '<div data-show="isValid">' +
              '<span class="pp-icon-warning"></span> ' +
              'Must provide either loop cardinality or collection' +
@@ -196,7 +196,7 @@ module.exports = function(element, bpmnFactory) {
   // loop cardinality //////////////////////////////////////////////////////////////
 
   entries.push(entryFactory.textField({
-    id: 'multi-instance-loop-cardinality',
+    id: 'multiInstance-loopCardinality',
     label: 'Loop Cardinality',
     modelProperty: 'loopCardinality',
 
@@ -215,7 +215,7 @@ module.exports = function(element, bpmnFactory) {
   // collection //////////////////////////////////////////////////////////////////
 
   entries.push(entryFactory.textField({
-    id: 'multi-instance-collection',
+    id: 'multiInstance-collection',
     label: 'Collection',
     modelProperty: 'collection',
 
@@ -246,7 +246,7 @@ module.exports = function(element, bpmnFactory) {
   // element variable ////////////////////////////////////////////////////////////
 
   entries.push(entryFactory.textField({
-    id: 'multi-instance-element-variable',
+    id: 'multiInstance-elementVariable',
     label: 'Element Variable',
     modelProperty: 'elementVariable',
 
@@ -268,7 +268,7 @@ module.exports = function(element, bpmnFactory) {
   // Completion Condition //////////////////////////////////////////////////////
 
   entries.push(entryFactory.textField({
-    id: 'multi-instance-completion-condition',
+    id: 'multiInstance-completionCondition',
     description: '',
     label: 'Completion Condition',
     modelProperty: 'completionCondition',

--- a/lib/provider/camunda/parts/implementation/ResultVariable.js
+++ b/lib/provider/camunda/parts/implementation/ResultVariable.js
@@ -11,7 +11,7 @@ module.exports = function(element, bpmnFactory, options) {
 
   var getBusinessObject     = options.getBusinessObject,
       hideResultVariable    = options.hideResultVariable,
-      id                    = options.id || 'result-variable';
+      id                    = options.id || 'resultVariable';
 
 
   var resultVariableEntry = entryFactory.textField({

--- a/test/spec/provider/camunda/AsynchronousContinuationsSpec.js
+++ b/test/spec/provider/camunda/AsynchronousContinuationsSpec.js
@@ -16,11 +16,11 @@ var propertiesPanelModule = require('../../../../lib'),
     getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
 
 function getAsyncBefore(container) {
-  return domQuery('div[data-entry=async-before] input[name=asyncBefore]', container);
+  return domQuery('div[data-entry=asyncBefore] input[name=asyncBefore]', container);
 }
 
 function getAsyncAfter(container) {
-  return domQuery('div[data-entry=async-after] input[name=asyncAfter]', container);
+  return domQuery('div[data-entry=asyncAfter] input[name=asyncAfter]', container);
 }
 
 function getExclusive(container) {
@@ -73,7 +73,7 @@ describe('flow-node-properties', function() {
 
     // assume
     // that the asyncBefore is false
-    expect(taskBo.get("asyncBefore")).to.not.be.ok;
+    expect(taskBo.get('asyncBefore')).to.not.be.ok;
 
     // when
     // I click on the checkbox
@@ -81,7 +81,7 @@ describe('flow-node-properties', function() {
 
     // then
     // the value is true in the model
-    expect(taskBo.get("asyncBefore")).to.be.ok;
+    expect(taskBo.get('asyncBefore')).to.be.ok;
   }));
 
 
@@ -98,7 +98,7 @@ describe('flow-node-properties', function() {
 
     // assume
     // that the asyncBefore is false
-    expect(taskBo.get("asyncBefore")).to.not.be.ok;
+    expect(taskBo.get('asyncBefore')).to.not.be.ok;
 
     // when
     // I click on the checkbox
@@ -106,7 +106,7 @@ describe('flow-node-properties', function() {
 
     // then
     // the value is true in the model
-    expect(taskBo.get("asyncBefore")).to.be.ok;
+    expect(taskBo.get('asyncBefore')).to.be.ok;
   }));
 
 
@@ -123,7 +123,7 @@ describe('flow-node-properties', function() {
 
     // assume
     // that the asyncBefore is false
-    expect(taskBo.get("asyncBefore")).to.not.be.ok;
+    expect(taskBo.get('asyncBefore')).to.not.be.ok;
 
     // when
     // I click on the checkbox
@@ -131,7 +131,7 @@ describe('flow-node-properties', function() {
 
     // then
     // the value is true in the model
-    expect(taskBo.get("asyncBefore")).to.be.ok;
+    expect(taskBo.get('asyncBefore')).to.be.ok;
   }));
 
 
@@ -148,7 +148,7 @@ describe('flow-node-properties', function() {
 
     // assume
     // that the asyncAfter is false
-    expect(taskBo.get("asyncAfter")).to.not.be.ok;
+    expect(taskBo.get('asyncAfter')).to.not.be.ok;
 
     // when
     // I click on the checkbox
@@ -156,7 +156,7 @@ describe('flow-node-properties', function() {
 
     // then
     // the value is true in the model
-    expect(taskBo.get("asyncAfter")).to.be.ok;
+    expect(taskBo.get('asyncAfter')).to.be.ok;
   }));
 
 
@@ -173,7 +173,7 @@ describe('flow-node-properties', function() {
 
     // assume
     // that the asyncAfter property is false (unset)
-    expect(taskBo.get("asyncAfter")).to.not.be.ok;
+    expect(taskBo.get('asyncAfter')).to.not.be.ok;
     expect(checkbox.selected).to.not.be.true;
 
     // when
@@ -182,7 +182,7 @@ describe('flow-node-properties', function() {
 
     // then
     // the value is true in the model
-    expect(taskBo.get("asyncAfter")).to.be.ok;
+    expect(taskBo.get('asyncAfter')).to.be.ok;
 
   }));
 
@@ -200,7 +200,7 @@ describe('flow-node-properties', function() {
 
     // assume
     // that the asyncAfter is false (unset)
-    expect(taskBo.get("asyncAfter")).to.not.be.ok;
+    expect(taskBo.get('asyncAfter')).to.not.be.ok;
 
     // when
     // I click on the checkbox
@@ -208,7 +208,7 @@ describe('flow-node-properties', function() {
 
     // then
     // the value is true in the model
-    expect(taskBo.get("asyncAfter")).to.be.ok;
+    expect(taskBo.get('asyncAfter')).to.be.ok;
   }));
 
 

--- a/test/spec/provider/camunda/CallActivitySpec.js
+++ b/test/spec/provider/camunda/CallActivitySpec.js
@@ -17,7 +17,7 @@ var propertiesPanelModule = require('../../../../lib'),
     camundaModdlePackage = require('camunda-bpmn-moddle/resources/camunda'),
     getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
 
-describe('call-activity-properties', function() {
+describe('callActivity - properties', function() {
 
   var diagramXML = require('./CallActivity.bpmn');
 

--- a/test/spec/provider/camunda/CallActivityVariableMappingSpec.js
+++ b/test/spec/provider/camunda/CallActivityVariableMappingSpec.js
@@ -7,17 +7,17 @@ var TestContainer = require('mocha-test-container-support');
 /* global bootstrapModeler, inject */
 
 var propertiesPanelModule = require('../../../../lib'),
-  domQuery = require('min-dom/lib/query'),
-  is = require('bpmn-js/lib/util/ModelUtil').is,
-  forEach = require('lodash/collection/forEach'),
-  coreModule = require('bpmn-js/lib/core'),
-  selectionModule = require('diagram-js/lib/features/selection'),
-  modelingModule = require('bpmn-js/lib/features/modeling'),
-  propertiesProviderModule = require('../../../../lib/provider/camunda'),
-  camundaModdlePackage = require('camunda-bpmn-moddle/resources/camunda'),
-  getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
+    domQuery = require('min-dom/lib/query'),
+    is = require('bpmn-js/lib/util/ModelUtil').is,
+    forEach = require('lodash/collection/forEach'),
+    coreModule = require('bpmn-js/lib/core'),
+    selectionModule = require('diagram-js/lib/features/selection'),
+    modelingModule = require('bpmn-js/lib/features/modeling'),
+    propertiesProviderModule = require('../../../../lib/provider/camunda'),
+    camundaModdlePackage = require('camunda-bpmn-moddle/resources/camunda'),
+    getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
 
-describe('call-activity-variable-mapping', function() {
+describe('CallActivity - variable mapping', function() {
 
   var diagramXML = require('./CallActivityVariableMapping.bpmn');
 
@@ -35,7 +35,7 @@ describe('call-activity-variable-mapping', function() {
 
   beforeEach(bootstrapModeler(diagramXML, {
     modules: testModules,
-    moddleExtensions: {camunda: camundaModdlePackage}
+    moddleExtensions: { camunda: camundaModdlePackage }
   }));
 
 
@@ -92,11 +92,11 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
     var shape = elementRegistry.get('CallActivity_2');
     selection.select(shape);
 
-    var selectBox = domQuery('select[id=cam-extension-elements-in-mapping]', propertiesPanel._container),
+    var selectBox = domQuery('select[id=cam-extensionElements-variableMapping-in]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     expect(selectBox.options).to.have.length.of(3);
-    
+
     expect(businessObject.extensionElements).not.to.be.undefined;
 
     var variableMappings = getVariableMappings(businessObject.extensionElements, CAMUNDA_IN_EXTENSION_ELEMENT);
@@ -110,11 +110,11 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
     var shape = elementRegistry.get('CallActivity_6');
     selection.select(shape);
 
-    var selectBox = domQuery('select[id=cam-extension-elements-out-mapping]', propertiesPanel._container),
+    var selectBox = domQuery('select[id=cam-extensionElements-variableMapping-out]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     expect(selectBox.options).to.have.length.of(3);
-    
+
     expect(businessObject.extensionElements).not.to.be.undefined;
 
     var variableMappings = getVariableMappings(businessObject.extensionElements, CAMUNDA_OUT_EXTENSION_ELEMENT);
@@ -128,8 +128,8 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
     var shape = elementRegistry.get('CallActivity_5');
     selection.select(shape);
 
-    var inSelectBox = domQuery('select[id=cam-extension-elements-in-mapping]', propertiesPanel._container),
-        outSelectBox = domQuery('select[id=cam-extension-elements-out-mapping]', propertiesPanel._container),
+    var inSelectBox = domQuery('select[id=cam-extensionElements-variableMapping-in]', propertiesPanel._container),
+        outSelectBox = domQuery('select[id=cam-extensionElements-variableMapping-out]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     expect(inSelectBox.options).to.have.length.of(4);
@@ -151,8 +151,8 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
     var shape = elementRegistry.get('CallActivity_5');
     selection.select(shape);
 
-    var inSelectBox = domQuery('select[id=cam-extension-elements-in-mapping]', propertiesPanel._container),
-        removeButton = domQuery('button[id=cam-extension-elements-remove-in-mapping]', propertiesPanel._container),
+    var inSelectBox = domQuery('select[id=cam-extensionElements-variableMapping-in]', propertiesPanel._container),
+        removeButton = domQuery('button[id=cam-extensionElements-remove-variableMapping-in]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     // given
@@ -191,9 +191,9 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
       var shape = elementRegistry.get('CallActivity_5');
       selection.select(shape);
 
-      outSelectBox = domQuery('select[id=cam-extension-elements-out-mapping]', propertiesPanel._container);
+      outSelectBox = domQuery('select[id=cam-extensionElements-variableMapping-out]', propertiesPanel._container);
       businessObject = getBusinessObject(shape);
-      var removeButton = domQuery('button[id=cam-extension-elements-remove-out-mapping]', propertiesPanel._container);
+      var removeButton = domQuery('button[id=cam-extensionElements-remove-variableMapping-out]', propertiesPanel._container);
 
       // given
       expect(outSelectBox.options).to.have.length.of(2);
@@ -264,9 +264,9 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
       var shape = elementRegistry.get('CallActivity_5');
       selection.select(shape);
 
-      inSelectBox = domQuery('select[id=cam-extension-elements-in-mapping]', propertiesPanel._container);
+      inSelectBox = domQuery('select[id=cam-extensionElements-variableMapping-in]', propertiesPanel._container);
       businessObject = getBusinessObject(shape);
-      var addButton = domQuery('button[id=cam-extension-elements-create-in-mapping]', propertiesPanel._container);
+      var addButton = domQuery('button[id=cam-extensionElements-create-variableMapping-in]', propertiesPanel._container);
 
       expect(inSelectBox.options).to.have.length.of(4);
 
@@ -326,8 +326,8 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
     var shape = elementRegistry.get('CallActivity_5');
     selection.select(shape);
 
-    var outSelectBox = domQuery('select[id=cam-extension-elements-out-mapping]', propertiesPanel._container),
-        addButton = domQuery('button[id=cam-extension-elements-create-out-mapping]', propertiesPanel._container),
+    var outSelectBox = domQuery('select[id=cam-extensionElements-variableMapping-out]', propertiesPanel._container),
+        addButton = domQuery('button[id=cam-extensionElements-create-variableMapping-out]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     // given
@@ -359,10 +359,10 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
     var shape = elementRegistry.get('CallActivity_3');
     selection.select(shape);
 
-    var selectBox = domQuery('select[id=cam-extension-elements-in-mapping]', propertiesPanel._container),
-        typeSelectBox = domQuery('select[id=camunda-in-out-type-select]', propertiesPanel._container),
-        sourceInput = domQuery('input[id=camunda-source]', propertiesPanel._container),
-        targetInput = domQuery('input[id="camunda-target"]', propertiesPanel._container),
+    var selectBox = domQuery('select[id=cam-extensionElements-variableMapping-in]', propertiesPanel._container),
+        typeSelectBox = domQuery('select[id=camunda-variableMapping-inOutType-select]', propertiesPanel._container),
+        sourceInput = domQuery('input[id=camunda-variableMapping-source]', propertiesPanel._container),
+        targetInput = domQuery('input[id=camunda-variableMapping-target]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     // given
@@ -386,10 +386,10 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
     var shape = elementRegistry.get('CallActivity_3');
     selection.select(shape);
 
-    var selectBox = domQuery('select[id=cam-extension-elements-in-mapping]', propertiesPanel._container),
-        typeSelectBox = domQuery('select[id=camunda-in-out-type-select]', propertiesPanel._container),
-        sourceInput = domQuery('input[id=camunda-source]', propertiesPanel._container),
-        targetInput = domQuery('input[id="camunda-target"]', propertiesPanel._container),
+    var selectBox = domQuery('select[id=cam-extensionElements-variableMapping-in]', propertiesPanel._container),
+        typeSelectBox = domQuery('select[id=camunda-variableMapping-inOutType-select]', propertiesPanel._container),
+        sourceInput = domQuery('input[id=camunda-variableMapping-source]', propertiesPanel._container),
+        targetInput = domQuery('input[id="camunda-variableMapping-target"]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     // given
@@ -418,10 +418,10 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
     var shape = elementRegistry.get('CallActivity_3');
     selection.select(shape);
 
-    var selectBox = domQuery('select[id=cam-extension-elements-in-mapping]', propertiesPanel._container),
-        typeSelectBox = domQuery('select[id=camunda-in-out-type-select]', propertiesPanel._container),
-        sourceInput = domQuery('input[id=camunda-source]', propertiesPanel._container),
-        targetInput = domQuery('input[id="camunda-target"]', propertiesPanel._container),
+    var selectBox = domQuery('select[id=cam-extensionElements-variableMapping-in]', propertiesPanel._container),
+        typeSelectBox = domQuery('select[id=camunda-variableMapping-inOutType-select]', propertiesPanel._container),
+        sourceInput = domQuery('input[id=camunda-variableMapping-source]', propertiesPanel._container),
+        targetInput = domQuery('input[id="camunda-variableMapping-target"]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     // given
@@ -454,10 +454,10 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
     var shape = elementRegistry.get('CallActivity_4');
     selection.select(shape);
 
-    var selectBox = domQuery('select[id=cam-extension-elements-in-mapping]', propertiesPanel._container),
-        typeSelectBox = domQuery('select[id=camunda-in-out-type-select]', propertiesPanel._container),
-        sourceInput = domQuery('input[id=camunda-source]', propertiesPanel._container),
-        targetInput = domQuery('input[id="camunda-target"]', propertiesPanel._container),
+    var selectBox = domQuery('select[id=cam-extensionElements-variableMapping-in]', propertiesPanel._container),
+        typeSelectBox = domQuery('select[id=camunda-variableMapping-inOutType-select]', propertiesPanel._container),
+        sourceInput = domQuery('input[id=camunda-variableMapping-source]', propertiesPanel._container),
+        targetInput = domQuery('input[id="camunda-variableMapping-target"]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     // given
@@ -490,10 +490,10 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
     var shape = elementRegistry.get('CallActivity_3');
     selection.select(shape);
 
-    var selectBox = domQuery('select[id=cam-extension-elements-out-mapping]', propertiesPanel._container),
-        typeSelectBox = domQuery('select[id=camunda-in-out-type-select]', propertiesPanel._container),
-        sourceInput = domQuery('input[id=camunda-source]', propertiesPanel._container),
-        targetInput = domQuery('input[id="camunda-target"]', propertiesPanel._container),
+    var selectBox = domQuery('select[id=cam-extensionElements-variableMapping-out]', propertiesPanel._container),
+        typeSelectBox = domQuery('select[id=camunda-variableMapping-inOutType-select]', propertiesPanel._container),
+        sourceInput = domQuery('input[id=camunda-variableMapping-source]', propertiesPanel._container),
+        targetInput = domQuery('input[id="camunda-variableMapping-target"]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     // given
@@ -531,12 +531,12 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
       var shape = elementRegistry.get('CallActivity_4');
       selection.select(shape);
 
-      selectBox = domQuery('select[id=cam-extension-elements-out-mapping]', propertiesPanel._container);
-      typeSelectBox = domQuery('select[id=camunda-in-out-type-select]', propertiesPanel._container);
-      sourceInput = domQuery('input[id=camunda-source]', propertiesPanel._container);
-      targetInput = domQuery('input[id="camunda-target"]', propertiesPanel._container);
+      selectBox = domQuery('select[id=cam-extensionElements-variableMapping-out]', propertiesPanel._container);
+      typeSelectBox = domQuery('select[id=camunda-variableMapping-inOutType-select]', propertiesPanel._container);
+      sourceInput = domQuery('input[id=camunda-variableMapping-source]', propertiesPanel._container);
+      targetInput = domQuery('input[id="camunda-variableMapping-target"]', propertiesPanel._container);
       businessObject = getBusinessObject(shape);
-      var clearButton = domQuery('[data-entry=target] [data-action=clear]', propertiesPanel._container);
+      var clearButton = domQuery('[data-entry=variableMapping-target] [data-action=clear]', propertiesPanel._container);
 
       expect(selectBox.options).to.have.length.of(1);
 
@@ -600,10 +600,10 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
     var shape = elementRegistry.get('CallActivity_4');
     selection.select(shape);
 
-    var selectBox = domQuery('select[id=cam-extension-elements-out-mapping]', propertiesPanel._container),
-        typeSelectBox = domQuery('select[id=camunda-in-out-type-select]', propertiesPanel._container),
-        sourceInput = domQuery('input[id=camunda-source]', propertiesPanel._container),
-        targetInput = domQuery('input[id="camunda-target"]', propertiesPanel._container),
+    var selectBox = domQuery('select[id=cam-extensionElements-variableMapping-out]', propertiesPanel._container),
+        typeSelectBox = domQuery('select[id=camunda-variableMapping-inOutType-select]', propertiesPanel._container),
+        sourceInput = domQuery('input[id=camunda-variableMapping-source]', propertiesPanel._container),
+        targetInput = domQuery('input[id="camunda-variableMapping-target"]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     // given
@@ -645,8 +645,8 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
     var shape = elementRegistry.get('CallActivity_5');
     selection.select(shape);
 
-    var selectBox = domQuery('select[id=cam-extension-elements-in-mapping]', propertiesPanel._container),
-        typeSelectBox = domQuery('select[id=camunda-in-out-type-select]', propertiesPanel._container);
+    var selectBox = domQuery('select[id=cam-extensionElements-variableMapping-in]', propertiesPanel._container),
+        typeSelectBox = domQuery('select[id=camunda-variableMapping-inOutType-select]', propertiesPanel._container);
 
     expect(selectBox.options).to.have.length.of(4);
 
@@ -663,10 +663,10 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
     var shape = elementRegistry.get('CallActivity_5');
     selection.select(shape);
 
-    var selectBox = domQuery('select[id=cam-extension-elements-in-mapping]', propertiesPanel._container),
-        typeSelectBox = domQuery('select[id=camunda-in-out-type-select]', propertiesPanel._container),
-        sourceInput = domQuery('input[id=camunda-source]', propertiesPanel._container),
-        targetInput = domQuery('input[id="camunda-target"]', propertiesPanel._container),
+    var selectBox = domQuery('select[id=cam-extensionElements-variableMapping-in]', propertiesPanel._container),
+        typeSelectBox = domQuery('select[id=camunda-variableMapping-inOutType-select]', propertiesPanel._container),
+        sourceInput = domQuery('input[id=camunda-variableMapping-source]', propertiesPanel._container),
+        targetInput = domQuery('input[id="camunda-variableMapping-target"]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     expect(selectBox.options).to.have.length.of(4);
@@ -688,9 +688,9 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
 
     selection.select(shape);
 
-    var selectBox = domQuery('select[id=cam-extension-elements-in-mapping]', propertiesPanel._container),
-        typeSelectBox = domQuery('select[id=camunda-in-out-type-select]', propertiesPanel._container),
-        removeButton = domQuery('button[id=cam-extension-elements-remove-in-mapping]', propertiesPanel._container),
+    var selectBox = domQuery('select[id=cam-extensionElements-variableMapping-in]', propertiesPanel._container),
+        typeSelectBox = domQuery('select[id=camunda-variableMapping-inOutType-select]', propertiesPanel._container),
+        removeButton = domQuery('button[id=cam-extensionElements-remove-variableMapping-in]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     // given
@@ -719,9 +719,9 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
 
     selection.select(shape);
 
-    var selectBox = domQuery('select[id=cam-extension-elements-in-mapping]', propertiesPanel._container),
-        typeSelectBox = domQuery('select[id=camunda-in-out-type-select]', propertiesPanel._container),
-        addButton = domQuery('button[id=cam-extension-elements-create-in-mapping]', propertiesPanel._container),
+    var selectBox = domQuery('select[id=cam-extensionElements-variableMapping-in]', propertiesPanel._container),
+        typeSelectBox = domQuery('select[id=camunda-variableMapping-inOutType-select]', propertiesPanel._container),
+        addButton = domQuery('button[id=cam-extensionElements-create-variableMapping-in]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     // given
@@ -754,8 +754,8 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
       var shape = elementRegistry.get('CallActivity_1');
       selection.select(shape);
 
-      var selectBox = domQuery('select[id=cam-extension-elements-in-mapping]', propertiesPanel._container),
-          checkBox = domQuery('input[id=camunda-local]', propertiesPanel._container);
+      var selectBox = domQuery('select[id=cam-extensionElements-variableMapping-in]', propertiesPanel._container),
+          checkBox = domQuery('input[id=camunda-variableMapping-local]', propertiesPanel._container);
 
       selectBox.options[0].selected = 'selected';
       TestHelper.triggerEvent(selectBox, 'change');
@@ -770,8 +770,8 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
       var shape = elementRegistry.get('CallActivity_2');
       selection.select(shape);
 
-      var selectBox = domQuery('select[id=cam-extension-elements-in-mapping]', propertiesPanel._container),
-          checkBox = domQuery('input[id=camunda-local]', propertiesPanel._container),
+      var selectBox = domQuery('select[id=cam-extensionElements-variableMapping-in]', propertiesPanel._container),
+          checkBox = domQuery('input[id=camunda-variableMapping-local]', propertiesPanel._container),
           businessObject = getBusinessObject(shape);
 
       // given
@@ -802,9 +802,9 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
       var shape = elementRegistry.get('CallActivity_1');
       selection.select(shape);
 
-      var selectBox = domQuery('select[id=cam-extension-elements-in-mapping]', propertiesPanel._container),
+      var selectBox = domQuery('select[id=cam-extensionElements-variableMapping-in]', propertiesPanel._container),
           businessObject = getBusinessObject(shape);
-      checkBox = domQuery('input[id=camunda-local]', propertiesPanel._container);
+      checkBox = domQuery('input[id=camunda-variableMapping-local]', propertiesPanel._container);
 
       // select mapping
       selectBox.options[0].selected = 'selected';
@@ -858,9 +858,9 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
       var shape = elementRegistry.get('CallActivity_1');
       selection.select(shape);
 
-      var selectBox = domQuery('select[id=cam-extension-elements-out-mapping]', propertiesPanel._container),
+      var selectBox = domQuery('select[id=cam-extensionElements-variableMapping-out]', propertiesPanel._container),
           businessObject = getBusinessObject(shape);
-      checkBox = domQuery('input[id=camunda-local]', propertiesPanel._container);
+      checkBox = domQuery('input[id=camunda-variableMapping-local]', propertiesPanel._container);
 
       // select mapping
       selectBox.options[0].selected = 'selected';
@@ -877,7 +877,7 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
     it('should execute', inject(function() {
 
       expect(checkBox.checked).to.be.true;
-      
+
       expect(variablesMappings[0].local).to.be.true;
 
     }));

--- a/test/spec/provider/camunda/CamundaPropertiesProviderSpec.js
+++ b/test/spec/provider/camunda/CamundaPropertiesProviderSpec.js
@@ -7,13 +7,13 @@ var TestContainer = require('mocha-test-container-support');
 /* global bootstrapModeler, inject */
 
 var propertiesPanelModule = require('../../../../lib'),
-  domQuery = require('min-dom/lib/query'),
-  domClasses = require('min-dom/lib/classes'),
-  coreModule = require('bpmn-js/lib/core'),
-  selectionModule = require('diagram-js/lib/features/selection'),
-  modelingModule = require('bpmn-js/lib/features/modeling'),
-  propertiesProviderModule = require('../../../../lib/provider/camunda'),
-  camundaModdlePackage = require('camunda-bpmn-moddle/resources/camunda');
+    domQuery = require('min-dom/lib/query'),
+    domClasses = require('min-dom/lib/classes'),
+    coreModule = require('bpmn-js/lib/core'),
+    selectionModule = require('diagram-js/lib/features/selection'),
+    modelingModule = require('bpmn-js/lib/features/modeling'),
+    propertiesProviderModule = require('../../../../lib/provider/camunda'),
+    camundaModdlePackage = require('camunda-bpmn-moddle/resources/camunda');
 
 
 describe('camunda-properties', function() {
@@ -62,7 +62,7 @@ describe('camunda-properties', function() {
 
     // given
     var shape = elementRegistry.get('ServiceTask_1'),
-        selector = '[data-group=job-configuration]';
+        selector = '[data-group=jobConfiguration]';
 
     // when
     selection.select(shape);
@@ -78,8 +78,8 @@ describe('camunda-properties', function() {
     inject(function(propertiesPanel, selection, elementRegistry) {
 
       var shape = elementRegistry.get('ServiceTask_1'),
-          groupSelector = '[data-group=job-configuration]',
-          inputSelector = 'div[data-entry=async-before] input[name=asyncBefore]';
+          groupSelector = '[data-group=jobConfiguration]',
+          inputSelector = 'div[data-entry=asyncBefore] input[name=asyncBefore]';
 
       // given
       selection.select(shape);

--- a/test/spec/provider/camunda/ConnectorSpec.js
+++ b/test/spec/provider/camunda/ConnectorSpec.js
@@ -54,7 +54,7 @@ function getButton(container, groupId, entryId, buttonAction) {
 }
 
 function getConnectorIdInput(container) {
-  return getInputField(container, 'connector-details', 'connector-id');
+  return getInputField(container, 'connector-details', 'connectorId');
 }
 
 function getConnectorInputParameterSelect(container) {
@@ -103,7 +103,7 @@ function getParameterGroupLabel(container) {
 }
 
 function getParameterNameInput(container) {
-  return getInputField(container, 'connector-input-output-parameter', 'connector-parameter-name');
+  return getInputField(container, 'connector-input-output-parameter', 'connector-parameterName');
 }
 
 function getConnector(element) {
@@ -535,7 +535,7 @@ describe('connector', function() {
 
   });
 
-  
+
   describe('add input parameter', function() {
 
     var bo;

--- a/test/spec/provider/camunda/DecisionBusinessRuleTaskSpec.js
+++ b/test/spec/provider/camunda/DecisionBusinessRuleTaskSpec.js
@@ -58,7 +58,7 @@ describe('decision-business-rule-task-properties', function() {
     selection.select(shape);
 
     var decisionRefField = domQuery('input[name=callableElementRef]', propertiesPanel._container),
-    	resultVariable = domQuery('div[data-entry=dmn-result-variable] input[name=resultVariable]', propertiesPanel._container),
+    	resultVariable = domQuery('div[data-entry=dmn-resultVariable] input[name=resultVariable]', propertiesPanel._container),
     	implType = TestHelper.selectedByIndex(domQuery('select[name=implType]', propertiesPanel._container)),
         businessObject = getBusinessObject(shape);
 
@@ -259,7 +259,7 @@ describe('decision-business-rule-task-properties', function() {
     selection.select(shape);
 
     var implType = domQuery('select[name=implType]', propertiesPanel._container),
-        resultVariable = domQuery('div[data-entry=result-variable] input[name=resultVariable]', propertiesPanel._container),
+        resultVariable = domQuery('div[data-entry=resultVariable] input[name=resultVariable]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     expect(implType.value).to.not.equal('decisionRef');
@@ -277,8 +277,8 @@ describe('decision-business-rule-task-properties', function() {
     selection.select(shape);
 
     var implType = domQuery('select[name=implType]', propertiesPanel._container),
-        resultVariable = domQuery('div[data-entry=dmn-result-variable] input[name=resultVariable]', propertiesPanel._container),
-        clearButton = domQuery('[data-entry=dmn-result-variable] button[data-action=clear]', propertiesPanel._container),
+        resultVariable = domQuery('div[data-entry=dmn-resultVariable] input[name=resultVariable]', propertiesPanel._container),
+        clearButton = domQuery('[data-entry=dmn-resultVariable] button[data-action=clear]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     // given
@@ -380,7 +380,7 @@ describe('decision-business-rule-task-properties', function() {
 
     var implType = domQuery('select[name=implType]', propertiesPanel._container),
         mapDecisionResult = domQuery('select[name=mapDecisionResult]', propertiesPanel._container),
-        dmnResultVariableInput = domQuery('div[data-entry=dmn-result-variable] input[name=resultVariable]', propertiesPanel._container),
+        dmnResultVariableInput = domQuery('div[data-entry=dmn-resultVariable] input[name=resultVariable]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     // given
@@ -400,7 +400,7 @@ describe('decision-business-rule-task-properties', function() {
 
     var implType = domQuery('select[name=implType]', propertiesPanel._container),
         mapDecisionResult = domQuery('select[name=mapDecisionResult]', propertiesPanel._container),
-        dmnResultVariableInput = domQuery('div[data-entry=dmn-result-variable] input[name=resultVariable]', propertiesPanel._container),
+        dmnResultVariableInput = domQuery('div[data-entry=dmn-resultVariable] input[name=resultVariable]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     // given
@@ -429,8 +429,8 @@ describe('decision-business-rule-task-properties', function() {
 
     var implType = domQuery('select[name=implType]', propertiesPanel._container),
         mapDecisionResult = domQuery('select[name=mapDecisionResult]', propertiesPanel._container),
-        dmnResultVariableInput = domQuery('div[data-entry=dmn-result-variable] input[name=resultVariable]', propertiesPanel._container),
-        clearButton = domQuery('[data-entry=dmn-result-variable] button[data-action=clear]', propertiesPanel._container),
+        dmnResultVariableInput = domQuery('div[data-entry=dmn-resultVariable] input[name=resultVariable]', propertiesPanel._container),
+        clearButton = domQuery('[data-entry=dmn-resultVariable] button[data-action=clear]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     // given
@@ -485,7 +485,7 @@ describe('decision-business-rule-task-properties', function() {
     var implType = domQuery('select[name=implType]', propertiesPanel._container),
         decisionRefBinding = domQuery('select[name="callableBinding"]', propertiesPanel._container),
         decisionRefValue = domQuery('input[name=callableElementRef]', propertiesPanel._container),
-        dmnResultVariable = domQuery('div[data-entry=dmn-result-variable] input[name=resultVariable]', propertiesPanel._container),
+        dmnResultVariable = domQuery('div[data-entry=dmn-resultVariable] input[name=resultVariable]', propertiesPanel._container),
         mapDecisionResult = domQuery('select[name=mapDecisionResult]', propertiesPanel._container),
         delegateField = domQuery('input[name=delegate]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);

--- a/test/spec/provider/camunda/ExecutionListenerPropertiesSpec.js
+++ b/test/spec/provider/camunda/ExecutionListenerPropertiesSpec.js
@@ -204,7 +204,7 @@ describe('listener-properties', function() {
 
     var bo = getBusinessObject(taskShape),
         executionListeners = getExecutionListener(bo.extensionElements),
-        addListenerButton = domQuery('[data-entry=execution-listeners] > div > button[data-action=addListener]', propertiesPanel._container);
+        addListenerButton = domQuery('[data-entry=executionListeners] > div > button[data-action=addListener]', propertiesPanel._container);
 
     // given
     expect(bo.extensionElements.values.length).to.equal(3);
@@ -244,7 +244,7 @@ describe('listener-properties', function() {
 
     var bo = getBusinessObject(taskShape),
         executionListeners = getExecutionListener(bo.extensionElements),
-        removeListenerButtons = domQuery.all('[data-entry=execution-listeners] button[data-action=removeListener]', propertiesPanel._container);
+        removeListenerButtons = domQuery.all('[data-entry=executionListeners] button[data-action=removeListener]', propertiesPanel._container);
 
     // given
     expect(bo.extensionElements.values.length).to.equal(3);
@@ -283,7 +283,7 @@ describe('listener-properties', function() {
 
     var bo = getBusinessObject(taskShape),
         executionListeners = getExecutionListener(bo.extensionElements),
-        addListenerButton = domQuery('[data-entry=execution-listeners] > div > button[data-action=addListener]', propertiesPanel._container);
+        addListenerButton = domQuery('[data-entry=executionListeners] > div > button[data-action=addListener]', propertiesPanel._container);
 
     // given
     expect(bo.extensionElements).to.be.empty;
@@ -326,7 +326,7 @@ describe('listener-properties', function() {
         eventTypes = domQuery.all('select[name=eventType]', propertiesPanel._container),
         listenerTypes = domQuery.all('select[name=listenerType]', propertiesPanel._container),
         listenerValues = domQuery.all('input[name=listenerValue]', propertiesPanel._container),
-        clearButtons = domQuery.all('[data-entry=execution-listeners] button[data-action=clearListenerValue]', propertiesPanel._container);
+        clearButtons = domQuery.all('[data-entry=executionListeners] button[data-action=clearListenerValue]', propertiesPanel._container);
 
     // given
     expect(clearButtons.length).to.equal(2);
@@ -364,7 +364,7 @@ describe('listener-properties', function() {
 
     var bo = getBusinessObject(taskShape),
         executionListeners = getExecutionListener(bo.extensionElements),
-        addListenerButton = domQuery('[data-entry=execution-listeners] > div > button[data-action=addListener]', propertiesPanel._container);
+        addListenerButton = domQuery('[data-entry=executionListeners] > div > button[data-action=addListener]', propertiesPanel._container);
 
     // given
     expect(bo.extensionElements.values.length).to.equal(1);
@@ -404,7 +404,7 @@ describe('listener-properties', function() {
 
     var bo = getBusinessObject(taskShape),
         executionListeners = getExecutionListener(bo.extensionElements),
-        addListenerButton = domQuery('[data-entry=execution-listeners] > div > button[data-action=addListener]', propertiesPanel._container);
+        addListenerButton = domQuery('[data-entry=executionListeners] > div > button[data-action=addListener]', propertiesPanel._container);
 
     // given
     expect(bo.extensionElements).to.be.empty;
@@ -454,7 +454,7 @@ describe('listener-properties', function() {
 
     selection.select(taskShape);
 
-    var query = '[data-entry=execution-listeners] > div > button[data-action=addListener]',
+    var query = '[data-entry=executionListeners] > div > button[data-action=addListener]',
         addListenerButton = domQuery(query, propertiesPanel._container);
 
     TestHelper.triggerEvent(addListenerButton, 'click');
@@ -488,7 +488,7 @@ describe('listener-properties', function() {
 
     selection.select(taskShape);
 
-    var query = '[data-entry=execution-listeners] > div > button[data-action=addListener]',
+    var query = '[data-entry=executionListeners] > div > button[data-action=addListener]',
         addListenerButton = domQuery(query, propertiesPanel._container);
 
     TestHelper.triggerEvent(addListenerButton, 'click');
@@ -518,7 +518,7 @@ describe('listener-properties', function() {
 
     selection.select(taskShape);
 
-    var query = '[data-entry=execution-listeners] > div > button[data-action=addListener]',
+    var query = '[data-entry=executionListeners] > div > button[data-action=addListener]',
         addListenerButton = domQuery(query, propertiesPanel._container);
 
     TestHelper.triggerEvent(addListenerButton, 'click');
@@ -556,7 +556,7 @@ describe('listener-properties', function() {
 
     selection.select(taskShape);
 
-    var query = '[data-entry=execution-listeners] > div > button[data-action=addListener]',
+    var query = '[data-entry=executionListeners] > div > button[data-action=addListener]',
         addListenerButton = domQuery(query, propertiesPanel._container);
 
     TestHelper.triggerEvent(addListenerButton, 'click');
@@ -588,7 +588,7 @@ describe('listener-properties', function() {
 
     selection.select(taskShape);
 
-    var query = '[data-entry=execution-listeners] > div > button[data-action=addListener]',
+    var query = '[data-entry=executionListeners] > div > button[data-action=addListener]',
         addListenerButton = domQuery(query, propertiesPanel._container);
 
     // given

--- a/test/spec/provider/camunda/ExtensionElementsSpec.js
+++ b/test/spec/provider/camunda/ExtensionElementsSpec.js
@@ -16,7 +16,7 @@ var propertiesPanelModule = require('../../../../lib'),
     getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject,
     forEach = require('lodash/collection/forEach');
 
-describe('extension-elements', function() {
+describe('extensionElements', function() {
 
   var diagramXML = require('./ExtensionElements.bpmn');
 

--- a/test/spec/provider/camunda/ExternalServiceTaskSpec.js
+++ b/test/spec/provider/camunda/ExternalServiceTaskSpec.js
@@ -252,7 +252,7 @@ describe('external-service-task-properties', function() {
     }
 
     function getTopicInput(container) {
-      return domQuery('div[data-entry="external-topic"] input[name="externalTopic"]', container);
+      return domQuery('div[data-entry="externalTopic"] input[name="externalTopic"]', container);
     }
 
     it('should offer external as implementation type for an intermediate message event',

--- a/test/spec/provider/camunda/FormDataSpec.js
+++ b/test/spec/provider/camunda/FormDataSpec.js
@@ -371,7 +371,7 @@ describe('form-data', function() {
       // select the third form field 'dateOfBirth'
       TestHelper.triggerFormFieldSelection(2, container);
 
-      var removeButton = domQuery('button[id=cam-extension-elements-remove-form-fields]', container);
+      var removeButton = domQuery('button[id=cam-extensionElements-remove-form-fields]', container);
 
       TestHelper.triggerEvent(removeButton, 'click');
     }));

--- a/test/spec/provider/camunda/FormKeySpec.js
+++ b/test/spec/provider/camunda/FormKeySpec.js
@@ -229,7 +229,7 @@ describe('form-key', function() {
       // when
       TestHelper.triggerEvent(selectBox, 'change');
 
-      var formFieldSelectBox = domQuery('select[id=cam-extension-elements-form-fields]', propertiesPanel._container);
+      var formFieldSelectBox = domQuery('select[id=cam-extensionElements-form-fields]', propertiesPanel._container);
 
       // then
       expect(isHiddenRow('form-field-id'), propertiesPanel._container).to.be.true;

--- a/test/spec/provider/camunda/ImplementationTypeSpec.js
+++ b/test/spec/provider/camunda/ImplementationTypeSpec.js
@@ -29,7 +29,7 @@ function getDetailsGroup(container) {
 
 function getEntry(entryId, container) {
   var group = getDetailsGroup(container);
-  return domQuery('div[data-entry="' + entryId + '"]', container);  
+  return domQuery('div[data-entry="' + entryId + '"]', container);
 }
 
 function getInputField(container, entryId, inputName) {
@@ -53,15 +53,15 @@ function getDelegateInput(container) {
 }
 
 function getResultVariableInput(container) {
-  return getInputField(container, 'result-variable');
+  return getInputField(container, 'resultVariable');
 }
 
 function getExternalTopicInput(container) {
-  return getInputField(container, 'external-topic');
+  return getInputField(container, 'externalTopic');
 }
 
 function getConfigureConnectorLink(container) {
-  var entry = getEntry('configure-connector-link', container)
+  var entry = getEntry('configureConnectorLink', container)
   return domQuery('a', entry);
 }
 
@@ -74,7 +74,7 @@ function getCallableBindingSelect(container) {
 }
 
 function getDmnResultVariableInput(container) {
-  return getInputField(container, 'dmn-result-variable');
+  return getInputField(container, 'dmn-resultVariable');
 }
 
 function selectImplementationType(type, container) {
@@ -149,7 +149,7 @@ describe('implementation type', function() {
         // given
         var shape = elementRegistry.get('CLASS');
         // when
-        selection.select(shape);  
+        selection.select(shape);
       }));
 
 
@@ -192,7 +192,7 @@ describe('implementation type', function() {
         // given
         var shape = elementRegistry.get('EXPRESSION');
         // when
-        selection.select(shape);  
+        selection.select(shape);
       }));
 
 
@@ -235,7 +235,7 @@ describe('implementation type', function() {
         // given
         var shape = elementRegistry.get('DELEGATE_EXPRESSION');
         // when
-        selection.select(shape);  
+        selection.select(shape);
       }));
 
 
@@ -278,7 +278,7 @@ describe('implementation type', function() {
         // given
         var shape = elementRegistry.get('EXTERNAL');
         // when
-        selection.select(shape);  
+        selection.select(shape);
       }));
 
 
@@ -321,7 +321,7 @@ describe('implementation type', function() {
         // given
         var shape = elementRegistry.get('CONNECTOR');
         // when
-        selection.select(shape);  
+        selection.select(shape);
       }));
 
       it('should show connector implementation type', function() {
@@ -362,7 +362,7 @@ describe('implementation type', function() {
         // given
         var shape = elementRegistry.get('DMN');
         // when
-        selection.select(shape);  
+        selection.select(shape);
       }));
 
       it('should show dmn implementation type', function() {
@@ -414,7 +414,7 @@ describe('implementation type', function() {
 
   describe('change implementation type', function() {
 
-    var container, implementationTypeSelect, bo; 
+    var container, implementationTypeSelect, bo;
 
     describe('from class', function() {
 
@@ -1605,7 +1605,7 @@ describe('implementation type', function() {
       });
 
     });
-  
+
 
     describe('from external', function() {
 

--- a/test/spec/provider/camunda/InputOutputParameterListSpec.js
+++ b/test/spec/provider/camunda/InputOutputParameterListSpec.js
@@ -58,15 +58,15 @@ function getInputOutputTab(container) {
 }
 
 function getParameterTypeSelect(container) {
-  return domQuery('select[id="camunda-parameter-type-select"]', getInputOutputTab(container));
+  return domQuery('select[id="camunda-parameterType-select"]', getInputOutputTab(container));
 }
 
 function getListAddRowDiv(container) {
-  return domQuery('div[data-entry="parameter-type-list"] > div.pp-table-add-row', getInputOutputTab(container));
+  return domQuery('div[data-entry="parameterType-list"] > div.pp-table-add-row', getInputOutputTab(container));
 }
 
 function getListTable(container) {
-  return domQuery('div[data-entry="parameter-type-list"] > div.pp-table', getInputOutputTab(container));
+  return domQuery('div[data-entry="parameterType-list"] > div.pp-table', getInputOutputTab(container));
 }
 
 function getListRows(container) {
@@ -92,10 +92,10 @@ function clickRemoveValueButton(idx, container) {
 // helper
 
 function getSelect(suffix, container) {
-  return domQuery('select[id="cam-extension-elements-' + suffix + '"]', getInputOutputTab(container));
+  return domQuery('select[id="cam-extensionElements-' + suffix + '"]', getInputOutputTab(container));
 }
 
-describe('input-output-parameter-type-list', function() {
+describe('input-output-parameterType-list', function() {
 
   var diagramXML = require('./InputOutput.bpmn');
 

--- a/test/spec/provider/camunda/InputOutputParameterMapSpec.js
+++ b/test/spec/provider/camunda/InputOutputParameterMapSpec.js
@@ -58,15 +58,15 @@ function getInputOutputTab(container) {
 }
 
 function getParameterTypeSelect(container) {
-  return domQuery('select[id="camunda-parameter-type-select"]', getInputOutputTab(container));
+  return domQuery('select[id="camunda-parameterType-select"]', getInputOutputTab(container));
 }
 
 function getMapAddRowDiv(container) {
-  return domQuery('div[data-entry="parameter-type-map"] > div', getInputOutputTab(container));
+  return domQuery('div[data-entry="parameterType-map"] > div', getInputOutputTab(container));
 }
 
 function getMapTable(container) {
-  return domQuery('div[data-entry="parameter-type-map"] > div.pp-table', getInputOutputTab(container));
+  return domQuery('div[data-entry="parameterType-map"] > div.pp-table', getInputOutputTab(container));
 }
 
 function getMapRows(container) {
@@ -92,10 +92,10 @@ function clickRemoveEntryButton(idx, container) {
 // helper
 
 function getSelect(suffix, container) {
-  return domQuery('select[id=cam-extension-elements-' + suffix + ']', getInputOutputTab(container));
+  return domQuery('select[id=cam-extensionElements-' + suffix + ']', getInputOutputTab(container));
 }
 
-describe('input-output-parameter-type-map', function() {
+describe('input-output-parameterType-map', function() {
 
   var diagramXML = require('./InputOutput.bpmn');
 

--- a/test/spec/provider/camunda/InputOutputParameterScriptSpec.js
+++ b/test/spec/provider/camunda/InputOutputParameterScriptSpec.js
@@ -45,7 +45,7 @@ function getInputOutputTab(container) {
 }
 
 function getParameterTypeSelect(container) {
-  return domQuery('select[id="camunda-parameter-type-select"]', getInputOutputTab(container));
+  return domQuery('select[id="camunda-parameterType-select"]', getInputOutputTab(container));
 }
 
 // input parameter
@@ -63,11 +63,11 @@ function selectInputParameter(idx, container) {
 // helper
 
 function getSelect(suffix, container) {
-  return domQuery('select[id=cam-extension-elements-' + suffix + ']', getInputOutputTab(container));
+  return domQuery('select[id=cam-extensionElements-' + suffix + ']', getInputOutputTab(container));
 }
 
 
-describe('input-output-parameter-type-script', function() {
+describe('input-output-parameterType-script', function() {
 
   var diagramXML = require('./InputOutput.bpmn');
 

--- a/test/spec/provider/camunda/InputOutputParameterTextSpec.js
+++ b/test/spec/provider/camunda/InputOutputParameterTextSpec.js
@@ -58,21 +58,21 @@ function getInputOutputTab(container) {
 }
 
 function getParameterTypeSelect(container) {
-  return domQuery('select[id="camunda-parameter-type-select"]', getInputOutputTab(container));
+  return domQuery('select[id="camunda-parameterType-select"]', getInputOutputTab(container));
 }
 
 function getParameterTextValue(container) {
-  return domQuery('textarea[id="camunda-parameter-type-text"]', getInputOutputTab(container));
+  return domQuery('textarea[id="camunda-parameterType-text"]', getInputOutputTab(container));
 }
 
 // helper
 
 function getSelect(suffix, container) {
-  return domQuery('select[id="cam-extension-elements-' + suffix + '"]', getInputOutputTab(container));
+  return domQuery('select[id="cam-extensionElements-' + suffix + '"]', getInputOutputTab(container));
 }
 
 
-describe('input-output-parameter-type-text', function() {
+describe('input-output-parameterType-text', function() {
 
   var diagramXML = require('./InputOutput.bpmn');
 

--- a/test/spec/provider/camunda/InputOutputSpec.js
+++ b/test/spec/provider/camunda/InputOutputSpec.js
@@ -121,27 +121,27 @@ function getParameterGroupLabel(container) {
 }
 
 function getParameterNameInput(container) {
-  return domQuery('input[id="camunda-parameter-name"]', getInputOutputTab(container));
+  return domQuery('input[id="camunda-parameterName"]', getInputOutputTab(container));
 }
 
 function getParameterTypeSelect(container) {
-  return domQuery('select[id="camunda-parameter-type-select"]', getInputOutputTab(container));
+  return domQuery('select[id="camunda-parameterType-select"]', getInputOutputTab(container));
 }
 
 function getParameterTextValue(container) {
-  return domQuery('textarea[id="camunda-parameter-type-text"]', getInputOutputTab(container));
+  return domQuery('textarea[id="camunda-parameterType-text"]', getInputOutputTab(container));
 }
 
 function getScriptEntry(container) {
-  return domQuery('div[data-entry="parameter-type-script"] > div', getInputOutputTab(container));
+  return domQuery('div[data-entry="parameterType-script"] > div', getInputOutputTab(container));
 }
 
 function getListAddRowDiv(container) {
-  return domQuery('div[data-entry="parameter-type-list"] > div.pp-table-add-row', getInputOutputTab(container));
+  return domQuery('div[data-entry="parameterType-list"] > div.pp-table-add-row', getInputOutputTab(container));
 }
 
 function getListTable(container) {
-  return domQuery('div[data-entry="parameter-type-list"] > div.pp-table', getInputOutputTab(container));
+  return domQuery('div[data-entry="parameterType-list"] > div.pp-table', getInputOutputTab(container));
 }
 
 function getListRows(container) {
@@ -155,11 +155,11 @@ function getListInput(idx, container) {
 }
 
 function getMapAddRowDiv(container) {
-  return domQuery('div[data-entry="parameter-type-map"] > div', getInputOutputTab(container));
+  return domQuery('div[data-entry="parameterType-map"] > div', getInputOutputTab(container));
 }
 
 function getMapTable(container) {
-  return domQuery('div[data-entry="parameter-type-map"] > div.pp-table', getInputOutputTab(container));
+  return domQuery('div[data-entry="parameterType-map"] > div.pp-table', getInputOutputTab(container));
 }
 
 function getMapRows(container) {
@@ -175,15 +175,15 @@ function getMapInput(idx, column, container) {
 // helper
 
 function getSelect(suffix, container) {
-  return domQuery('select[id="cam-extension-elements-' + suffix + '"]', getInputOutputTab(container));
+  return domQuery('select[id="cam-extensionElements-' + suffix + '"]', getInputOutputTab(container));
 }
 
 function getAddButton(suffix, container) {
-  return domQuery('button[id="cam-extension-elements-create-' + suffix + '"]', getInputOutputTab(container));
+  return domQuery('button[id="cam-extensionElements-create-' + suffix + '"]', getInputOutputTab(container));
 }
 
 function getRemoveButton(suffix, container) {
-  return domQuery('button[id="cam-extension-elements-remove-' + suffix + '"]', getInputOutputTab(container));
+  return domQuery('button[id="cam-extensionElements-remove-' + suffix + '"]', getInputOutputTab(container));
 }
 
 function isParameterContainedIn(params, value) {

--- a/test/spec/provider/camunda/JobPrioritySpec.js
+++ b/test/spec/provider/camunda/JobPrioritySpec.js
@@ -16,7 +16,7 @@ var propertiesPanelModule = require('../../../../lib'),
     getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject,
     forEach = require('lodash/collection/forEach');
 
-describe('job-priority', function() {
+describe('jobPriority', function() {
   var diagramXML = require('./JobPriority.bpmn');
 
   var testModules = [

--- a/test/spec/provider/camunda/MultiInstanceLoopSpec.js
+++ b/test/spec/provider/camunda/MultiInstanceLoopSpec.js
@@ -7,19 +7,19 @@ var TestContainer = require('mocha-test-container-support');
 /* global bootstrapModeler, inject */
 
 var propertiesPanelModule = require('../../../../lib'),
-  domQuery = require('min-dom/lib/query'),
-  domClasses = require('min-dom/lib/classes'),
-  coreModule = require('bpmn-js/lib/core'),
-  selectionModule = require('diagram-js/lib/features/selection'),
-  modelingModule = require('bpmn-js/lib/features/modeling'),
-  propertiesProviderModule = require('../../../../lib/provider/camunda'),
-  camundaModdlePackage = require('camunda-bpmn-moddle/resources/camunda'),
-  getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
+    domQuery = require('min-dom/lib/query'),
+    domClasses = require('min-dom/lib/classes'),
+    coreModule = require('bpmn-js/lib/core'),
+    selectionModule = require('diagram-js/lib/features/selection'),
+    modelingModule = require('bpmn-js/lib/features/modeling'),
+    propertiesProviderModule = require('../../../../lib/provider/camunda'),
+    camundaModdlePackage = require('camunda-bpmn-moddle/resources/camunda'),
+    getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
 
 var HIDE_CLASS = 'pp-hidden';
 
 function getMultiInstanceGroup(container) {
-  return domQuery('div[data-group=multi-instance]', container);
+  return domQuery('div[data-group=multiInstance]', container);
 }
 
 function getEntry(container, entryId) {
@@ -32,43 +32,43 @@ function getInputField(container, entryId, inputName) {
 }
 
 function getLoopCardinalityInput(container) {
-  return getInputField(container, 'multi-instance-loop-cardinality', 'loopCardinality');
+  return getInputField(container, 'multiInstance-loopCardinality', 'loopCardinality');
 }
 
 function getCollectionInput(container) {
-  return getInputField(container, 'multi-instance-collection', 'collection');
+  return getInputField(container, 'multiInstance-collection', 'collection');
 }
 
 function getElementVariableInput(container) {
-  return getInputField(container, 'multi-instance-element-variable', 'elementVariable');
+  return getInputField(container, 'multiInstance-elementVariable', 'elementVariable');
 }
 
 function getCompletionConditionInput(container) {
-  return getInputField(container, 'multi-instance-completion-condition', 'completionCondition');
+  return getInputField(container, 'multiInstance-completionCondition', 'completionCondition');
 }
 
 function getErrorMessageEntry(container) {
-  return getEntry(container, 'multi-instance-error-message');
+  return getEntry(container, 'multiInstance-errorMessage');
 }
 
 function getAsyncBefore(container) {
-  return getInputField(container, 'multi-instance-async-before', 'asyncBefore');
+  return getInputField(container, 'multiInstance-asyncBefore', 'asyncBefore');
 }
 
 function getAsyncAfter(container) {
-  return getInputField(container, 'multi-instance-async-after', 'asyncAfter');
+  return getInputField(container, 'multiInstance-asyncAfter', 'asyncAfter');
 }
 
 function getExclusive(container) {
-  return getInputField(container, 'multi-instance-exclusive', 'exclusive');
+  return getInputField(container, 'multiInstance-exclusive', 'exclusive');
 }
 
 function getCycle(container) {
-  return getInputField(container, 'multi-instance-retry-time-cycle', 'cycle');
+  return getInputField(container, 'multiInstance-retryTimeCycle', 'cycle');
 }
 
 
-describe('multi-instance-loop-properties', function() {
+describe('multiInstance-loop-properties', function() {
 
   var diagramXML = require('./MultiInstanceLoop.bpmn');
 

--- a/test/spec/provider/camunda/PropertiesSpec.js
+++ b/test/spec/provider/camunda/PropertiesSpec.js
@@ -20,12 +20,12 @@ var camundaModdlePackage = require('camunda-bpmn-moddle/resources/camunda');
 var domQuery = require('min-dom/lib/query');
 
 function getExtensionsTab(container) {
-  return domQuery('div[data-tab="extension-elements"]', container);
+  return domQuery('div[data-tab="extensionElements"]', container);
 }
 
 function getPropertiesGroup(container) {
   var extensions = getExtensionsTab(container);
-  return domQuery('div[data-group="extension-elements-properties"]', extensions);
+  return domQuery('div[data-group="extensionElements-properties"]', extensions);
 }
 
 function getPropertiesEntry(container) {
@@ -52,7 +52,7 @@ var getPropertyValues = function(element) {
   }
 };
 
-describe('extension-elements-properties', function() {
+describe('extensionElements-properties', function() {
 
   var diagramXML = require('./Properties.bpmn');
 
@@ -633,14 +633,14 @@ describe('extension-elements-properties', function() {
 
     it('should retain other extension elements when removing last property value',
       inject(function(elementRegistry, selection, propertiesPanel) {
-      
+
       // given
       var shape = elementRegistry.get('WITH_LISTENER_AND_PROP');
       selection.select(shape);
       var bo = getBusinessObject(shape);
 
       var propertiesTable = getPropertiesTable(propertiesPanel._container);
-      var removeButton = domQuery('[data-index="0"] [data-action="deleteElement"]', propertiesTable);     
+      var removeButton = domQuery('[data-index="0"] [data-action="deleteElement"]', propertiesTable);
 
       // when
       TestHelper.triggerEvent(removeButton, 'click');
@@ -656,7 +656,7 @@ describe('extension-elements-properties', function() {
 
     it('should retain other extension elements when adding property value',
       inject(function(elementRegistry, selection, propertiesPanel) {
-      
+
       // given
       var shape = elementRegistry.get('WITH_LISTENER');
       selection.select(shape);

--- a/test/spec/provider/camunda/ResultVariableSpec.js
+++ b/test/spec/provider/camunda/ResultVariableSpec.js
@@ -15,7 +15,7 @@ var propertiesPanelModule = require('../../../../lib'),
   camundaModdlePackage = require('camunda-bpmn-moddle/resources/camunda'),
   getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
 
-describe('result-variable', function() {
+describe('resultVariable', function() {
 
   var diagramXML = require('./ResultVariable.bpmn');
 
@@ -177,7 +177,7 @@ describe('result-variable', function() {
 
     var implType = domQuery('select[name=implType]', propertiesPanel._container),
         resultVariable = domQuery('input[name=resultVariable]', propertiesPanel._container),
-        clearButton = domQuery('[data-entry=result-variable] button[data-action=clear]', propertiesPanel._container),
+        clearButton = domQuery('[data-entry=resultVariable] button[data-action=clear]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     // given

--- a/test/spec/provider/camunda/RetryTimeCycleSpec.js
+++ b/test/spec/provider/camunda/RetryTimeCycleSpec.js
@@ -20,7 +20,7 @@ var propertiesPanelModule = require('../../../../lib'),
 var asyncCapableHelper = require('../../../../lib/helper/AsyncCapableHelper');
 var extensionElementsHelper = require('../../../../lib/helper/ExtensionElementsHelper');
 
-describe('retry-time-cycle', function() {
+describe('retryTimeCycle', function() {
 
   var diagramXML = require('./RetryTimeCycle.bpmn');
 
@@ -61,7 +61,7 @@ describe('retry-time-cycle', function() {
     inject(function(propertiesPanel, selection, elementRegistry) {
 
     var shape = elementRegistry.get('BoundaryEvent'),
-        inputEl = 'div[data-entry=retry-time-cycle] input[name=cycle]';
+        inputEl = 'div[data-entry=retryTimeCycle] input[name=cycle]';
 
     selection.select(shape);
 
@@ -79,7 +79,7 @@ describe('retry-time-cycle', function() {
     inject(function(propertiesPanel, selection, elementRegistry) {
 
     var shape = elementRegistry.get('ServiceTask'),
-        inputEl = 'div[data-entry=retry-time-cycle] input[name=cycle]';
+        inputEl = 'div[data-entry=retryTimeCycle] input[name=cycle]';
     var bo = getBusinessObject(shape);
 
     selection.select(shape);
@@ -109,7 +109,7 @@ describe('retry-time-cycle', function() {
     inject(function(propertiesPanel, selection, elementRegistry) {
 
     var shape = elementRegistry.get('BoundaryEvent'),
-        inputEl = 'div[data-entry=retry-time-cycle] input[name=cycle]';
+        inputEl = 'div[data-entry=retryTimeCycle] input[name=cycle]';
 
     selection.select(shape);
 
@@ -144,7 +144,7 @@ describe('retry-time-cycle', function() {
 
       bo = getBusinessObject(shape);
 
-      input = domQuery('div[data-entry=retry-time-cycle] input[name=cycle]', container);
+      input = domQuery('div[data-entry=retryTimeCycle] input[name=cycle]', container);
 
       // when
       TestHelper.triggerValue(input, 'foo', 'change');
@@ -271,7 +271,7 @@ describe('retry-time-cycle', function() {
 
       bo = getBusinessObject(shape);
 
-      input = domQuery('div[data-entry=retry-time-cycle] input[name=cycle]', container);
+      input = domQuery('div[data-entry=retryTimeCycle] input[name=cycle]', container);
 
       // when
       TestHelper.triggerValue(input, 'bar', 'change');
@@ -400,7 +400,7 @@ describe('retry-time-cycle', function() {
 
       bo = getBusinessObject(shape);
 
-      input = domQuery('div[data-entry=retry-time-cycle] input[name=cycle]', container);
+      input = domQuery('div[data-entry=retryTimeCycle] input[name=cycle]', container);
 
       // when
       TestHelper.triggerValue(input, '', 'change');

--- a/test/spec/provider/camunda/ScriptPropertiesSpec.js
+++ b/test/spec/provider/camunda/ScriptPropertiesSpec.js
@@ -412,11 +412,11 @@ describe('script-properties', function() {
     var shape = elementRegistry.get('StartEvent_1');
     selection.select(shape);
 
-    var eventType = domQuery('div[data-entry="execution-listeners"] select[name=eventType]', propertiesPanel._container),
-        listenerType = domQuery('div[data-entry="execution-listeners"] select[name=listenerType]', propertiesPanel._container),
-        scriptFormat = domQuery('div[data-entry="execution-listeners"] input[name=scriptFormat]', propertiesPanel._container),
-        scriptType = domQuery('div[data-entry="execution-listeners"] select[name="scriptType"]', propertiesPanel._container),
-        scriptValue = domQuery('div[data-entry="execution-listeners"] textarea[name="scriptValue"]', propertiesPanel._container),
+    var eventType = domQuery('div[data-entry="executionListeners"] select[name=eventType]', propertiesPanel._container),
+        listenerType = domQuery('div[data-entry="executionListeners"] select[name=listenerType]', propertiesPanel._container),
+        scriptFormat = domQuery('div[data-entry="executionListeners"] input[name=scriptFormat]', propertiesPanel._container),
+        scriptType = domQuery('div[data-entry="executionListeners"] select[name="scriptType"]', propertiesPanel._container),
+        scriptValue = domQuery('div[data-entry="executionListeners"] textarea[name="scriptValue"]', propertiesPanel._container),
         businessObject = getBusinessObject(shape).extensionElements.values;
 
     expect(eventType.value).to.equal('start');
@@ -439,7 +439,7 @@ describe('script-properties', function() {
     var shape = elementRegistry.get('ServiceTask_1');
     selection.select(shape);
 
-    var addListenerButton = domQuery('[data-entry=execution-listeners] > div > button[data-action=addListener]', propertiesPanel._container),
+    var addListenerButton = domQuery('[data-entry=executionListeners] > div > button[data-action=addListener]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     // given
@@ -448,11 +448,11 @@ describe('script-properties', function() {
     // when
     TestHelper.triggerEvent(addListenerButton, 'click');
 
-    var eventType = domQuery('div[data-entry="execution-listeners"] select[name=eventType]', propertiesPanel._container),
-        listenerType = domQuery('div[data-entry="execution-listeners"] select[name=listenerType]', propertiesPanel._container),
-        scriptFormat = domQuery('div[data-entry="execution-listeners"] input[name=scriptFormat]', propertiesPanel._container),
-        scriptType = domQuery('div[data-entry="execution-listeners"] select[name="scriptType"]', propertiesPanel._container),
-        scriptValue = domQuery('div[data-entry="execution-listeners"] textarea[name="scriptValue"]', propertiesPanel._container);
+    var eventType = domQuery('div[data-entry="executionListeners"] select[name=eventType]', propertiesPanel._container),
+        listenerType = domQuery('div[data-entry="executionListeners"] select[name=listenerType]', propertiesPanel._container),
+        scriptFormat = domQuery('div[data-entry="executionListeners"] input[name=scriptFormat]', propertiesPanel._container),
+        scriptType = domQuery('div[data-entry="executionListeners"] select[name="scriptType"]', propertiesPanel._container),
+        scriptValue = domQuery('div[data-entry="executionListeners"] textarea[name="scriptValue"]', propertiesPanel._container);
 
     // select 'script'
     listenerType.options[3].selected = "selected";
@@ -484,12 +484,12 @@ describe('script-properties', function() {
     var shape = elementRegistry.get('StartEvent_1');
     selection.select(shape);
 
-    var listenerType = domQuery('div[data-entry="execution-listeners"] select[name=listenerType]', propertiesPanel._container),
-        eventType = domQuery('div[data-entry="execution-listeners"] select[name=eventType]', propertiesPanel._container),
-        scriptFormat = domQuery('div[data-entry="execution-listeners"] input[name=scriptFormat]', propertiesPanel._container),
-        scriptType = domQuery('div[data-entry="execution-listeners"] select[name="scriptType"]', propertiesPanel._container),
-        scriptResourceValue = domQuery('div[data-entry="execution-listeners"] input[name="scriptResourceValue"]', propertiesPanel._container),
-        scriptValue = domQuery('div[data-entry="execution-listeners"] textarea[name="scriptValue"]', propertiesPanel._container),
+    var listenerType = domQuery('div[data-entry="executionListeners"] select[name=listenerType]', propertiesPanel._container),
+        eventType = domQuery('div[data-entry="executionListeners"] select[name=eventType]', propertiesPanel._container),
+        scriptFormat = domQuery('div[data-entry="executionListeners"] input[name=scriptFormat]', propertiesPanel._container),
+        scriptType = domQuery('div[data-entry="executionListeners"] select[name="scriptType"]', propertiesPanel._container),
+        scriptResourceValue = domQuery('div[data-entry="executionListeners"] input[name="scriptResourceValue"]', propertiesPanel._container),
+        scriptValue = domQuery('div[data-entry="executionListeners"] textarea[name="scriptValue"]', propertiesPanel._container),
         businessObject = getBusinessObject(shape).extensionElements.values;
 
     // given

--- a/test/spec/provider/camunda/TaskListenerPropertiesSpec.js
+++ b/test/spec/provider/camunda/TaskListenerPropertiesSpec.js
@@ -107,7 +107,7 @@ describe('task-listener-properties', function() {
     selection.select(taskShape);
 
     var bo = getBusinessObject(taskShape),
-        taskListenersEntry = domQuery.all('[data-entry=task-listeners]', propertiesPanel._container);
+        taskListenersEntry = domQuery.all('[data-entry=taskListeners]', propertiesPanel._container);
 
     expect(bo.extensionElements.values).to.have.length.of(1);
     expect(taskListenersEntry).to.have.length(0);
@@ -126,9 +126,9 @@ describe('task-listener-properties', function() {
 
     var bo = getBusinessObject(taskShape),
         taskListeners = getTaskListener(bo.extensionElements),
-        eventTypes = domQuery.all('[data-entry=task-listeners] select[name=eventType]', propertiesPanel._container),
-        listenerTypes = domQuery.all('[data-entry=task-listeners] select[name=listenerType]', propertiesPanel._container),
-        listenerValues = domQuery.all('[data-entry=task-listeners] input[name=listenerValue]', propertiesPanel._container);
+        eventTypes = domQuery.all('[data-entry=taskListeners] select[name=eventType]', propertiesPanel._container),
+        listenerTypes = domQuery.all('[data-entry=taskListeners] select[name=listenerType]', propertiesPanel._container),
+        listenerValues = domQuery.all('[data-entry=taskListeners] input[name=listenerValue]', propertiesPanel._container);
 
     // given
     expect(bo.extensionElements.values).to.have.length.of(2);
@@ -171,7 +171,7 @@ describe('task-listener-properties', function() {
 
     var bo = getBusinessObject(taskShape),
         taskListeners = getTaskListener(bo.extensionElements),
-        addListenerButton = domQuery('[data-entry=task-listeners] > div > button[data-action=addListener]', propertiesPanel._container);
+        addListenerButton = domQuery('[data-entry=taskListeners] > div > button[data-action=addListener]', propertiesPanel._container);
 
     // given
     expect(bo.extensionElements.values).to.have.length.of(2);
@@ -180,9 +180,9 @@ describe('task-listener-properties', function() {
     // when
     TestHelper.triggerEvent(addListenerButton, 'click');
 
-    var eventTypes = domQuery.all('[data-entry=task-listeners] select[name=eventType]', propertiesPanel._container),
-        listenerTypes = domQuery.all('[data-entry=task-listeners] select[name=listenerType]', propertiesPanel._container),
-        listenerValues = domQuery.all('[data-entry=task-listeners] input[name=listenerValue]', propertiesPanel._container);
+    var eventTypes = domQuery.all('[data-entry=taskListeners] select[name=eventType]', propertiesPanel._container),
+        listenerTypes = domQuery.all('[data-entry=taskListeners] select[name=listenerType]', propertiesPanel._container),
+        listenerValues = domQuery.all('[data-entry=taskListeners] input[name=listenerValue]', propertiesPanel._container);
 
     // set listener value to have a successfully validation
     TestHelper.triggerValue(listenerValues[1], 'newTaskListenerVal');
@@ -211,7 +211,7 @@ describe('task-listener-properties', function() {
 
     var bo = getBusinessObject(taskShape),
         taskListeners = getTaskListener(bo.extensionElements),
-        removeListenerButtons = domQuery.all('[data-entry=task-listeners] button[data-action=removeListener]', propertiesPanel._container);
+        removeListenerButtons = domQuery.all('[data-entry=taskListeners] button[data-action=removeListener]', propertiesPanel._container);
 
     // given
     expect(bo.extensionElements.values).to.have.length.of(2);
@@ -223,9 +223,9 @@ describe('task-listener-properties', function() {
     TestHelper.triggerEvent(removeListenerButtons[0], 'click');
 
     // then
-    var eventTypes = domQuery.all('[data-entry=task-listeners] select[name=eventType]', propertiesPanel._container),
-        listenerTypes = domQuery.all('[data-entry=task-listeners] select[name=listenerType]', propertiesPanel._container),
-        listenerValues = domQuery.all('[data-entry=task-listeners] input[name=listenerValue]', propertiesPanel._container);
+    var eventTypes = domQuery.all('[data-entry=taskListeners] select[name=eventType]', propertiesPanel._container),
+        listenerTypes = domQuery.all('[data-entry=taskListeners] select[name=listenerType]', propertiesPanel._container),
+        listenerValues = domQuery.all('[data-entry=taskListeners] input[name=listenerValue]', propertiesPanel._container);
 
     // check html
     expect(eventTypes[0]).to.be.undefined;
@@ -248,7 +248,7 @@ describe('task-listener-properties', function() {
 
     var bo = getBusinessObject(taskShape),
         taskListeners = getTaskListener(bo.extensionElements),
-        addListenerButton = domQuery('[data-entry=task-listeners] > div > button[data-action=addListener]', propertiesPanel._container);
+        addListenerButton = domQuery('[data-entry=taskListeners] > div > button[data-action=addListener]', propertiesPanel._container);
 
     // given
     expect(bo.extensionElements).to.be.empty;
@@ -257,9 +257,9 @@ describe('task-listener-properties', function() {
     // when
     TestHelper.triggerEvent(addListenerButton, 'click');
 
-    var eventTypes = domQuery.all('[data-entry=task-listeners] select[name=eventType]', propertiesPanel._container),
-        listenerTypes = domQuery.all('[data-entry=task-listeners] select[name=listenerType]', propertiesPanel._container),
-        listenerValues = domQuery.all('[data-entry=task-listeners] input[name=listenerValue]', propertiesPanel._container);
+    var eventTypes = domQuery.all('[data-entry=taskListeners] select[name=eventType]', propertiesPanel._container),
+        listenerTypes = domQuery.all('[data-entry=taskListeners] select[name=listenerType]', propertiesPanel._container),
+        listenerValues = domQuery.all('[data-entry=taskListeners] input[name=listenerValue]', propertiesPanel._container);
 
     // set listener value to have a successfully validation
     TestHelper.triggerValue(listenerValues[0], 'newTaskListenerVal');
@@ -288,10 +288,10 @@ describe('task-listener-properties', function() {
 
     var bo = getBusinessObject(taskShape),
         taskListeners = getTaskListener(bo.extensionElements),
-        eventTypes = domQuery.all('[data-entry=task-listeners] select[name=eventType]', propertiesPanel._container),
-        listenerTypes = domQuery.all('[data-entry=task-listeners] select[name=listenerType]', propertiesPanel._container),
-        listenerValues = domQuery.all('[data-entry=task-listeners] input[name=listenerValue]', propertiesPanel._container),
-        clearButtons = domQuery.all('[data-entry=task-listeners] button[data-action=clearListenerValue]', propertiesPanel._container);
+        eventTypes = domQuery.all('[data-entry=taskListeners] select[name=eventType]', propertiesPanel._container),
+        listenerTypes = domQuery.all('[data-entry=taskListeners] select[name=listenerType]', propertiesPanel._container),
+        listenerValues = domQuery.all('[data-entry=taskListeners] input[name=listenerValue]', propertiesPanel._container),
+        clearButtons = domQuery.all('[data-entry=taskListeners] button[data-action=clearListenerValue]', propertiesPanel._container);
 
     // given
     expect(clearButtons).to.have.length.of(1);
@@ -328,7 +328,7 @@ describe('task-listener-properties', function() {
 
     var bo = getBusinessObject(taskShape),
         taskListeners = getTaskListener(bo.extensionElements),
-        addListenerButton = domQuery('[data-entry=task-listeners] > div > button[data-action=addListener]', propertiesPanel._container);
+        addListenerButton = domQuery('[data-entry=taskListeners] > div > button[data-action=addListener]', propertiesPanel._container);
 
     // given
     expect(bo.extensionElements).to.be.empty;
@@ -339,9 +339,9 @@ describe('task-listener-properties', function() {
     TestHelper.triggerEvent(addListenerButton, 'click');
     TestHelper.triggerEvent(addListenerButton, 'click');
 
-    var eventTypes = domQuery.all('[data-entry=task-listeners] select[name=eventType]', propertiesPanel._container),
-        listenerTypes = domQuery.all('[data-entry=task-listeners] select[name=listenerType]', propertiesPanel._container),
-        listenerValues = domQuery.all('[data-entry=task-listeners] input[name=listenerValue]', propertiesPanel._container),
+    var eventTypes = domQuery.all('[data-entry=taskListeners] select[name=eventType]', propertiesPanel._container),
+        listenerTypes = domQuery.all('[data-entry=taskListeners] select[name=listenerType]', propertiesPanel._container),
+        listenerValues = domQuery.all('[data-entry=taskListeners] input[name=listenerValue]', propertiesPanel._container),
         errorMessages = domQuery.all('.pp-error-message', propertiesPanel._container);
 
     expect(listenerValues[0].className).to.equal('invalid');
@@ -388,12 +388,12 @@ describe('task-listener-properties', function() {
 
     selection.select(taskShape);
 
-    var query = '[data-entry=task-listeners] > div > button[data-action=addListener]',
+    var query = '[data-entry=taskListeners] > div > button[data-action=addListener]',
         addListenerButton = domQuery(query, propertiesPanel._container);
 
     TestHelper.triggerEvent(addListenerButton, 'click');
 
-    var listenerValues = domQuery.all('[data-entry=task-listeners] input[name=listenerValue]', propertiesPanel._container);
+    var listenerValues = domQuery.all('[data-entry=taskListeners] input[name=listenerValue]', propertiesPanel._container);
 
     // add task listener value to the task listener
     TestHelper.triggerValue(listenerValues[0], 'taskListenerValOne');
@@ -422,12 +422,12 @@ describe('task-listener-properties', function() {
 
     selection.select(taskShape);
 
-    var query = '[data-entry=task-listeners] > div > button[data-action=addListener]',
+    var query = '[data-entry=taskListeners] > div > button[data-action=addListener]',
         addListenerButton = domQuery(query, propertiesPanel._container);
 
     TestHelper.triggerEvent(addListenerButton, 'click');
 
-    var listenerValues = domQuery.all('[data-entry=task-listeners] input[name=listenerValue]', propertiesPanel._container);
+    var listenerValues = domQuery.all('[data-entry=taskListeners] input[name=listenerValue]', propertiesPanel._container);
 
     TestHelper.triggerValue(listenerValues[0], 'taskListenerValOne');
 
@@ -452,13 +452,13 @@ describe('task-listener-properties', function() {
 
     selection.select(taskShape);
 
-    var query = '[data-entry=task-listeners] > div > button[data-action=addListener]',
+    var query = '[data-entry=taskListeners] > div > button[data-action=addListener]',
         addListenerButton = domQuery(query, propertiesPanel._container);
 
     TestHelper.triggerEvent(addListenerButton, 'click');
     TestHelper.triggerEvent(addListenerButton, 'click');
 
-    var listenerValues = domQuery.all('[data-entry=task-listeners] input[name=listenerValue]', propertiesPanel._container);
+    var listenerValues = domQuery.all('[data-entry=taskListeners] input[name=listenerValue]', propertiesPanel._container);
 
     // add task listener value to both the task listeners
     TestHelper.triggerValue(listenerValues[0], 'taskListenerValOne');
@@ -490,13 +490,13 @@ describe('task-listener-properties', function() {
 
     selection.select(taskShape);
 
-    var query = '[data-entry=task-listeners] > div > button[data-action=addListener]',
+    var query = '[data-entry=taskListeners] > div > button[data-action=addListener]',
         addListenerButton = domQuery(query, propertiesPanel._container);
 
     TestHelper.triggerEvent(addListenerButton, 'click');
     TestHelper.triggerEvent(addListenerButton, 'click');
 
-    var listenerValues = domQuery.all('[data-entry=task-listeners] input[name=listenerValue]', propertiesPanel._container);
+    var listenerValues = domQuery.all('[data-entry=taskListeners] input[name=listenerValue]', propertiesPanel._container);
 
     TestHelper.triggerValue(listenerValues[0], 'taskListenerValOne');
     TestHelper.triggerValue(listenerValues[1], 'taskListenerValTwo');
@@ -521,8 +521,8 @@ describe('task-listener-properties', function() {
 
     var bo = getBusinessObject(taskShape),
         taskListeners = getTaskListener(bo.extensionElements),
-        addExecutionListenerButton = domQuery('[data-entry=execution-listeners] > div > button[data-action=addListener]', propertiesPanel._container),
-        addTaskListenerButton = domQuery('[data-entry=task-listeners] > div > button[data-action=addListener]', propertiesPanel._container);
+        addExecutionListenerButton = domQuery('[data-entry=executionListeners] > div > button[data-action=addListener]', propertiesPanel._container),
+        addTaskListenerButton = domQuery('[data-entry=taskListeners] > div > button[data-action=addListener]', propertiesPanel._container);
 
     // given
     expect(bo.extensionElements).to.be.empty;
@@ -533,13 +533,13 @@ describe('task-listener-properties', function() {
     TestHelper.triggerEvent(addExecutionListenerButton, 'click');
     TestHelper.triggerEvent(addTaskListenerButton, 'click');
 
-    var taskEventTypes = domQuery.all('[data-entry=task-listeners] select[name=eventType]', propertiesPanel._container),
-        taskListenerTypes = domQuery.all('[data-entry=task-listeners] select[name=listenerType]', propertiesPanel._container),
-        taskListenerValues = domQuery.all('[data-entry=task-listeners] input[name=listenerValue]', propertiesPanel._container);
+    var taskEventTypes = domQuery.all('[data-entry=taskListeners] select[name=eventType]', propertiesPanel._container),
+        taskListenerTypes = domQuery.all('[data-entry=taskListeners] select[name=listenerType]', propertiesPanel._container),
+        taskListenerValues = domQuery.all('[data-entry=taskListeners] input[name=listenerValue]', propertiesPanel._container);
 
-    var eventTypes = domQuery.all('[data-entry=execution-listeners] select[name=eventType]', propertiesPanel._container),
-        listenerTypes = domQuery.all('[data-entry=execution-listeners] select[name=listenerType]', propertiesPanel._container),
-        listenerValues = domQuery.all('[data-entry=execution-listeners] input[name=listenerValue]', propertiesPanel._container);
+    var eventTypes = domQuery.all('[data-entry=executionListeners] select[name=eventType]', propertiesPanel._container),
+        listenerTypes = domQuery.all('[data-entry=executionListeners] select[name=listenerType]', propertiesPanel._container),
+        listenerValues = domQuery.all('[data-entry=executionListeners] input[name=listenerValue]', propertiesPanel._container);
 
     // set listener value to have a successfully validation
     TestHelper.triggerValue(taskListenerValues[0], 'taskListenerVal');

--- a/test/spec/provider/camunda/element-templates/parts/ChooserPropsSpec.js
+++ b/test/spec/provider/camunda/element-templates/parts/ChooserPropsSpec.js
@@ -35,7 +35,7 @@ describe('element-templates/parts - Chooser', function() {
       selectAndGet('Gateway');
 
       // when
-      var chooser = entrySelect('element-template-chooser');
+      var chooser = entrySelect('elementTemplate-chooser');
 
       // then
       expect(chooser).not.to.exist;
@@ -166,7 +166,7 @@ describe('element-templates/parts - Chooser', function() {
 
 
 function getElementTemplates() {
-  var options = entrySelect.all('element-template-chooser', 'select option');
+  var options = entrySelect.all('elementTemplate-chooser', 'select option');
 
   return options.map(function(o) {
     return {
@@ -179,8 +179,8 @@ function getElementTemplates() {
 
 function switchTemplate(templateId) {
 
-  var templateSelect = entrySelect('element-template-chooser', 'select'),
-      option = entrySelect('element-template-chooser', 'option[value="' + templateId + '"]');
+  var templateSelect = entrySelect('elementTemplate-chooser', 'select'),
+      option = entrySelect('elementTemplate-chooser', 'option[value="' + templateId + '"]');
 
   option.selected = 'selected';
 

--- a/test/spec/provider/camunda/element-templates/parts/CustomProps.json
+++ b/test/spec/provider/camunda/element-templates/parts/CustomProps.json
@@ -59,9 +59,9 @@
       "_all": false,
       "id": true,
       "name": true,
-      "async-before": true,
-      "async-after": true,
-      "execution-listeners": true,
+      "asyncBefore": true,
+      "asyncAfter": true,
+      "executionListeners": true,
       "documentation": true
     }
   },

--- a/test/spec/provider/camunda/element-templates/parts/Visibility.json
+++ b/test/spec/provider/camunda/element-templates/parts/Visibility.json
@@ -28,9 +28,9 @@
     "entriesVisible": {
       "_all": true,
       "name": false,
-      "async-before": false,
-      "async-after": false,
-      "execution-listeners": false,
+      "asyncBefore": false,
+      "asyncAfter": false,
+      "executionListeners": false,
       "documentation": false
     }
   },
@@ -42,9 +42,9 @@
     ],
     "properties": [],
     "entriesVisible": {
-      "async-before": true,
-      "async-after": true,
-      "execution-listeners": true,
+      "asyncBefore": true,
+      "asyncAfter": true,
+      "executionListeners": true,
       "documentation": true
     }
   }

--- a/test/spec/provider/camunda/element-templates/parts/VisibilitySpec.js
+++ b/test/spec/provider/camunda/element-templates/parts/VisibilitySpec.js
@@ -28,12 +28,12 @@ describe('element-templates/parts - Visibility', function() {
     expectShown([
       'id',
       'name',
-      'element-template-chooser'
+      'elementTemplate-chooser'
     ]);
 
     expectHidden([
-      'async-before',
-      'execution-listeners'
+      'asyncBefore',
+      'executionListeners'
     ]);
   }));
 
@@ -49,10 +49,10 @@ describe('element-templates/parts - Visibility', function() {
       expectShown([
         'id',
         'name',
-        'element-template-chooser',
+        'elementTemplate-chooser',
         'documentation',
-        'async-before',
-        'execution-listeners',
+        'asyncBefore',
+        'executionListeners',
         'properties'
       ]);
     }));
@@ -67,16 +67,16 @@ describe('element-templates/parts - Visibility', function() {
       expectShown([
         'id',
         'properties',
-        'parameter-name',
-        'element-template-chooser'
+        'parameterName',
+        'elementTemplate-chooser'
       ]);
 
       expectHidden([
         'name',
-        'async-before',
-        'async-after',
+        'asyncBefore',
+        'asyncAfter',
         'documentation',
-        'execution-listeners'
+        'executionListeners'
       ]);
     }));
 
@@ -88,10 +88,10 @@ describe('element-templates/parts - Visibility', function() {
 
       // then
       expectShown([
-        'element-template-chooser',
-        'async-before',
-        'async-after',
-        'execution-listeners',
+        'elementTemplate-chooser',
+        'asyncBefore',
+        'asyncAfter',
+        'executionListeners',
         'documentation'
       ]);
 
@@ -99,7 +99,7 @@ describe('element-templates/parts - Visibility', function() {
         'id',
         'name',
         'properties',
-        'parameter-name',
+        'parameterName',
       ]);
     }));
 


### PR DESCRIPTION
This is a really nice to have clean up for the properties panel. It basically makes sure entries are in camelCased form:

* `propertyName` such as `asyncBefore`
* `domain-propertyName` for complex properties such as `elementTemplate-chooser` or `multiInstance-asyncBefore`

This gets important as users may start to reference properties panel parts when defining element visibility (via element templates).