### PR TITLE
fix(change): Stronger check for jQuery before unwraping.

### DIFF
--- a/lib/PropertiesPanel.js
+++ b/lib/PropertiesPanel.js
@@ -351,7 +351,7 @@ PropertiesPanel.prototype.attachTo = function(parentNode) {
   this.detach();
 
   // unwrap jQuery if provided
-  if (parentNode.get) {
+  if (parentNode.get && parentNode.constructor.prototype.jquery) {
     parentNode = parentNode.get(0);
   }
 
@@ -1098,7 +1098,7 @@ PropertiesPanel.prototype._createPanel = function(element, tabs) {
         }
 
         // unwrap jquery
-        if (html.get) {
+        if (html.get && window.jQuery) {
           html = html.get(0);
         }
 

--- a/lib/PropertiesPanel.js
+++ b/lib/PropertiesPanel.js
@@ -1098,7 +1098,7 @@ PropertiesPanel.prototype._createPanel = function(element, tabs) {
         }
 
         // unwrap jquery
-        if (html.get && window.jQuery) {
+        if (html.get && html.constructor.prototype.jquery) {
           html = html.get(0);
         }
 


### PR DESCRIPTION
Other libraries exits that adds the `.get()` functionality to element nodes, in my case Mootools which behaves in a different fashion resulting in multiple errors.
 
Since the comment indicates that the condition is only for JQuery users, it should only fire if the lib is present. 