### PR TITLE
add i18n support according to #207 mentioned

### DIFF
--- a/lib/i18n/I18N.js
+++ b/lib/i18n/I18N.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * A component that handles language switching in a unified way.
+ *
+ * @param {EventBus} eventBus
+ */
+function I18N(eventBus) {
+
+  /**
+   * Inform components that the language changed.
+   *
+   * Emit a `i18n.changed` event for others to hook into, too.
+   */
+  this.changed = function changed() {
+    eventBus.fire('i18n.changed');
+  };
+}
+
+I18N.$inject = [ 'eventBus' ];
+
+module.exports = I18N;

--- a/lib/i18n/index.js
+++ b/lib/i18n/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  i18n: [ 'type', require('./I18N') ]
+};

--- a/lib/i18n/translate/index.js
+++ b/lib/i18n/translate/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  translate: [ 'value', require('./translate') ]
+};

--- a/lib/i18n/translate/translate.js
+++ b/lib/i18n/translate/translate.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * A simple translation stub to be used for multi-language support
+ * in diagrams. Can be easily replaced with a more sophisticated
+ * solution.
+ *
+ * @example
+ *
+ * // use it inside any diagram component by injecting `translate`.
+ *
+ * function MyService(translate) {
+ *   alert(translate('HELLO {you}', { you: 'You!' }));
+ * }
+ *
+ * @param {String} template to interpolate
+ * @param {Object} [replacements] a map with substitutes
+ *
+ * @return {String} the translated string
+ */
+module.exports = function translate(template, replacements) {
+
+  replacements = replacements || {};
+
+  return template.replace(/{([^}]+)}/g, function(_, key) {
+    return replacements[key] || '{' + key + '}';
+  });
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   __depends__: [
-    require('./cmd')
+    require('./cmd'),
+    require('./i18n/translate')
   ],
   __init__: [ 'propertiesPanel' ],
   propertiesPanel: [ 'type', require('./PropertiesPanel') ]

--- a/lib/provider/bpmn/BpmnPropertiesProvider.js
+++ b/lib/provider/bpmn/BpmnPropertiesProvider.js
@@ -30,8 +30,8 @@ function createGeneralTabGroups(element, bpmnFactory, elementRegistry, translate
     label: translate('Details'),
     entries: []
   };
-  linkProps(detailsGroup, element);
-  eventProps(detailsGroup, element, bpmnFactory, elementRegistry);
+  linkProps(detailsGroup, element, translate);
+  eventProps(detailsGroup, element, bpmnFactory, elementRegistry, translate);
 
   var documentationGroup = {
     id: 'documentation',
@@ -39,7 +39,7 @@ function createGeneralTabGroups(element, bpmnFactory, elementRegistry, translate
     entries: []
   };
 
-  documentationProps(documentationGroup, element, bpmnFactory);
+  documentationProps(documentationGroup, element, bpmnFactory, translate);
 
   return [
     generalGroup,

--- a/lib/provider/bpmn/BpmnPropertiesProvider.js
+++ b/lib/provider/bpmn/BpmnPropertiesProvider.js
@@ -13,21 +13,21 @@ var processProps = require('./parts/ProcessProps'),
     nameProps = require('./parts/NameProps'),
     executableProps = require('./parts/ExecutableProps');
 
-function createGeneralTabGroups(element, bpmnFactory, elementRegistry) {
+function createGeneralTabGroups(element, bpmnFactory, elementRegistry, translate) {
 
   var generalGroup = {
     id: 'general',
-    label: 'General',
+    label: translate('General'),
     entries: []
   };
-  idProps(generalGroup, element, elementRegistry);
-  nameProps(generalGroup, element);
-  processProps(generalGroup, element);
-  executableProps(generalGroup, element);
+  idProps(generalGroup, element, elementRegistry, translate);
+  nameProps(generalGroup, element, translate);
+  processProps(generalGroup, element, translate);
+  executableProps(generalGroup, element, translate);
 
   var detailsGroup = {
     id: 'details',
-    label: 'Details',
+    label: translate('Details'),
     entries: []
   };
   linkProps(detailsGroup, element);
@@ -35,7 +35,7 @@ function createGeneralTabGroups(element, bpmnFactory, elementRegistry) {
 
   var documentationGroup = {
     id: 'documentation',
-    label: 'Documentation',
+    label: translate('Documentation'),
     entries: []
   };
 
@@ -49,7 +49,7 @@ function createGeneralTabGroups(element, bpmnFactory, elementRegistry) {
 
 }
 
-function BpmnPropertiesProvider(eventBus, bpmnFactory, elementRegistry) {
+function BpmnPropertiesProvider(eventBus, bpmnFactory, elementRegistry, translate) {
 
   PropertiesActivator.call(this, eventBus);
 
@@ -57,8 +57,8 @@ function BpmnPropertiesProvider(eventBus, bpmnFactory, elementRegistry) {
 
     var generalTab = {
       id: 'general',
-      label: 'General',
-      groups: createGeneralTabGroups(element, bpmnFactory, elementRegistry)
+      label: translate('General'),
+      groups: createGeneralTabGroups(element, bpmnFactory, elementRegistry, translate)
     };
 
     return [
@@ -67,7 +67,7 @@ function BpmnPropertiesProvider(eventBus, bpmnFactory, elementRegistry) {
   };
 }
 
-BpmnPropertiesProvider.$inject = [ 'eventBus', 'bpmnFactory', 'elementRegistry' ];
+BpmnPropertiesProvider.$inject = [ 'eventBus', 'bpmnFactory', 'elementRegistry', 'translate' ];
 
 inherits(BpmnPropertiesProvider, PropertiesActivator);
 

--- a/lib/provider/bpmn/parts/DocumentationProps.js
+++ b/lib/provider/bpmn/parts/DocumentationProps.js
@@ -8,7 +8,7 @@ var ModelUtil = require('bpmn-js/lib/util/ModelUtil'),
     getBusinessObject = ModelUtil.getBusinessObject;
 
 
-module.exports = function(group, element, bpmnFactory) {
+module.exports = function(group, element, bpmnFactory, translate) {
 
   var getValue = function(businessObject) {
     return function(element) {
@@ -36,7 +36,7 @@ module.exports = function(group, element, bpmnFactory) {
   // Element Documentation
   var elementDocuEntry = entryFactory.textBox({
     id: 'documentation',
-    label: 'Element Documentation',
+    label: translate('Element Documentation'),
     modelProperty: 'documentation'
   });
 
@@ -58,7 +58,7 @@ module.exports = function(group, element, bpmnFactory) {
     if (processRef) {
       var processDocuEntry = entryFactory.textBox({
         id: 'process-documentation',
-        label: 'Process Documentation',
+        label: translate('Process Documentation'),
         modelProperty: 'documentation'
       });
 

--- a/lib/provider/bpmn/parts/EventProps.js
+++ b/lib/provider/bpmn/parts/EventProps.js
@@ -17,7 +17,7 @@ var message = require('./implementation/MessageEventDefinition'),
     condition = require('./implementation/ConditionalEventDefinition');
 
 
-module.exports = function(group, element, bpmnFactory, elementRegistry) {
+module.exports = function(group, element, bpmnFactory, elementRegistry, translate) {
   var events = [
     'bpmn:StartEvent',
     'bpmn:EndEvent',

--- a/lib/provider/bpmn/parts/ExecutableProps.js
+++ b/lib/provider/bpmn/parts/ExecutableProps.js
@@ -7,7 +7,7 @@ var entryFactory = require('../../../factory/EntryFactory');
 
 var participantHelper = require('../../../helper/ParticipantHelper');
 
-module.exports = function(group, element) {
+module.exports = function(group, element, translate) {
 
   var bo = getBusinessObject(element);
 
@@ -19,7 +19,7 @@ module.exports = function(group, element) {
 
     var executableEntry = entryFactory.checkbox({
       id: 'process-is-executable',
-      label: 'Executable',
+      label: translate('Executable'),
       modelProperty: 'isExecutable'
     });
 

--- a/lib/provider/bpmn/parts/IdProps.js
+++ b/lib/provider/bpmn/parts/IdProps.js
@@ -5,12 +5,12 @@ var entryFactory = require('../../../factory/EntryFactory'),
     utils = require('../../../Utils'),
     cmdHelper = require('../../../helper/CmdHelper');
 
-module.exports = function(group, element) {
+module.exports = function(group, element, _, translate) {
 
   // Id
   group.entries.push(entryFactory.validationAwareTextField({
     id: 'id',
-    label: 'Id',
+    label: translate('Id'),
     modelProperty: 'id',
     getProperty: function(element) {
       return getBusinessObject(element).id;

--- a/lib/provider/bpmn/parts/LinkProps.js
+++ b/lib/provider/bpmn/parts/LinkProps.js
@@ -23,7 +23,7 @@ function getLinkEventDefinition(element) {
   return linkEventDefinition;
 }
 
-module.exports = function(group, element) {
+module.exports = function(group, element, translate) {
   var linkEvents = [ 'bpmn:IntermediateThrowEvent', 'bpmn:IntermediateCatchEvent' ];
 
   forEach(linkEvents, function(event) {
@@ -34,7 +34,7 @@ module.exports = function(group, element) {
       if (linkEventDefinition) {
         var entry = entryFactory.textField({
           id: 'link-event',
-          label: 'Link Name',
+          label: translate('Link Name'),
           modelProperty: 'link-name'
         });
 

--- a/lib/provider/bpmn/parts/NameProps.js
+++ b/lib/provider/bpmn/parts/NameProps.js
@@ -3,7 +3,7 @@
 var nameEntryFactory = require('./implementation/Name'),
     is = require('bpmn-js/lib/util/ModelUtil').is;
 
-module.exports = function(group, element) {
+module.exports = function(group, element, translate) {
 
   if (!is(element, 'bpmn:Collaboration')) {
 
@@ -13,7 +13,7 @@ module.exports = function(group, element) {
     }
 
     // name
-    group.entries = group.entries.concat(nameEntryFactory(element, options));
+    group.entries = group.entries.concat(nameEntryFactory(element, options, translate));
 
   }
 

--- a/lib/provider/bpmn/parts/ProcessProps.js
+++ b/lib/provider/bpmn/parts/ProcessProps.js
@@ -7,7 +7,7 @@ var is = require('bpmn-js/lib/util/ModelUtil').is,
     nameEntryFactory = require('./implementation/Name'),
     utils = require('../../../Utils');
 
-module.exports = function(group, element) {
+module.exports = function(group, element, translate) {
   var businessObject = getBusinessObject(element);
 
   if (is(element, 'bpmn:Process') || (is(element, 'bpmn:Participant') && businessObject.get('processRef'))) {
@@ -18,7 +18,7 @@ module.exports = function(group, element) {
     if (is(element, 'bpmn:Participant')) {
       var idEntry = entryFactory.validationAwareTextField({
         id: 'process-id',
-        label: 'Process Id',
+        label: translate('Process Id'),
         modelProperty: 'processId'
       });
 
@@ -50,7 +50,7 @@ module.exports = function(group, element) {
        */
       var processNameEntry = nameEntryFactory(element, {
         id: 'process-name',
-        label: 'Process Name'
+        label: translate('Process Name')
       })[0];
 
       // in participants we have to change the default behavior of set and get

--- a/lib/provider/bpmn/parts/implementation/Name.js
+++ b/lib/provider/bpmn/parts/implementation/Name.js
@@ -13,11 +13,11 @@ var entryFactory = require('../../../../factory/EntryFactory');
  * @return {Array<Object>} return an array containing
  *                         the entry to modify the name
  */
-module.exports = function(element, options) {
+module.exports = function(element, options, translate) {
 
   options = options || {};
   var id = options.id || 'name',
-      label = options.label || 'Name',
+      label = options.label || translate('Name'),
       modelProperty = options.modelProperty || 'name';
 
   var nameEntry = entryFactory.textBox({

--- a/lib/provider/camunda/CamundaPropertiesProvider.js
+++ b/lib/provider/camunda/CamundaPropertiesProvider.js
@@ -335,7 +335,7 @@ function createConnectorTabGroups(element, bpmnFactory, elementRegistry, transla
     },
     label: function(element, node) {
       var param = options.getSelectedParameter(element, node);
-      return getInputOutputParameterLabel(param);
+      return getInputOutputParameterLabel(param, translate);
     }
   };
 

--- a/lib/provider/camunda/CamundaPropertiesProvider.js
+++ b/lib/provider/camunda/CamundaPropertiesProvider.js
@@ -101,103 +101,103 @@ var isJobConfigEnabled = function(element) {
   return false;
 };
 
-var getInputOutputParameterLabel = function(param) {
+var getInputOutputParameterLabel = function(param, translate) {
 
   if (is(param, 'camunda:InputParameter')) {
-    return 'Input Parameter';
+    return translate('Input Parameter');
   }
 
   if (is(param, 'camunda:OutputParameter')) {
-    return 'Output Parameter';
+    return translate('Output Parameter');
   }
 
   return '';
 };
 
-var getListenerLabel = function(param) {
+var getListenerLabel = function(param, translate) {
 
   if (is(param, 'camunda:ExecutionListener')) {
-    return 'Execution Listener';
+    return translate('Execution Listener');
   }
 
   if (is(param, 'camunda:TaskListener')) {
-    return 'Task Listener';
+    return translate('Task Listener');
   }
 
   return '';
 };
 
-function createGeneralTabGroups(element, bpmnFactory, elementRegistry, elementTemplates) {
+function createGeneralTabGroups(element, bpmnFactory, elementRegistry, elementTemplates, translate) {
 
   var generalGroup = {
     id: 'general',
-    label: 'General',
+    label: translate('General'),
     entries: []
   };
-  idProps(generalGroup, element, elementRegistry);
-  nameProps(generalGroup, element);
-  processProps(generalGroup, element);
-  versionTag(generalGroup, element);
-  executableProps(generalGroup, element);
-  elementTemplateChooserProps(generalGroup, element, elementTemplates);
+  idProps(generalGroup, element, elementRegistry, translate);
+  nameProps(generalGroup, element, translate);
+  processProps(generalGroup, element, translate);
+  versionTag(generalGroup, element, translate);
+  executableProps(generalGroup, element, translate);
+  elementTemplateChooserProps(generalGroup, element, elementTemplates, translate);
 
   var customFieldsGroup = {
     id: 'customField',
-    label: 'Custom Fields',
+    label: translate('Custom Fields'),
     entries: []
   };
-  elementTemplateCustomProps(customFieldsGroup, element, elementTemplates, bpmnFactory);
+  elementTemplateCustomProps(customFieldsGroup, element, elementTemplates, bpmnFactory, translate);
 
   var detailsGroup = {
     id: 'details',
-    label: 'Details',
+    label: translate('Details'),
     entries: []
   };
-  serviceTaskDelegateProps(detailsGroup, element, bpmnFactory);
-  userTaskProps(detailsGroup, element);
-  scriptProps(detailsGroup, element, bpmnFactory);
-  linkProps(detailsGroup, element);
-  callActivityProps(detailsGroup, element, bpmnFactory);
-  eventProps(detailsGroup, element, bpmnFactory, elementRegistry);
-  sequenceFlowProps(detailsGroup, element, bpmnFactory);
-  startEventInitiator(detailsGroup, element); // this must be the last element of the details group!
+  serviceTaskDelegateProps(detailsGroup, element, bpmnFactory, translate);
+  userTaskProps(detailsGroup, element, translate);
+  scriptProps(detailsGroup, element, bpmnFactory, translate);
+  linkProps(detailsGroup, element, translate);
+  callActivityProps(detailsGroup, element, bpmnFactory, translate);
+  eventProps(detailsGroup, element, bpmnFactory, elementRegistry, translate);
+  sequenceFlowProps(detailsGroup, element, bpmnFactory, translate);
+  startEventInitiator(detailsGroup, element, translate); // this must be the last element of the details group!
 
   var multiInstanceGroup = {
     id: 'multiInstance',
-    label: 'Multi Instance',
+    label: translate('Multi Instance'),
     entries: []
   };
-  multiInstanceProps(multiInstanceGroup, element, bpmnFactory);
+  multiInstanceProps(multiInstanceGroup, element, bpmnFactory, translate);
 
   var asyncGroup = {
     id : 'async',
-    label: 'Asynchronous Continuations',
+    label: translate('Asynchronous Continuations'),
     entries : []
   };
-  asynchronousContinuationProps(asyncGroup, element, bpmnFactory);
+  asynchronousContinuationProps(asyncGroup, element, bpmnFactory, translate);
 
   var jobConfigurationGroup = {
     id : 'jobConfiguration',
-    label : 'Job Configuration',
+    label : translate('Job Configuration'),
     entries : [],
     enabled: isJobConfigEnabled
   };
-  jobConfiguration(jobConfigurationGroup, element, bpmnFactory);
+  jobConfiguration(jobConfigurationGroup, element, bpmnFactory, translate);
 
   var externalTaskGroup = {
     id : 'externalTaskConfiguration',
-    label : 'External Task Configuration',
+    label : translate('External Task Configuration'),
     entries : [],
     enabled: isExternalTaskPriorityEnabled
   };
-  externalTaskConfiguration(externalTaskGroup, element, bpmnFactory);
+  externalTaskConfiguration(externalTaskGroup, element, bpmnFactory, translate);
 
   var documentationGroup = {
     id: 'documentation',
-    label: 'Documentation',
+    label: translate('Documentation'),
     entries: []
   };
-  documentationProps(documentationGroup, element, bpmnFactory);
+  documentationProps(documentationGroup, element, bpmnFactory, translate);
 
   return [
     generalGroup,
@@ -212,41 +212,41 @@ function createGeneralTabGroups(element, bpmnFactory, elementRegistry, elementTe
 
 }
 
-function createVariablesTabGroups(element, bpmnFactory, elementRegistry) {
+function createVariablesTabGroups(element, bpmnFactory, elementRegistry, translate) {
   var variablesGroup = {
     id : 'variables',
-    label : 'Variables',
+    label : translate('Variables'),
     entries: []
   };
-  variableMapping(variablesGroup, element, bpmnFactory);
+  variableMapping(variablesGroup, element, bpmnFactory, translate);
 
   return [
     variablesGroup
   ];
 }
 
-function createFormsTabGroups(element, bpmnFactory, elementRegistry) {
+function createFormsTabGroups(element, bpmnFactory, elementRegistry, translate) {
   var formGroup = {
     id : 'forms',
-    label : 'Forms',
+    label : translate('Forms'),
     entries: []
   };
-  formProps(formGroup, element, bpmnFactory);
+  formProps(formGroup, element, bpmnFactory, translate);
 
   return [
     formGroup
   ];
 }
 
-function createListenersTabGroups(element, bpmnFactory, elementRegistry) {
+function createListenersTabGroups(element, bpmnFactory, elementRegistry, translate) {
 
   var listenersGroup = {
     id : 'listeners',
-    label: 'Listeners',
+    label: translate('Listeners'),
     entries: []
   };
 
-  var options = listenerProps(listenersGroup, element, bpmnFactory);
+  var options = listenerProps(listenersGroup, element, bpmnFactory, translate);
 
   var listenerDetailsGroup = {
     id: 'listener-details',
@@ -256,22 +256,22 @@ function createListenersTabGroups(element, bpmnFactory, elementRegistry) {
     },
     label: function(element, node) {
       var param = options.getSelectedListener(element, node);
-      return getListenerLabel(param);
+      return getListenerLabel(param, translate);
     }
   };
 
-  listenerDetails(listenerDetailsGroup, element, bpmnFactory, options);
+  listenerDetails(listenerDetailsGroup, element, bpmnFactory, options, translate);
 
   var listenerFieldsGroup = {
     id: 'listener-fields',
-    label: 'Field Injection',
+    label: translate('Field Injection'),
     entries: [],
     enabled: function(element, node) {
       return options.getSelectedListener(element, node);
     }
   };
 
-  listenerFields(listenerFieldsGroup, element, bpmnFactory, options);
+  listenerFields(listenerFieldsGroup, element, bpmnFactory, options, translate);
 
   return [
     listenersGroup,
@@ -280,15 +280,15 @@ function createListenersTabGroups(element, bpmnFactory, elementRegistry) {
   ];
 }
 
-function createInputOutputTabGroups(element, bpmnFactory, elementRegistry) {
+function createInputOutputTabGroups(element, bpmnFactory, elementRegistry, translate) {
 
   var inputOutputGroup = {
     id: 'input-output',
-    label: 'Parameters',
+    label: translate('Parameters'),
     entries: []
   };
 
-  var options = inputOutput(inputOutputGroup, element, bpmnFactory);
+  var options = inputOutput(inputOutputGroup, element, bpmnFactory, translate);
 
   var inputOutputParameterGroup = {
     id: 'input-output-parameter',
@@ -298,11 +298,11 @@ function createInputOutputTabGroups(element, bpmnFactory, elementRegistry) {
     },
     label: function(element, node) {
       var param = options.getSelectedParameter(element, node);
-      return getInputOutputParameterLabel(param);
+      return getInputOutputParameterLabel(param, translate);
     }
   };
 
-  inputOutputParameter(inputOutputParameterGroup, element, bpmnFactory, options);
+  inputOutputParameter(inputOutputParameterGroup, element, bpmnFactory, options, translate);
 
   return [
     inputOutputGroup,
@@ -310,22 +310,22 @@ function createInputOutputTabGroups(element, bpmnFactory, elementRegistry) {
   ];
 }
 
-function createConnectorTabGroups(element, bpmnFactory, elementRegistry) {
+function createConnectorTabGroups(element, bpmnFactory, elementRegistry, translate) {
   var connectorDetailsGroup = {
     id: 'connector-details',
-    label: 'Details',
+    label: translate('Details'),
     entries: []
   };
 
-  connectorDetails(connectorDetailsGroup, element, bpmnFactory);
+  connectorDetails(connectorDetailsGroup, element, bpmnFactory, translate);
 
   var connectorInputOutputGroup = {
     id: 'connector-input-output',
-    label: 'Input/Output',
+    label: translate('Input/Output'),
     entries: []
   };
 
-  var options = connectorInputOutput(connectorInputOutputGroup, element, bpmnFactory);
+  var options = connectorInputOutput(connectorInputOutputGroup, element, bpmnFactory, translate);
 
   var connectorInputOutputParameterGroup = {
     id: 'connector-input-output-parameter',
@@ -339,7 +339,7 @@ function createConnectorTabGroups(element, bpmnFactory, elementRegistry) {
     }
   };
 
-  connectorInputOutputParameter(connectorInputOutputParameterGroup, element, bpmnFactory, options);
+  connectorInputOutputParameter(connectorInputOutputParameterGroup, element, bpmnFactory, options, translate);
 
   return [
     connectorDetailsGroup,
@@ -348,29 +348,29 @@ function createConnectorTabGroups(element, bpmnFactory, elementRegistry) {
   ];
 }
 
-function createFieldInjectionsTabGroups(element, bpmnFactory, elementRegistry) {
+function createFieldInjectionsTabGroups(element, bpmnFactory, elementRegistry, translate) {
 
   var fieldGroup = {
     id: 'field-injections-properties',
-    label: 'Field Injections',
+    label: translate('Field Injections'),
     entries: []
   };
 
-  fieldInjections(fieldGroup, element, bpmnFactory);
+  fieldInjections(fieldGroup, element, bpmnFactory, translate);
 
   return [
     fieldGroup
   ];
 }
 
-function createExtensionElementsGroups(element, bpmnFactory, elementRegistry) {
+function createExtensionElementsGroups(element, bpmnFactory, elementRegistry, translate) {
 
   var propertiesGroup = {
     id : 'extensionElements-properties',
-    label: 'Properties',
+    label: translate('Properties'),
     entries: []
   };
-  properties(propertiesGroup, element, bpmnFactory);
+  properties(propertiesGroup, element, bpmnFactory, translate);
 
   return [
     propertiesGroup
@@ -388,7 +388,7 @@ function createExtensionElementsGroups(element, bpmnFactory, elementRegistry) {
  * @param {ElementRegistry} elementRegistry
  * @param {ElementTemplates} elementTemplates
  */
-function CamundaPropertiesProvider(eventBus, bpmnFactory, elementRegistry, elementTemplates) {
+function CamundaPropertiesProvider(eventBus, bpmnFactory, elementRegistry, elementTemplates, translate) {
 
   PropertiesActivator.call(this, eventBus);
 
@@ -396,28 +396,28 @@ function CamundaPropertiesProvider(eventBus, bpmnFactory, elementRegistry, eleme
 
     var generalTab = {
       id: 'general',
-      label: 'General',
+      label: translate('General'),
       groups: createGeneralTabGroups(
                   element, bpmnFactory,
-                  elementRegistry, elementTemplates)
+                  elementRegistry, elementTemplates, translate)
     };
 
     var variablesTab = {
       id: 'variables',
-      label: 'Variables',
-      groups: createVariablesTabGroups(element, bpmnFactory, elementRegistry)
+      label: translate('Variables'),
+      groups: createVariablesTabGroups(element, bpmnFactory, elementRegistry, translate)
     };
 
     var formsTab = {
       id: 'forms',
-      label: 'Forms',
-      groups: createFormsTabGroups(element, bpmnFactory, elementRegistry)
+      label: translate('Forms'),
+      groups: createFormsTabGroups(element, bpmnFactory, elementRegistry, translate)
     };
 
     var listenersTab = {
       id: 'listeners',
-      label: 'Listeners',
-      groups: createListenersTabGroups(element, bpmnFactory, elementRegistry),
+      label: translate('Listeners'),
+      groups: createListenersTabGroups(element, bpmnFactory, elementRegistry, translate),
       enabled: function(element) {
         return !eventDefinitionHelper.getLinkEventDefinition(element)
           || (!is(element, 'bpmn:IntermediateThrowEvent')
@@ -427,14 +427,14 @@ function CamundaPropertiesProvider(eventBus, bpmnFactory, elementRegistry, eleme
 
     var inputOutputTab = {
       id: 'input-output',
-      label: 'Input/Output',
-      groups: createInputOutputTabGroups(element, bpmnFactory, elementRegistry)
+      label: translate('Input/Output'),
+      groups: createInputOutputTabGroups(element, bpmnFactory, elementRegistry, translate)
     };
 
     var connectorTab = {
       id: 'connector',
-      label: 'Connector',
-      groups: createConnectorTabGroups(element, bpmnFactory, elementRegistry),
+      label: translate('Connector'),
+      groups: createConnectorTabGroups(element, bpmnFactory, elementRegistry, translate),
       enabled: function(element) {
         var bo = implementationTypeHelper.getServiceTaskLikeBusinessObject(element);
         return bo && implementationTypeHelper.getImplementationType(bo) === 'connector';
@@ -443,14 +443,14 @@ function CamundaPropertiesProvider(eventBus, bpmnFactory, elementRegistry, eleme
 
     var fieldInjectionsTab = {
       id: 'field-injections',
-      label: 'Field Injections',
-      groups: createFieldInjectionsTabGroups(element, bpmnFactory, elementRegistry)
+      label: translate('Field Injections'),
+      groups: createFieldInjectionsTabGroups(element, bpmnFactory, elementRegistry, translate)
     };
 
     var extensionsTab = {
       id: 'extensionElements',
-      label: 'Extensions',
-      groups: createExtensionElementsGroups(element, bpmnFactory, elementRegistry)
+      label: translate('Extensions'),
+      groups: createExtensionElementsGroups(element, bpmnFactory, elementRegistry, translate)
     };
 
     return [
@@ -471,7 +471,8 @@ CamundaPropertiesProvider.$inject = [
   'eventBus',
   'bpmnFactory',
   'elementRegistry',
-  'elementTemplates'
+  'elementTemplates',
+  'translate'
 ];
 
 inherits(CamundaPropertiesProvider, PropertiesActivator);

--- a/lib/provider/camunda/element-templates/index.js
+++ b/lib/provider/camunda/element-templates/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   __depends__: [
-    require('./cmd')
+    require('./cmd'),
+    require('../../../i18n/translate')
   ],
   __init__: [
     'customElementsPropertiesActivator',

--- a/lib/provider/camunda/element-templates/parts/ChooserProps.js
+++ b/lib/provider/camunda/element-templates/parts/ChooserProps.js
@@ -16,7 +16,7 @@ function isAny(element, types) {
 }
 
 
-module.exports = function(group, element, elementTemplates) {
+module.exports = function(group, element, elementTemplates, translate) {
 
   var options = getTemplateOptions(element, elementTemplates);
 
@@ -27,7 +27,7 @@ module.exports = function(group, element, elementTemplates) {
   // select element template (via dropdown)
   group.entries.push(entryFactory.selectBox({
     id: 'elementTemplate-chooser',
-    label: 'Element Template',
+    label: translate('Element Template'),
     modelProperty: 'camunda:modelerTemplate',
     selectOptions: options,
     set: function(element, properties) {

--- a/lib/provider/camunda/element-templates/parts/CustomProps.js
+++ b/lib/provider/camunda/element-templates/parts/CustomProps.js
@@ -60,7 +60,7 @@ var IN_OUT_BINDING_TYPES = [
  * @param {ElementTemplates} elementTemplates
  * @param {BpmnFactory} bpmnFactory
  */
-module.exports = function(group, element, elementTemplates, bpmnFactory) {
+module.exports = function(group, element, elementTemplates, bpmnFactory, translate) {
 
   var template = getTemplate(element, elementTemplates);
 

--- a/lib/provider/camunda/index.js
+++ b/lib/provider/camunda/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   __depends__: [
-    require('./element-templates')
+    require('./element-templates'),
+    require('../../i18n/translate')
   ],
   __init__: [ 'propertiesProvider' ],
   propertiesProvider: [ 'type', require('./CamundaPropertiesProvider') ]

--- a/lib/provider/camunda/parts/AsynchronousContinuationProps.js
+++ b/lib/provider/camunda/parts/AsynchronousContinuationProps.js
@@ -4,13 +4,13 @@ var getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject,
     is = require('bpmn-js/lib/util/ModelUtil').is,
     asyncContinuation = require('./implementation/AsyncContinuation');
 
-module.exports = function(group, element, bpmnFactory) {
+module.exports = function(group, element, bpmnFactory, translate) {
 
   if (is(element, 'camunda:AsyncCapable')) {
 
     group.entries = group.entries.concat(asyncContinuation(element, bpmnFactory, {
       getBusinessObject: getBusinessObject
-    }));
+    }, translate));
 
   }
 };

--- a/lib/provider/camunda/parts/CallActivityProps.js
+++ b/lib/provider/camunda/parts/CallActivityProps.js
@@ -43,7 +43,7 @@ var DEFAULT_PROPS = {
   'camunda:caseTenantId': undefined
 };
 
-module.exports = function(group, element, bpmnFactory) {
+module.exports = function(group, element, bpmnFactory, translate) {
 
   if (!is(element, 'camunda:CallActivity')) {
     return;
@@ -51,7 +51,7 @@ module.exports = function(group, element, bpmnFactory) {
 
   group.entries.push(entryFactory.selectBox({
     id : 'callActivity',
-    label: 'CallActivity Type',
+    label: translate('CallActivity Type'),
     selectOptions: [
       { name: 'BPMN', value: 'bpmn' },
       { name: 'CMMN', value: 'cmmn' }

--- a/lib/provider/camunda/parts/CallActivityProps.js
+++ b/lib/provider/camunda/parts/CallActivityProps.js
@@ -84,7 +84,7 @@ module.exports = function(group, element, bpmnFactory, translate) {
 
   group.entries.push(callable(element, bpmnFactory, {
     getCallableType: getCallableType
-  }));
+  }, translate));
 
   group.entries = flattenDeep(group.entries);
 };

--- a/lib/provider/camunda/parts/ConnectorDetailProps.js
+++ b/lib/provider/camunda/parts/ConnectorDetailProps.js
@@ -22,11 +22,11 @@ function isConnector(element) {
   return getImplementationType(element) === 'connector';
 }
 
-module.exports = function(group, element, bpmnFactory) {
+module.exports = function(group, element, bpmnFactory, translate) {
 
   group.entries.push(entryFactory.textField({
     id: 'connectorId',
-    label: 'Connector Id',
+    label: translate('Connector Id'),
     modelProperty: 'connectorId',
 
     get: function(element, node) {
@@ -45,7 +45,7 @@ module.exports = function(group, element, bpmnFactory) {
     },
 
     validate: function(element, values, node) {
-      return isConnector(element) && !values.connectorId ? { connectorId: 'Must provide a value' } : {};
+      return isConnector(element) && !values.connectorId ? { connectorId: translate('Must provide a value') } : {};
     },
 
     hidden: function(element, node) {

--- a/lib/provider/camunda/parts/ConnectorInputOutputParameterProps.js
+++ b/lib/provider/camunda/parts/ConnectorInputOutputParameterProps.js
@@ -4,13 +4,13 @@ var assign = require('lodash/object/assign');
 
 var inputOutputParameter = require('./implementation/InputOutputParameter');
 
-module.exports = function(group, element, bpmnFactory, options) {
+module.exports = function(group, element, bpmnFactory, options, translate) {
 
   options = assign({
     idPrefix: 'connector-',
     insideConnector: true
   }, options);
 
-  group.entries = group.entries.concat(inputOutputParameter(element, bpmnFactory, options));
+  group.entries = group.entries.concat(inputOutputParameter(element, bpmnFactory, options, translate));
 
 };

--- a/lib/provider/camunda/parts/ConnectorInputOutputProps.js
+++ b/lib/provider/camunda/parts/ConnectorInputOutputProps.js
@@ -2,12 +2,12 @@
 
 var inputOutput = require('./implementation/InputOutput');
 
-module.exports = function(group, element, bpmnFactory) {
+module.exports = function(group, element, bpmnFactory, translate) {
 
   var inputOutputEntry = inputOutput(element, bpmnFactory, {
     idPrefix: 'connector-',
     insideConnector: true
-  });
+  }, translate);
 
   group.entries = group.entries.concat(inputOutputEntry.entries);
 

--- a/lib/provider/camunda/parts/ExternalTaskConfigurationProps.js
+++ b/lib/provider/camunda/parts/ExternalTaskConfigurationProps.js
@@ -19,7 +19,7 @@ function getServiceTaskLikeBusinessObject(element) {
   return bo;
 }
 
-module.exports = function(group, element, bpmnFactory) {
+module.exports = function(group, element, bpmnFactory, translate) {
 
   var bo = getServiceTaskLikeBusinessObject(element);
 
@@ -35,6 +35,6 @@ module.exports = function(group, element, bpmnFactory) {
         }
         return bo.get('processRef');
       }
-    }));
+    }, translate));
   }
 };

--- a/lib/provider/camunda/parts/FieldInjectionProps.js
+++ b/lib/provider/camunda/parts/FieldInjectionProps.js
@@ -4,13 +4,13 @@ var ImplementationTypeHelper = require('../../../helper/ImplementationTypeHelper
 
 var fieldInjection = require('./implementation/FieldInjection');
 
-module.exports = function(group, element, bpmnFactory) {
+module.exports = function(group, element, bpmnFactory, translate) {
 
   if (!ImplementationTypeHelper.getServiceTaskLikeBusinessObject(element)) {
     return;
   }
 
-  var fieldInjectionEntry = fieldInjection(element, bpmnFactory);
+  var fieldInjectionEntry = fieldInjection(element, bpmnFactory, {}, translate);
 
   if (fieldInjectionEntry && fieldInjectionEntry.length > 0) {
     group.entries = group.entries.concat(fieldInjectionEntry);

--- a/lib/provider/camunda/parts/FormProps.js
+++ b/lib/provider/camunda/parts/FormProps.js
@@ -79,7 +79,7 @@ function ensureFormKeyAndDataSupported(element) {
       is(element, 'bpmn:UserTask');
 }
 
-module.exports = function(group, element, bpmnFactory) {
+module.exports = function(group, element, bpmnFactory, translate) {
 
   if (!ensureFormKeyAndDataSupported(element)) {
     return;
@@ -108,7 +108,7 @@ module.exports = function(group, element, bpmnFactory) {
   //[FormKey] form key text input field
   group.entries.push(entryFactory.textField({
     id : 'form-key',
-    label : 'Form Key',
+    label : translate('Form Key'),
     modelProperty: 'formKey',
     get: function(element, node) {
       var bo = getBusinessObject(element);
@@ -128,7 +128,7 @@ module.exports = function(group, element, bpmnFactory) {
   // [FormData] form field select box
   var formFieldsEntry = extensionElements(element, bpmnFactory, {
     id: 'form-fields',
-    label: 'Form Fields',
+    label: translate('Form Fields'),
     modelProperty: 'id',
     prefix: 'FormField',
     createExtensionElement: function(element, extensionElements, value) {
@@ -187,7 +187,7 @@ module.exports = function(group, element, bpmnFactory) {
   // [FormData] business key form field select box
   var formBusinessKeyFormFieldEntry = entryFactory.selectBox({
     id: 'form-business-key',
-    label: 'Business Key',
+    label: translate('Business Key'),
     modelProperty: 'businessKey',
     selectOptions: function(element, inputNode) {
       var selectOptions = [{ name: '', value: '' }];
@@ -224,7 +224,7 @@ module.exports = function(group, element, bpmnFactory) {
   // [FormData] Form Field label
   group.entries.push(entryFactory.label({
     id: 'form-field-header',
-    labelText: 'Form Field',
+    labelText: translate('Form Field'),
     showLabel: function(element, node) {
       return !!getSelectedFormField(element, node);
     }
@@ -233,7 +233,7 @@ module.exports = function(group, element, bpmnFactory) {
   // [FormData] form field id text input field
   group.entries.push(entryFactory.validationAwareTextField({
     id: 'form-field-id',
-    label: 'ID',
+    label: translate('ID'),
     modelProperty: 'id',
 
     getProperty: function(element, node) {
@@ -280,7 +280,7 @@ module.exports = function(group, element, bpmnFactory) {
   // [FormData] form field type combo box
   group.entries.push(entryFactory.comboBox({
     id: 'form-field-type',
-    label: 'Type',
+    label: translate('Type'),
     selectOptions: [
       { name: 'string', value: 'string' },
       { name: 'long', value: 'long' },
@@ -324,14 +324,14 @@ module.exports = function(group, element, bpmnFactory) {
   // [FormData] form field label text input field
   group.entries.push(formFieldTextField({
     id: 'form-field-label',
-    label: 'Label',
+    label: translate('Label'),
     modelProperty: 'label'
   }, getSelectedFormField));
 
   // [FormData] form field defaultValue text input field
   group.entries.push(formFieldTextField({
     id: 'form-field-defaultValue',
-    label: 'Default Value',
+    label: translate('Default Value'),
     modelProperty: 'defaultValue'
   }, getSelectedFormField));
 
@@ -339,7 +339,7 @@ module.exports = function(group, element, bpmnFactory) {
   // [FormData] form field enum values label
   group.entries.push(entryFactory.label({
     id: 'form-field-enum-values-header',
-    labelText: 'Values',
+    labelText: translate('Values'),
     divider: true,
     showLabel: function(element, node) {
       var selectedFormField = getSelectedFormField(element, node);
@@ -351,7 +351,7 @@ module.exports = function(group, element, bpmnFactory) {
   // [FormData] form field enum values table
   group.entries.push(entryFactory.table({
     id: 'form-field-enum-values',
-    labels: [ 'Id', 'Name' ],
+    labels: [ translate('Id'), translate('Name') ],
     modelProperties: [ 'id', 'name' ],
     show: function(element, node) {
       var selectedFormField = getSelectedFormField(element, node);
@@ -404,7 +404,7 @@ module.exports = function(group, element, bpmnFactory) {
   // [FormData] Validation label
   group.entries.push(entryFactory.label({
     id: 'form-field-validation-header',
-    labelText: 'Validation',
+    labelText: translate('Validation'),
     divider: true,
     showLabel: function(element, node) {
       return !!getSelectedFormField(element, node);
@@ -415,8 +415,8 @@ module.exports = function(group, element, bpmnFactory) {
   group.entries.push(entryFactory.table({
     id: 'constraints-list',
     modelProperties: [ 'name', 'config' ],
-    labels: [ 'Name', 'Config' ],
-    addLabel: 'Add Constraint',
+    labels: [ translate('Name'), translate('Config') ],
+    addLabel: translate('Add Constraint'),
     getElements: function(element, node) {
       var formField = getSelectedFormField(element, node);
 
@@ -475,7 +475,7 @@ module.exports = function(group, element, bpmnFactory) {
   // [FormData] Properties label
   group.entries.push(entryFactory.label({
     id: 'form-field-properties-header',
-    labelText: 'Properties',
+    labelText: translate('Properties'),
     divider: true,
     showLabel: function(element, node) {
       return !!getSelectedFormField(element, node);
@@ -486,12 +486,12 @@ module.exports = function(group, element, bpmnFactory) {
   group.entries.push(properties(element, bpmnFactory, {
     id: 'form-field-properties',
     modelProperties: [ 'id', 'value' ],
-    labels: [ 'Id', 'Value' ],
+    labels: [ translate('Id'), translate('Value') ],
     getParent: function(element, node) {
       return getSelectedFormField(element, node);
     },
     show: function(element, node) {
       return !!getSelectedFormField(element, node);
     }
-  }));
+  }, translate));
 };

--- a/lib/provider/camunda/parts/InputOutputParameterProps.js
+++ b/lib/provider/camunda/parts/InputOutputParameterProps.js
@@ -4,8 +4,8 @@ var inputOutputParameter = require('./implementation/InputOutputParameter');
 
 var assign = require('lodash/object/assign');
 
-module.exports = function(group, element, bpmnFactory, options) {
+module.exports = function(group, element, bpmnFactory, options, translate) {
 
-  group.entries = group.entries.concat(inputOutputParameter(element, bpmnFactory, assign({}, options)));
+  group.entries = group.entries.concat(inputOutputParameter(element, bpmnFactory, assign({}, options), translate));
 
 };

--- a/lib/provider/camunda/parts/InputOutputProps.js
+++ b/lib/provider/camunda/parts/InputOutputProps.js
@@ -2,9 +2,9 @@
 
 var inputOutput = require('./implementation/InputOutput');
 
-module.exports = function(group, element, bpmnFactory) {
+module.exports = function(group, element, bpmnFactory, translate) {
 
-  var inputOutputEntry = inputOutput(element, bpmnFactory);
+  var inputOutputEntry = inputOutput(element, bpmnFactory, {}, translate);
 
   group.entries = group.entries.concat(inputOutputEntry.entries);
 

--- a/lib/provider/camunda/parts/JobConfigurationProps.js
+++ b/lib/provider/camunda/parts/JobConfigurationProps.js
@@ -6,7 +6,7 @@ var is = require('bpmn-js/lib/util/ModelUtil').is,
 var jobPriority = require('./implementation/JobPriority'),
     jobRetryTimeCycle = require('./implementation/JobRetryTimeCycle');
 
-module.exports = function(group, element, bpmnFactory) {
+module.exports = function(group, element, bpmnFactory, translate) {
   var businessObject = getBusinessObject(element);
 
   if (is(element, 'camunda:JobPriorized') ||
@@ -22,13 +22,13 @@ module.exports = function(group, element, bpmnFactory) {
 
         return bo.get('processRef');
       }
-    }));
+    }, translate));
   }
 
   if (is(element, 'camunda:AsyncCapable')) {
     group.entries = group.entries.concat(jobRetryTimeCycle(element, bpmnFactory, {
       getBusinessObject: getBusinessObject
-    }));
+    }, translate));
   }
 
 };

--- a/lib/provider/camunda/parts/ListenerDetailProps.js
+++ b/lib/provider/camunda/parts/ListenerDetailProps.js
@@ -15,7 +15,7 @@ var LISTENER_TYPE_LABEL = {
   script: 'Script'
 };
 
-module.exports = function(group, element, bpmnFactory, options) {
+module.exports = function(group, element, bpmnFactory, options, translate) {
 
   options = options || {};
 
@@ -46,7 +46,7 @@ module.exports = function(group, element, bpmnFactory, options) {
 
   group.entries.push(entryFactory.selectBox({
     id: 'listener-event-type',
-    label: 'Event Type',
+    label: translate('Event Type'),
     modelProperty: 'eventType',
     emptyParameter: false,
 
@@ -91,12 +91,12 @@ module.exports = function(group, element, bpmnFactory, options) {
 
   group.entries.push(entryFactory.selectBox({
     id: 'listener-type',
-    label: 'Listener Type',
+    label: translate('Listener Type'),
     selectOptions: [
-      { value: classProp, name: 'Java Class' },
-      { value: expressionProp, name: 'Expression' },
-      { value: delegateExpressionProp, name: 'Delegate Expression' },
-      { value: scriptProp, name: 'Script' }
+      { value: classProp, name: translate('Java Class') },
+      { value: expressionProp, name: translate('Expression') },
+      { value: delegateExpressionProp, name: translate('Delegate Expression') },
+      { value: scriptProp, name: translate('Script') }
     ],
     modelProperty: 'listenerType',
     emptyParameter: false,
@@ -164,7 +164,7 @@ module.exports = function(group, element, bpmnFactory, options) {
           validate = {};
 
       if (!value) {
-        validate.listenerValue = 'Must provide a value';
+        validate.listenerValue = translate('Must provide a value');
       }
 
       return validate;

--- a/lib/provider/camunda/parts/ListenerFieldInjectionProps.js
+++ b/lib/provider/camunda/parts/ListenerFieldInjectionProps.js
@@ -4,14 +4,14 @@ var assign = require('lodash/object/assign');
 
 var fieldInjection = require('./implementation/FieldInjection');
 
-module.exports = function(group, element, bpmnFactory, options) {
+module.exports = function(group, element, bpmnFactory, options, translate) {
 
   options = assign({
     idPrefix: 'listener-',
     insideListener: true
   }, options);
 
-  var fieldInjectionEntry = fieldInjection(element, bpmnFactory, options);
+  var fieldInjectionEntry = fieldInjection(element, bpmnFactory, options, translate);
 
   if (fieldInjectionEntry && fieldInjectionEntry.length > 0) {
     group.entries = group.entries.concat(fieldInjectionEntry);

--- a/lib/provider/camunda/parts/ListenerProps.js
+++ b/lib/provider/camunda/parts/ListenerProps.js
@@ -2,9 +2,9 @@
 
 var listener = require('./implementation/Listener');
 
-module.exports = function(group, element, bpmnFactory) {
+module.exports = function(group, element, bpmnFactory, translate) {
 
-  var listenerEntry = listener(element, bpmnFactory);
+  var listenerEntry = listener(element, bpmnFactory, {}, translate);
 
   group.entries = group.entries.concat(listenerEntry.entries);
 

--- a/lib/provider/camunda/parts/MultiInstanceLoopProps.js
+++ b/lib/provider/camunda/parts/MultiInstanceLoopProps.js
@@ -27,14 +27,14 @@ module.exports = function(group, element, bpmnFactory, translate) {
   }
 
   // multi instance properties
-  group.entries = group.entries.concat(multiInstanceLoopCharacteristics(element, bpmnFactory));
+  group.entries = group.entries.concat(multiInstanceLoopCharacteristics(element, bpmnFactory, translate));
 
   // async continuation ///////////////////////////////////////////////////////
   group.entries = group.entries.concat(asyncContinuation(element, bpmnFactory, {
     getBusinessObject: getLoopCharacteristics,
     idPrefix: 'multiInstance-',
     labelPrefix: translate('Multi Instance ')
-  }));
+  }, translate));
 
 
   // retry time cycle //////////////////////////////////////////////////////////
@@ -42,5 +42,5 @@ module.exports = function(group, element, bpmnFactory, translate) {
     getBusinessObject: getLoopCharacteristics,
     idPrefix: 'multiInstance-',
     labelPrefix: translate('Multi Instance ')
-  }));
+  }, translate));
 };

--- a/lib/provider/camunda/parts/MultiInstanceLoopProps.js
+++ b/lib/provider/camunda/parts/MultiInstanceLoopProps.js
@@ -20,7 +20,7 @@ function ensureMultiInstanceSupported(element) {
   return !!loopCharacteristics && is(loopCharacteristics, 'camunda:Collectable');
 }
 
-module.exports = function(group, element, bpmnFactory) {
+module.exports = function(group, element, bpmnFactory, translate) {
 
   if (!ensureMultiInstanceSupported(element)) {
     return;
@@ -33,7 +33,7 @@ module.exports = function(group, element, bpmnFactory) {
   group.entries = group.entries.concat(asyncContinuation(element, bpmnFactory, {
     getBusinessObject: getLoopCharacteristics,
     idPrefix: 'multiInstance-',
-    labelPrefix: 'Multi Instance '
+    labelPrefix: translate('Multi Instance ')
   }));
 
 
@@ -41,6 +41,6 @@ module.exports = function(group, element, bpmnFactory) {
   group.entries = group.entries.concat(jobRetryTimeCycle(element, bpmnFactory, {
     getBusinessObject: getLoopCharacteristics,
     idPrefix: 'multiInstance-',
-    labelPrefix: 'Multi Instance '
+    labelPrefix: translate('Multi Instance ')
   }));
 };

--- a/lib/provider/camunda/parts/PropertiesProps.js
+++ b/lib/provider/camunda/parts/PropertiesProps.js
@@ -5,12 +5,12 @@ var properties = require('./implementation/Properties'),
     cmdHelper = require('../../../helper/CmdHelper');
 
 
-module.exports = function(group, element, bpmnFactory) {
+module.exports = function(group, element, bpmnFactory, translate) {
 
   var propertiesEntry = properties(element, bpmnFactory, {
     id: 'properties',
     modelProperties: [ 'name', 'value' ],
-    labels: [ 'Name', 'Value' ],
+    labels: [ translate('Name'), translate('Value') ],
 
     getParent: function(element, node, bo) {
       return bo.extensionElements;
@@ -24,7 +24,7 @@ module.exports = function(group, element, bpmnFactory) {
         parent: parent
       };
     }
-  });
+  }, translate);
 
   if (propertiesEntry) {
     group.entries.push(propertiesEntry);

--- a/lib/provider/camunda/parts/ScriptTaskProps.js
+++ b/lib/provider/camunda/parts/ScriptTaskProps.js
@@ -7,7 +7,7 @@ var getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject,
     script = require('./implementation/Script')('scriptFormat', 'script', false);
 
 
-module.exports = function(group, element, bpmnFactory) {
+module.exports = function(group, element, bpmnFactory, translate) {
   var bo;
 
   if (is(element, 'bpmn:ScriptTask')) {
@@ -20,7 +20,7 @@ module.exports = function(group, element, bpmnFactory) {
 
   group.entries.push({
     id: 'script-implementation',
-    label: 'Script',
+    label: translate('Script'),
     html: script.template,
 
     get: function(element) {
@@ -45,7 +45,7 @@ module.exports = function(group, element, bpmnFactory) {
 
   group.entries.push(entryFactory.textField({
     id : 'scriptResultVariable',
-    label : 'Result Variable',
+    label : translate('Result Variable'),
     modelProperty : 'scriptResultVariable',
 
     get: function(element, propertyName) {

--- a/lib/provider/camunda/parts/SequenceFlowProps.js
+++ b/lib/provider/camunda/parts/SequenceFlowProps.js
@@ -9,7 +9,7 @@ var is = require('bpmn-js/lib/util/ModelUtil').is,
     script = require('./implementation/Script')('language', 'body', true);
 
 
-module.exports = function(group, element, bpmnFactory) {
+module.exports = function(group, element, bpmnFactory, translate) {
   var bo;
 
   if (is(element, 'bpmn:SequenceFlow')) {
@@ -26,13 +26,13 @@ module.exports = function(group, element, bpmnFactory) {
 
   group.entries.push({
     id: 'condition',
-    label: 'Condition',
+    label: translate('Condition'),
     html: '<div class="bpp-row">' +
-              '<label for="cam-condition-type">Condition Type</label>' +
+              '<label for="cam-condition-type">'+translate('Condition Type')+'</label>' +
               '<div class="bpp-field-wrapper">' +
                 '<select id="cam-condition-type" name="conditionType" data-value>' +
-                  '<option value="expression">Expression</option>' +
-                  '<option value="script">Script</option>' +
+                  '<option value="expression">'+translate('Expression')+'</option>' +
+                  '<option value="script">'+translate('Script')+'</option>' +
                   '<option value="" selected></option>' +
                 '</select>' +
               '</div>' +
@@ -40,7 +40,7 @@ module.exports = function(group, element, bpmnFactory) {
 
             // expression
             '<div class="bpp-row">' +
-              '<label for="cam-condition" data-show="isExpression">Expression</label>' +
+              '<label for="cam-condition" data-show="isExpression">'+translate('Expression')+'</label>' +
               '<div class="bpp-field-wrapper" data-show="isExpression">' +
                 '<input id="cam-condition" type="text" name="condition" />' +
                 '<button class="clear" data-action="clear" data-show="canClear">' +

--- a/lib/provider/camunda/parts/ServiceTaskDelegateProps.js
+++ b/lib/provider/camunda/parts/ServiceTaskDelegateProps.js
@@ -35,7 +35,7 @@ function isServiceTaskLike(element) {
   return ImplementationTypeHelper.isServiceTaskLike(element);
 }
 
-module.exports = function(group, element, bpmnFactory) {
+module.exports = function(group, element, bpmnFactory, translate) {
 
   if (!isServiceTaskLike(getBusinessObject(element))) {
     return;
@@ -52,7 +52,7 @@ module.exports = function(group, element, bpmnFactory) {
     hasDmnSupport: hasDmnSupport,
     hasExternalSupport: hasExternalSupport,
     hasServiceTaskLikeSupport: true
-  }));
+  }, translate));
 
 
   // delegate (class, expression, delegateExpression) //////////
@@ -60,7 +60,7 @@ module.exports = function(group, element, bpmnFactory) {
   group.entries = group.entries.concat(delegate(element, bpmnFactory, {
     getBusinessObject: getBusinessObject,
     getImplementationType: getImplementationType
-  }));
+  }, translate));
 
 
   // result variable /////////////////////////////////////////
@@ -71,7 +71,7 @@ module.exports = function(group, element, bpmnFactory) {
     hideResultVariable: function(element, node) {
       return getImplementationType(element) !== 'expression';
     }
-  }));
+  }, translate));
 
   // external //////////////////////////////////////////////////
 
@@ -79,7 +79,7 @@ module.exports = function(group, element, bpmnFactory) {
     group.entries = group.entries.concat(external(element, bpmnFactory, {
       getBusinessObject: getBusinessObject,
       getImplementationType: getImplementationType
-    }));
+    }, translate));
   }
 
 
@@ -88,7 +88,7 @@ module.exports = function(group, element, bpmnFactory) {
   if (hasDmnSupport) {
     group.entries = group.entries.concat(callable(element, bpmnFactory, {
       getCallableType: getImplementationType
-    }));
+    }, translate));
   }
 
 
@@ -100,7 +100,7 @@ module.exports = function(group, element, bpmnFactory) {
 
   group.entries.push(entryFactory.link({
     id: 'configureConnectorLink',
-    label: 'Configure Connector',
+    label: translate('Configure Connector'),
     getClickableElement: function(element, node) {
       var panel = domClosest(node, 'div.bpp-properties-panel');
       return domQuery('a[data-tab-target="connector"]', panel);
@@ -113,7 +113,7 @@ module.exports = function(group, element, bpmnFactory) {
       if (isConnector(element)) {
         var connectorId = InputOutputHelper.getConnector(element).get('connectorId');
         if (connectorId) {
-          link.textContent = 'Configure Connector';
+          link.textContent = translate('Configure Connector');
         }
         else {
           link.innerHTML = '<span class="bpp-icon-warning"></span> Must configure Connector';

--- a/lib/provider/camunda/parts/StartEventInitiator.js
+++ b/lib/provider/camunda/parts/StartEventInitiator.js
@@ -5,7 +5,7 @@ var entryFactory = require('../../../factory/EntryFactory'),
     getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
 
 
-module.exports = function(group, element) {
+module.exports = function(group, element, translate) {
 
   var bo = getBusinessObject(element);
 
@@ -16,7 +16,7 @@ module.exports = function(group, element) {
   if ( is(element, 'camunda:Initiator') && !is(element.parent, 'bpmn:SubProcess') ) {
     group.entries.push(entryFactory.textField({
       id: 'initiator',
-      label: 'Initiator',
+      label: translate('Initiator'),
       modelProperty: 'initiator'
     }));
   }

--- a/lib/provider/camunda/parts/UserTaskProps.js
+++ b/lib/provider/camunda/parts/UserTaskProps.js
@@ -4,51 +4,51 @@ var is = require('bpmn-js/lib/util/ModelUtil').is,
     entryFactory = require('../../../factory/EntryFactory');
 
 
-module.exports = function(group, element) {
+module.exports = function(group, element, translate) {
   if (is(element, 'camunda:Assignable')) {
 
     // Assignee
     group.entries.push(entryFactory.textField({
       id : 'assignee',
-      label : 'Assignee',
+      label : translate('Assignee'),
       modelProperty : 'assignee'
     }));
 
     // Candidate Users
     group.entries.push(entryFactory.textField({
       id : 'candidateUsers',
-      label : 'Candidate Users',
+      label : translate('Candidate Users'),
       modelProperty : 'candidateUsers'
     }));
 
     // Candidate Groups
     group.entries.push(entryFactory.textField({
       id : 'candidateGroups',
-      label : 'Candidate Groups',
+      label : translate('Candidate Groups'),
       modelProperty : 'candidateGroups'
     }));
 
     // Due Date
     group.entries.push(entryFactory.textField({
       id : 'dueDate',
-      description : 'The due date as an EL expression (e.g. ${someDate} or an ISO date (e.g. 2015-06-26T09:54:00)',
-      label : 'Due Date',
+      description : translate('The due date as an EL expression (e.g. ${someDate} or an ISO date (e.g. 2015-06-26T09:54:00)'),
+      label : translate('Due Date'),
       modelProperty : 'dueDate'
     }));
 
     // FollowUp Date
     group.entries.push(entryFactory.textField({
       id : 'followUpDate',
-      description : 'The follow up date as an EL expression (e.g. ${someDate} or an ' +
-                    'ISO date (e.g. 2015-06-26T09:54:00)',
-      label : 'Follow Up Date',
+      description : translate('The follow up date as an EL expression (e.g. ${someDate} or an ' +
+                    'ISO date (e.g. 2015-06-26T09:54:00)'),
+      label : translate('Follow Up Date'),
       modelProperty : 'followUpDate'
     }));
 
     // priority
     group.entries.push(entryFactory.textField({
       id : 'priority',
-      label : 'Priority',
+      label : translate('Priority'),
       modelProperty : 'priority'
     }));
   }

--- a/lib/provider/camunda/parts/VariableMappingProps.js
+++ b/lib/provider/camunda/parts/VariableMappingProps.js
@@ -68,7 +68,7 @@ var CAMUNDA_IN_EXTENSION_ELEMENT = 'camunda:In',
     CAMUNDA_OUT_EXTENSION_ELEMENT = 'camunda:Out';
 
 
-module.exports = function(group, element, bpmnFactory) {
+module.exports = function(group, element, bpmnFactory, translate) {
 
   if (!is(element, 'camunda:CallActivity')) {
     return;
@@ -136,7 +136,7 @@ module.exports = function(group, element, bpmnFactory) {
 
   var inEntry = extensionElementsEntry(element, bpmnFactory, {
     id: 'variableMapping-in',
-    label: 'In Mapping',
+    label: translate('In Mapping'),
     modelProperty: 'source',
     prefix: 'In',
     idGeneration: false,
@@ -161,7 +161,7 @@ module.exports = function(group, element, bpmnFactory) {
 
   var outEntry = extensionElementsEntry(element, bpmnFactory, {
     id: 'variableMapping-out',
-    label: 'Out Mapping',
+    label: translate('Out Mapping'),
     modelProperty: 'source',
     prefix: 'Out',
     idGeneration: false,
@@ -191,10 +191,10 @@ module.exports = function(group, element, bpmnFactory) {
 
       var value = '';
       if (is(mapping, CAMUNDA_IN_EXTENSION_ELEMENT)) {
-        value = 'In Mapping';
+        value = translate('In Mapping');
       }
       else if (is(mapping, CAMUNDA_OUT_EXTENSION_ELEMENT)) {
-        value = 'Out Mapping';
+        value = translate('Out Mapping');
       }
 
       return {
@@ -210,7 +210,7 @@ module.exports = function(group, element, bpmnFactory) {
 
   group.entries.push(entryFactory.selectBox({
     id: 'variableMapping-inOutType',
-    label: 'Type',
+    label: translate('Type'),
     selectOptions: inOutTypeOptions,
     modelProperty: 'inOutType',
     get: function(element, node) {
@@ -304,7 +304,7 @@ module.exports = function(group, element, bpmnFactory) {
 
   group.entries.push(entryFactory.textField({
     id: 'variableMapping-target',
-    label: 'Target',
+    label: translate('Target'),
     modelProperty: 'target',
     get: function(element, node) {
       return {
@@ -338,7 +338,7 @@ module.exports = function(group, element, bpmnFactory) {
 
   group.entries.push(entryFactory.checkbox({
     id: 'variableMapping-local',
-    label: 'Local',
+    label: translate('Local'),
     modelProperty: 'local',
     get: function(element, node) {
       return {

--- a/lib/provider/camunda/parts/VersionTagProps.js
+++ b/lib/provider/camunda/parts/VersionTagProps.js
@@ -5,7 +5,7 @@ var entryFactory = require('../../../factory/EntryFactory'),
     is = require('bpmn-js/lib/util/ModelUtil').is,
     getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
 
-module.exports = function(group, element) {
+module.exports = function(group, element, translate) {
 
   var bo = getBusinessObject(element);
 
@@ -16,7 +16,7 @@ module.exports = function(group, element) {
   if (is(element, 'bpmn:Process') || is(element, 'bpmn:Participant') && bo.get('processRef')) {
     var versionTagEntry = entryFactory.textField({
       id: 'versionTag',
-      label: 'Version Tag',
+      label: translate('Version Tag'),
       modelProperty: 'versionTag'
     });
 

--- a/lib/provider/camunda/parts/implementation/AsyncContinuation.js
+++ b/lib/provider/camunda/parts/implementation/AsyncContinuation.js
@@ -28,7 +28,7 @@ function canRemoveFailedJobRetryTimeCycle(element) {
   return !eventDefinitionHelper.getTimerEventDefinition(element);
 }
 
-module.exports = function(element, bpmnFactory, options) {
+module.exports = function(element, bpmnFactory, options, translate) {
 
   var getBusinessObject = options.getBusinessObject;
 
@@ -38,7 +38,7 @@ module.exports = function(element, bpmnFactory, options) {
 
   var asyncBeforeEntry = entryFactory.checkbox({
     id: idPrefix + 'asyncBefore',
-    label: labelPrefix + 'Asynchronous Before',
+    label: labelPrefix + translate('Asynchronous Before'),
     modelProperty: 'asyncBefore',
 
     get: function(element, node) {
@@ -73,7 +73,7 @@ module.exports = function(element, bpmnFactory, options) {
 
   var asyncAfterEntry = entryFactory.checkbox({
     id: idPrefix + 'asyncAfter',
-    label: labelPrefix + 'Asynchronous After',
+    label: labelPrefix + translate('Asynchronous After'),
     modelProperty: 'asyncAfter',
 
     get: function(element, node) {
@@ -107,7 +107,7 @@ module.exports = function(element, bpmnFactory, options) {
 
   var exclusiveEntry = entryFactory.checkbox({
     id: idPrefix + 'exclusive',
-    label: labelPrefix + 'Exclusive',
+    label: labelPrefix + translate('Exclusive'),
     modelProperty: 'exclusive',
 
     get: function(element, node) {

--- a/lib/provider/camunda/parts/implementation/Callable.js
+++ b/lib/provider/camunda/parts/implementation/Callable.js
@@ -137,7 +137,7 @@ function isSupportedCallableType(type) {
   return [ 'bpmn', 'cmmn', 'dmn' ].indexOf(type) !== -1;
 }
 
-module.exports = function(element, bpmnFactory, options) {
+module.exports = function(element, bpmnFactory, options, translate) {
 
   var getCallableType = options.getCallableType;
 
@@ -191,13 +191,13 @@ module.exports = function(element, bpmnFactory, options) {
       var label = '';
       var type = getCallableType(element);
       if (type === 'bpmn') {
-        label = 'Called Element';
+        label = translate('Called Element');
       }
       else if (type === 'cmmn') {
-        label = 'Case Ref';
+        label = translate('Case Ref');
       }
       else if (type === 'dmn') {
-        label = 'Decision Ref';
+        label = translate('Decision Ref');
       }
 
       return {
@@ -231,7 +231,7 @@ module.exports = function(element, bpmnFactory, options) {
 
   entries.push(entryFactory.selectBox({
     id: 'callable-binding',
-    label: 'Binding',
+    label: translate('Binding'),
     selectOptions: bindingOptions,
     modelProperty: 'callableBinding',
 
@@ -271,7 +271,7 @@ module.exports = function(element, bpmnFactory, options) {
 
   entries.push(entryFactory.textField({
     id: 'callable-version',
-    label: 'Version',
+    label: translate('Version'),
     modelProperty: 'callableVersion',
 
     get: function(element, node) {
@@ -303,7 +303,7 @@ module.exports = function(element, bpmnFactory, options) {
 
       var type = getCallableType(element);
       return isSupportedCallableType(type) && (getCallActivityBindingValue(element) === 'version') && !version ?
-             { callableVersion: 'Value must provide a value.' } : {};
+             { callableVersion: translate('Value must provide a value.') } : {};
     },
 
     hidden: function(element, node) {
@@ -315,7 +315,7 @@ module.exports = function(element, bpmnFactory, options) {
 
   entries.push(entryFactory.textField({
     id: 'tenant-id',
-    label: 'Tenant Id',
+    label: translate('Tenant Id'),
     modelProperty: 'tenantId',
 
     get: function(element, node) {
@@ -352,7 +352,7 @@ module.exports = function(element, bpmnFactory, options) {
   if (is(getBusinessObject(element), 'bpmn:CallActivity')) {
     entries.push(entryFactory.checkbox({
       id: 'callable-business-key',
-      label: 'Business Key',
+      label: translate('Business Key'),
       modelProperty: 'callableBusinessKey',
 
       get: function(element, node) {
@@ -384,7 +384,7 @@ module.exports = function(element, bpmnFactory, options) {
 
   entries.push(entryFactory.selectBox({
     id: 'dmn-map-decision-result',
-    label: 'Map Decision Result',
+    label: translate('Map Decision Result'),
     selectOptions: mapDecisionResultOptions,
     modelProperty: 'mapDecisionResult',
 
@@ -412,7 +412,7 @@ module.exports = function(element, bpmnFactory, options) {
 
   entries.push(entryFactory.selectBox({
     id: 'delegateVariableMappingType',
-    label: 'Delegate Variable Mapping',
+    label: translate('Delegate Variable Mapping'),
     selectOptions: delegateVariableMappingOptions,
     emptyParameter: true,
     modelProperty: 'delegateVariableMappingType',
@@ -460,11 +460,11 @@ module.exports = function(element, bpmnFactory, options) {
       var type = getDelegateVariableMappingType(element);
 
       if (type === 'variableMappingClass') {
-        label = 'Class';
+        label = translate('Class');
         delegateVariableMapping = bo.get('camunda:variableMappingClass');
       }
       else if (type === 'variableMappingDelegateExpression') {
-        label = 'Delegate Expression';
+        label = translate('Delegate Expression');
         delegateVariableMapping = bo.get('camunda:variableMappingDelegateExpression');
       }
 
@@ -488,7 +488,7 @@ module.exports = function(element, bpmnFactory, options) {
     validate: function(element, values, node) {
       var delegateVariableMapping = values.delegateVariableMapping;
       return (getCallableType(element) === 'bpmn') && !delegateVariableMapping ?
-        { delegateVariableMapping: 'Must provide a value.' } : {};
+        { delegateVariableMapping: translate('Must provide a value.') } : {};
     },
 
     hidden: function(element, node) {

--- a/lib/provider/camunda/parts/implementation/Callable.js
+++ b/lib/provider/camunda/parts/implementation/Callable.js
@@ -380,7 +380,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
     hideResultVariable: function(element, node) {
       return getCallableType(element) !== 'dmn';
     }
-  }));
+  }, translate));
 
   entries.push(entryFactory.selectBox({
     id: 'dmn-map-decision-result',

--- a/lib/provider/camunda/parts/implementation/Delegate.js
+++ b/lib/provider/camunda/parts/implementation/Delegate.js
@@ -23,27 +23,28 @@ function getAttribute(type) {
   return PROPERTIES[type];
 }
 
-function getDelegationLabel(type) {
-  switch (type) {
-  case 'class':
-    return 'Java Class';
-  case 'expression':
-    return 'Expression';
-  case 'delegateExpression':
-    return 'Delegate Expression';
-  default:
-    return '';
-  }
-}
 
-module.exports = function(element, bpmnFactory, options) {
+module.exports = function(element, bpmnFactory, options, translate) {
 
   var getImplementationType = options.getImplementationType,
       getBusinessObject     = options.getBusinessObject;
 
+  function getDelegationLabel(type) {
+    switch (type) {
+    case 'class':
+      return translate('Java Class');
+    case 'expression':
+      return translate('Expression');
+    case 'delegateExpression':
+      return translate('Delegate Expression');
+    default:
+      return '';
+    }
+  }
+
   var delegateEntry = entryFactory.textField({
     id: 'delegate',
-    label: 'Value',
+    label: translate('Value'),
     dataValueLabel: 'delegationLabel',
     modelProperty: 'delegate',
 

--- a/lib/provider/camunda/parts/implementation/ExtensionElements.js
+++ b/lib/provider/camunda/parts/implementation/ExtensionElements.js
@@ -33,7 +33,7 @@ function generateElementId(prefix) {
 var CREATE_EXTENSION_ELEMENT_ACTION = 'create-extension-element',
     REMOVE_EXTENSION_ELEMENT_ACTION = 'remove-extension-element';
 
-module.exports = function(element, bpmnFactory, options) {
+module.exports = function(element, bpmnFactory, options, translate) {
 
   var id     = options.id,
       prefix = options.prefix || 'elem',

--- a/lib/provider/camunda/parts/implementation/External.js
+++ b/lib/provider/camunda/parts/implementation/External.js
@@ -3,7 +3,7 @@
 var entryFactory = require('../../../../factory/EntryFactory'),
     cmdHelper    = require('../../../../helper/CmdHelper');
 
-module.exports = function(element, bpmnFactory, options) {
+module.exports = function(element, bpmnFactory, options, translate) {
 
   var getImplementationType = options.getImplementationType,
       getBusinessObject     = options.getBusinessObject;
@@ -14,7 +14,7 @@ module.exports = function(element, bpmnFactory, options) {
 
   var topicEntry = entryFactory.textField({
     id: 'externalTopic',
-    label: 'Topic',
+    label: translate('Topic'),
     modelProperty: 'externalTopic',
 
     get: function(element, node) {

--- a/lib/provider/camunda/parts/implementation/ExternalTaskPriority.js
+++ b/lib/provider/camunda/parts/implementation/ExternalTaskPriority.js
@@ -4,13 +4,13 @@ var entryFactory = require('../../../../factory/EntryFactory');
 
 var cmdHelper = require('../../../../helper/CmdHelper');
 
-module.exports = function(element, bpmnFactory, options) {
+module.exports = function(element, bpmnFactory, options, translate) {
 
   var getBusinessObject = options.getBusinessObject;
 
   var externalTaskPriorityEntry = entryFactory.textField({
     id: 'externalTaskPriority',
-    label: 'Task Priority',
+    label: translate('Task Priority'),
     modelProperty: 'taskPriority',
 
     get: function(element, node) {

--- a/lib/provider/camunda/parts/implementation/FieldInjection.js
+++ b/lib/provider/camunda/parts/implementation/FieldInjection.js
@@ -22,20 +22,9 @@ var DEFAULT_PROPS = {
   'expression': undefined
 };
 
-var fieldTypeOptions = [
-  {
-    name: 'String',
-    value: 'string'
-  },
-  {
-    name: 'Expression',
-    value: 'expression'
-  }
-];
-
 var CAMUNDA_FIELD_EXTENSION_ELEMENT = 'camunda:Field';
 
-module.exports = function(element, bpmnFactory, options) {
+module.exports = function(element, bpmnFactory, options, translate) {
 
   options = options || {};
 
@@ -144,7 +133,7 @@ module.exports = function(element, bpmnFactory, options) {
 
   var fieldEntry = extensionElementsEntry(element, bpmnFactory, {
     id : idPrefix + 'fields',
-    label : 'Fields',
+    label : translate('Fields'),
     modelProperty: 'fieldName',
     idGeneration: 'false',
 
@@ -163,7 +152,7 @@ module.exports = function(element, bpmnFactory, options) {
 
   entries.push(entryFactory.validationAwareTextField({
     id: idPrefix + 'field-name',
-    label: 'Name',
+    label: translate('Name'),
     modelProperty: 'fieldName',
 
     getProperty: function(element, node) {
@@ -184,11 +173,11 @@ module.exports = function(element, bpmnFactory, options) {
 
         if (nameValue) {
           if (utils.containsSpace(nameValue)) {
-            validation.fieldName = 'Name must not contain spaces';
+            validation.fieldName = translate('Name must not contain spaces');
           }
         }
         else {
-          validation.fieldName = 'Parameter must have a name';
+          validation.fieldName = translate('Parameter must have a name');
         }
       }
 
@@ -201,10 +190,20 @@ module.exports = function(element, bpmnFactory, options) {
 
   }));
 
+  var fieldTypeOptions = [
+    {
+      name: translate('String'),
+      value: 'string'
+    },
+    {
+      name: translate('Expression'),
+      value: 'expression'
+    }
+  ];
 
   entries.push(entryFactory.selectBox({
     id: idPrefix + 'field-type',
-    label: 'Type',
+    label: translate('Type'),
     selectOptions: fieldTypeOptions,
     modelProperty: 'fieldType',
 
@@ -242,7 +241,7 @@ module.exports = function(element, bpmnFactory, options) {
 
   entries.push(entryFactory.textBox({
     id: idPrefix + 'field-value',
-    label: 'Value',
+    label: translate('Value'),
     modelProperty: 'fieldValue',
 
     get: function(element, node) {
@@ -288,7 +287,7 @@ module.exports = function(element, bpmnFactory, options) {
       var validation = {};
       if (bo) {
         if (!values.fieldValue) {
-          validation.fieldValue = 'Must provide a value';
+          validation.fieldValue = translate('Must provide a value');
         }
       }
 

--- a/lib/provider/camunda/parts/implementation/ImplementationType.js
+++ b/lib/provider/camunda/parts/implementation/ImplementationType.js
@@ -31,29 +31,29 @@ var EXTERNAL_CAPABLE_PROPS = {
   'camunda:topic': undefined
 };
 
-var DEFAULT_OPTIONS = [
-  { value: 'class', name: 'Java Class' },
-  { value: 'expression', name: 'Expression' },
-  { value: 'delegateExpression', name: 'Delegate Expression' }
-];
+module.exports = function(element, bpmnFactory, options, translate) {
 
-var DMN_OPTION = [
-  { value: 'dmn', name: 'DMN' }
-];
+  var DEFAULT_OPTIONS = [
+    { value: 'class', name: translate('Java Class') },
+    { value: 'expression', name: translate('Expression') },
+    { value: 'delegateExpression', name: translate('Delegate Expression') }
+  ];
 
-var EXTERNAL_OPTION = [
-  { value: 'external', name: 'External' }
-];
+  var DMN_OPTION = [
+    { value: 'dmn', name: translate('DMN') }
+  ];
 
-var CONNECTOR_OPTION = [
-  { value: 'connector', name: 'Connector' }
-];
+  var EXTERNAL_OPTION = [
+    { value: 'external', name: translate('External') }
+  ];
 
-var SCRIPT_OPTION = [
-  { value: 'script', name: 'Script' }
-];
+  var CONNECTOR_OPTION = [
+    { value: 'connector', name: translate('Connector') }
+  ];
 
-module.exports = function(element, bpmnFactory, options) {
+  var SCRIPT_OPTION = [
+    { value: 'script', name: translate('Script') }
+  ];
 
   var getType           = options.getImplementationType,
       getBusinessObject = options.getBusinessObject;
@@ -87,7 +87,7 @@ module.exports = function(element, bpmnFactory, options) {
 
   entries.push(entryFactory.selectBox({
     id : 'implementation',
-    label: 'Implementation',
+    label: translate('Implementation'),
     selectOptions: selectOptions,
     modelProperty: 'implType',
 

--- a/lib/provider/camunda/parts/implementation/InputOutput.js
+++ b/lib/provider/camunda/parts/implementation/InputOutput.js
@@ -56,13 +56,13 @@ function ensureOutparameterSupported(element, insideConnector) {
   return inputOutputHelper.areOutputParametersSupported(element, insideConnector);
 }
 
-var TYPE_LABEL = {
-  'camunda:Map': 'Map',
-  'camunda:List': 'List',
-  'camunda:Script': 'Script'
-};
+module.exports = function(element, bpmnFactory, options, translate) {
 
-module.exports = function(element, bpmnFactory, options) {
+  var TYPE_LABEL = {
+    'camunda:Map': translate('Map'),
+    'camunda:List': translate('List'),
+    'camunda:Script': translate('Script')
+  };
 
   options = options || {};
 
@@ -173,7 +173,7 @@ module.exports = function(element, bpmnFactory, options) {
 
   var inputEntry = extensionElementsEntry(element, bpmnFactory, {
     id: idPrefix + 'inputs',
-    label: 'Input Parameters',
+    label: translate('Input Parameters'),
     modelProperty: 'name',
     prefix: 'Input',
     resizable: true,
@@ -200,7 +200,7 @@ module.exports = function(element, bpmnFactory, options) {
   if (ensureOutparameterSupported(element, insideConnector)) {
     var outputEntry = extensionElementsEntry(element, bpmnFactory, {
       id: idPrefix + 'outputs',
-      label: 'Output Parameters',
+      label: translate('Output Parameters'),
       modelProperty: 'name',
       prefix: 'Output',
       resizable: true,

--- a/lib/provider/camunda/parts/implementation/InputOutputParameter.js
+++ b/lib/provider/camunda/parts/implementation/InputOutputParameter.js
@@ -31,22 +31,22 @@ function ensureInputOutputSupported(element, insideConnector) {
   return inputOutputHelper.isInputOutputSupported(element, insideConnector);
 }
 
-var typeInfo = {
-  'camunda:Map': {
-    value: 'map',
-    label: 'Map'
-  },
-  'camunda:List': {
-    value: 'list',
-    label: 'List'
-  },
-  'camunda:Script': {
-    value: 'script',
-    label: 'Script'
-  }
-};
+module.exports = function(element, bpmnFactory, options, translate) {
 
-module.exports = function(element, bpmnFactory, options) {
+  var typeInfo = {
+    'camunda:Map': {
+      value: 'map',
+      label: translate('Map')
+    },
+    'camunda:List': {
+      value: 'list',
+      label: translate('List')
+    },
+    'camunda:Script': {
+      value: 'script',
+      label: translate('Script')
+    }
+  };
 
   options = options || {};
 

--- a/lib/provider/camunda/parts/implementation/JobPriority.js
+++ b/lib/provider/camunda/parts/implementation/JobPriority.js
@@ -4,13 +4,13 @@ var entryFactory = require('../../../../factory/EntryFactory');
 
 var cmdHelper = require('../../../../helper/CmdHelper');
 
-module.exports = function(element, bpmnFactory, options) {
+module.exports = function(element, bpmnFactory, options, translate) {
 
   var getBusinessObject = options.getBusinessObject;
 
   var jobPriorityEntry = entryFactory.textField({
     id: 'jobPriority',
-    label: 'Job Priority',
+    label: translate('Job Priority'),
     modelProperty: 'jobPriority',
 
     get: function(element, node) {

--- a/lib/provider/camunda/parts/implementation/JobRetryTimeCycle.js
+++ b/lib/provider/camunda/parts/implementation/JobRetryTimeCycle.js
@@ -34,7 +34,7 @@ function createFailedJobRetryTimeCycle(parent, bpmnFactory, cycle) {
   return elementHelper.createElement('camunda:FailedJobRetryTimeCycle', { body: cycle }, parent, bpmnFactory);
 }
 
-module.exports = function(element, bpmnFactory, options) {
+module.exports = function(element, bpmnFactory, options, translate) {
 
   var getBusinessObject = options.getBusinessObject;
 
@@ -43,7 +43,7 @@ module.exports = function(element, bpmnFactory, options) {
 
   var retryTimeCycleEntry = entryFactory.textField({
     id: idPrefix + 'retryTimeCycle',
-    label: labelPrefix + 'Retry Time Cycle',
+    label: labelPrefix + translate('Retry Time Cycle'),
     modelProperty: 'cycle',
 
     get: function(element, node) {

--- a/lib/provider/camunda/parts/implementation/Listener.js
+++ b/lib/provider/camunda/parts/implementation/Listener.js
@@ -14,17 +14,17 @@ function getListeners(bo, type) {
   return bo && extensionElementsHelper.getExtensionElements(bo, type) || [];
 }
 
-var LISTENER_TYPE_LABEL = {
-  class: 'Java Class',
-  expression: 'Expression',
-  delegateExpression: 'Delegate Expression',
-  script: 'Script'
-};
-
 var CAMUNDA_EXECUTION_LISTENER_ELEMENT = 'camunda:ExecutionListener';
 var CAMUNDA_TASK_LISTENER_ELEMENT = 'camunda:TaskListener';
 
-module.exports = function(element, bpmnFactory, options) {
+module.exports = function(element, bpmnFactory, options, translate) {
+
+  var LISTENER_TYPE_LABEL = {
+    class: translate('Java Class'),
+    expression: translate('Expression'),
+    delegateExpression: translate('Delegate Expression'),
+    script: translate('Script')
+  };
 
   var bo;
 
@@ -98,7 +98,7 @@ module.exports = function(element, bpmnFactory, options) {
 
       var executionListenerEntry = extensionElementsEntry(element, bpmnFactory, {
         id : 'executionListeners',
-        label : 'Execution Listener',
+        label : translate('Execution Listener'),
         modelProperty: 'name',
         idGeneration: 'false',
         reference: 'processRef',
@@ -130,7 +130,7 @@ module.exports = function(element, bpmnFactory, options) {
 
     var taskListenerEntry = extensionElementsEntry(element, bpmnFactory, {
       id : 'taskListeners',
-      label : 'Task Listener',
+      label : translate('Task Listener'),
       modelProperty: 'name',
       idGeneration: 'false',
 

--- a/lib/provider/camunda/parts/implementation/MultiInstanceLoopCharacteristics.js
+++ b/lib/provider/camunda/parts/implementation/MultiInstanceLoopCharacteristics.js
@@ -162,7 +162,7 @@ function updateFormalExpression(element, propertyName, newValue, bpmnFactory) {
 }
 
 
-module.exports = function(element, bpmnFactory) {
+module.exports = function(element, bpmnFactory, translate) {
 
   var entries = [];
 
@@ -172,7 +172,7 @@ module.exports = function(element, bpmnFactory) {
     id: 'multiInstance-errorMessage',
     html: '<div data-show="isValid">' +
              '<span class="bpp-icon-warning"></span> ' +
-             'Must provide either loop cardinality or collection' +
+             translate('Must provide either loop cardinality or collection') +
           '</div>',
 
     isValid: function(element, node, notification, scope) {
@@ -197,7 +197,7 @@ module.exports = function(element, bpmnFactory) {
 
   entries.push(entryFactory.textField({
     id: 'multiInstance-loopCardinality',
-    label: 'Loop Cardinality',
+    label: translate('Loop Cardinality'),
     modelProperty: 'loopCardinality',
 
     get: function(element, node) {
@@ -216,7 +216,7 @@ module.exports = function(element, bpmnFactory) {
 
   entries.push(entryFactory.textField({
     id: 'multiInstance-collection',
-    label: 'Collection',
+    label: translate('Collection'),
     modelProperty: 'collection',
 
     get: function(element, node) {
@@ -247,7 +247,7 @@ module.exports = function(element, bpmnFactory) {
 
   entries.push(entryFactory.textField({
     id: 'multiInstance-elementVariable',
-    label: 'Element Variable',
+    label: translate('Element Variable'),
     modelProperty: 'elementVariable',
 
     get: function(element, node) {
@@ -269,7 +269,7 @@ module.exports = function(element, bpmnFactory) {
 
   entries.push(entryFactory.textField({
     id: 'multiInstance-completionCondition',
-    label: 'Completion Condition',
+    label: translate('Completion Condition'),
     modelProperty: 'completionCondition',
 
     get: function(element) {

--- a/lib/provider/camunda/parts/implementation/Properties.js
+++ b/lib/provider/camunda/parts/implementation/Properties.js
@@ -86,7 +86,7 @@ function isExtensionElements(element) {
  * @param  {function} options.getParent Gets the parent business object
  * @param  {function} options.show Indicate when the entry will be shown, should return boolean
  */
-module.exports = function(element, bpmnFactory, options) {
+module.exports = function(element, bpmnFactory, options, translate) {
 
   var getParent = options.getParent;
 
@@ -104,7 +104,7 @@ module.exports = function(element, bpmnFactory, options) {
   }
 
   assign(options, {
-    addLabel: 'Add Property',
+    addLabel: translate('Add Property'),
     getElements: function(element, node) {
       var parent = getParent(element, node, bo);
       return getPropertyValues(parent);

--- a/lib/provider/camunda/parts/implementation/ResultVariable.js
+++ b/lib/provider/camunda/parts/implementation/ResultVariable.js
@@ -7,7 +7,7 @@ var assign = require('lodash/object/assign');
 var entryFactory = require('../../../../factory/EntryFactory'),
     cmdHelper    = require('../../../../helper/CmdHelper');
 
-module.exports = function(element, bpmnFactory, options) {
+module.exports = function(element, bpmnFactory, options, translate) {
 
   var getBusinessObject     = options.getBusinessObject,
       hideResultVariable    = options.hideResultVariable,
@@ -16,7 +16,7 @@ module.exports = function(element, bpmnFactory, options) {
 
   var resultVariableEntry = entryFactory.textField({
     id: id,
-    label: 'Result Variable',
+    label: translate('Result Variable'),
     modelProperty: 'resultVariable',
 
     get: function(element, node) {


### PR DESCRIPTION
I migrated the localization part from diagram-js here according the commit mentioned in #207. I didn't include customized translate method and language files here. Below is a sample screenshot with the mechanism.

<img width="320" alt="zh-panel" src="https://cloud.githubusercontent.com/assets/724105/24637214/071d688c-1912-11e7-8158-62100a8f55c1.png">