### PR TITLE
feat(element-templates): Add Map and List type for inputParameter and outputParameter

### DIFF
--- a/lib/provider/camunda/element-templates/CreateHelper.js
+++ b/lib/provider/camunda/element-templates/CreateHelper.js
@@ -7,21 +7,55 @@
  * @param {PropertyBinding} binding
  * @param {String} value
  * @param {BpmnFactory} bpmnFactory
+ * @param {String} type
  *
  * @return {ModdleElement}
  */
-function createInputParameter(binding, value, bpmnFactory) {
+function createInputParameter(binding, value, bpmnFactory, type) {
   var scriptFormat = binding.scriptFormat,
       parameterValue,
       parameterDefinition;
 
-  if (scriptFormat) {
-    parameterDefinition = bpmnFactory.create('camunda:Script', {
+  if (type == 'Map') {
+
+    var entries = [];
+    if (value) {
+      value.forEach(function(item) {
+        entries.push(bpmnFactory.create('camunda:Entry', item));
+      });
+    }
+
+    parameterDefinition = bpmnFactory.create('camunda:Map', {
       scriptFormat: scriptFormat,
-      value: value
+      entries: entries
     });
-  } else {
-    parameterValue = value;
+  }
+  else if (type == 'List') {
+
+    var items = [];
+    if (value) {
+      value.forEach(function(item) {
+        items.push(bpmnFactory.create('camunda:Value', {
+          value: item
+        }));
+      });
+    }
+
+    parameterDefinition = bpmnFactory.create('camunda:List', {
+      scriptFormat: scriptFormat,
+      items: items
+    });
+
+  }
+  else {
+    if (scriptFormat) {
+      parameterDefinition = bpmnFactory.create('camunda:Script', {
+        scriptFormat: scriptFormat,
+        value: value
+      });
+    } else {
+      parameterValue = value;
+    }
   }
 
   return bpmnFactory.create('camunda:InputParameter', {
@@ -41,21 +75,55 @@ module.exports.createInputParameter = createInputParameter;
  * @param {PropertyBinding} binding
  * @param {String} value
  * @param {BpmnFactory} bpmnFactory
+ * @param {String} type
  *
  * @return {ModdleElement}
  */
-function createOutputParameter(binding, value, bpmnFactory) {
+function createOutputParameter(binding, value, bpmnFactory, type) {
   var scriptFormat = binding.scriptFormat,
       parameterValue,
       parameterDefinition;
 
-  if (scriptFormat) {
-    parameterDefinition = bpmnFactory.create('camunda:Script', {
+  if (type == 'Map') {
+
+    var entries = [];
+    if (value) {
+      value.forEach(function(item) {
+        entries.push(bpmnFactory.create('camunda:Entry', item));
+      });
+    }
+
+    parameterDefinition = bpmnFactory.create('camunda:Map', {
       scriptFormat: scriptFormat,
-      value: binding.source
+      entries: entries
     });
-  } else {
-    parameterValue = binding.source;
+  }
+  else if (type == 'List') {
+
+    var items = [];
+    if (value) {
+      value.forEach(function(item) {
+        items.push(bpmnFactory.create('camunda:Value', {
+          value: item
+        }));
+      });
+    }
+
+    parameterDefinition = bpmnFactory.create('camunda:List', {
+      scriptFormat: scriptFormat,
+      items: items
+    });
+
+  }
+  else {
+    if (scriptFormat) {
+      parameterDefinition = bpmnFactory.create('camunda:Script', {
+        scriptFormat: scriptFormat,
+        value: binding.source
+      });
+    } else {
+      parameterValue = binding.source;
+    }
   }
 
   return bpmnFactory.create('camunda:OutputParameter', {

--- a/lib/provider/camunda/element-templates/Validator.js
+++ b/lib/provider/camunda/element-templates/Validator.js
@@ -4,8 +4,10 @@ var isArray = require('lodash/lang/isArray');
 var isObject = require('lodash/lang/isObject');
 
 var DROPDOWN_TYPE = 'Dropdown';
+var LIST_TYPE = 'List';
+var MAP_TYPE = 'Map';
 
-var VALID_TYPES = [ 'String', 'Text', 'Boolean', 'Hidden', DROPDOWN_TYPE ];
+var VALID_TYPES = [ 'String', 'Text', 'Boolean', 'Hidden', DROPDOWN_TYPE, LIST_TYPE, MAP_TYPE ];
 
 var PROPERTY_TYPE = 'property',
     CAMUNDA_PROPERTY_TYPE = 'camunda:property',
@@ -209,6 +211,38 @@ function Validator() {
               'must be any of { ' + VALID_BINDING_TYPES.join(', ') + ' }');
     }
 
+    if (bindingType === CAMUNDA_INPUT_PARAMETER_TYPE
+        || bindingType === CAMUNDA_OUTPUT_PARAMETER_TYPE) {
+      if (type === MAP_TYPE) {
+        if (property.value) {
+          if (!isObject(property.value)) {
+            err = this._logError('must provide value={} with ' + MAP_TYPE + ' type');
+          } else
+
+          if (!property.value.every(isMapValueValid)) {
+            err = this._logError(
+              '{ key, value } must be specified for ' +
+              MAP_TYPE + ' value'
+            );
+          }
+        }
+      }
+      else if (type === LIST_TYPE) {
+        if (property.value) {
+          if (!isArray(property.value)) {
+            err = this._logError('must provide value=[] with ' + LIST_TYPE + ' type');
+          } else
+
+          if (!property.value.every(isListValueValid)) {
+            err = this._logError(
+              '[ string, ] must be specified for ' +
+              LIST_TYPE + ' value'
+            );
+          }
+        }
+      }
+    }
+
     if (bindingType === PROPERTY_TYPE ||
         bindingType === CAMUNDA_PROPERTY_TYPE ||
         bindingType === CAMUNDA_INPUT_PARAMETER_TYPE) {
@@ -288,4 +322,12 @@ module.exports = Validator;
 
 function isDropdownChoiceValid(c) {
   return 'name' in c && 'value' in c;
+}
+
+function isMapValueValid(c) {
+  return 'key' in c && 'value' in c;
+}
+
+function isListValueValid(c) {
+  return !isArray(c) && !isObject(c);
 }

--- a/lib/provider/camunda/element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/lib/provider/camunda/element-templates/cmd/ChangeElementTemplateHandler.js
@@ -349,13 +349,13 @@ function createInputOutputMappings(template, bpmnFactory) {
 
     if (bindingType === 'camunda:inputParameter') {
       inputParameters.push(createInputParameter(
-        binding, p.value, bpmnFactory
+        binding, p.value, bpmnFactory, p.type
       ));
     }
 
     if (bindingType === 'camunda:outputParameter') {
       outputParameters.push(createOutputParameter(
-        binding, p.value, bpmnFactory
+        binding, p.value, bpmnFactory, p.type
       ));
     }
   });

--- a/test/spec/provider/camunda/element-templates/ValidatorSpec.js
+++ b/test/spec/provider/camunda/element-templates/ValidatorSpec.js
@@ -202,7 +202,7 @@ describe('element-templates - Validator', function() {
 
     // then
     expect(errors(templates)).to.eql([
-      'invalid property type <InvalidType>; must be any of { String, Text, Boolean, Hidden, Dropdown }',
+      'invalid property type <InvalidType>; must be any of { String, Text, Boolean, Hidden, Dropdown, List, Map }',
       'invalid property.binding type <alsoInvalid>; must be any of { ' +
         'property, camunda:property, camunda:inputParameter, ' +
         'camunda:outputParameter, camunda:in, camunda:out, camunda:in:businessKey, camunda:executionListener }'
@@ -273,6 +273,78 @@ describe('element-templates - Validator', function() {
   });
 
 
+  it('should reject invalid map value', function() {
+
+    // given
+    var templates = new Validator();
+
+    var templateDescriptors = require('./fixtures/error-map-value-invalid');
+
+    // when
+    templates.addAll(templateDescriptors);
+
+    // then
+    expect(errors(templates)).to.eql([
+      '{ key, value } must be specified for Map value'
+    ]);
+
+    expect(valid(templates)).to.be.empty;
+  });
+
+
+  it('should accept map example template', function() {
+
+    // given
+    var templates = new Validator();
+
+    var templateDescriptors = require('./fixtures/map');
+
+    // when
+    templates.addAll(templateDescriptors);
+
+    // then
+    expect(errors(templates)).to.be.empty;
+
+    expect(valid(templates)).to.have.length(1);
+  });
+
+
+  it('should reject invalid list value', function() {
+
+    // given
+    var templates = new Validator();
+
+    var templateDescriptors = require('./fixtures/error-list-value-invalid');
+
+    // when
+    templates.addAll(templateDescriptors);
+
+    // then
+    expect(errors(templates)).to.eql([
+      '[ string, ] must be specified for List value'
+    ]);
+
+    expect(valid(templates)).to.be.empty;
+  });
+
+
+  it('should accept list example template', function() {
+
+    // given
+    var templates = new Validator();
+
+    var templateDescriptors = require('./fixtures/list');
+
+    // when
+    templates.addAll(templateDescriptors);
+
+    // then
+    expect(errors(templates)).to.be.empty;
+
+    expect(valid(templates)).to.have.length(1);
+  });
+
+
   it('should reject invalid scopes type', function() {
 
     // given
@@ -336,7 +408,7 @@ describe('element-templates - Validator', function() {
 
     // then
     expect(errors(templates)).to.eql([
-      'invalid property type <InvalidType>; must be any of { String, Text, Boolean, Hidden, Dropdown }',
+      'invalid property type <InvalidType>; must be any of { String, Text, Boolean, Hidden, Dropdown, List, Map }',
       'invalid property.binding type <alsoInvalid>; must be any of { ' +
         'property, camunda:property, camunda:inputParameter, ' +
         'camunda:outputParameter, camunda:in, camunda:out, camunda:in:businessKey, camunda:executionListener }'

--- a/test/spec/provider/camunda/element-templates/cmd/ChangeElementTemplateHandlerSpec.js
+++ b/test/spec/provider/camunda/element-templates/cmd/ChangeElementTemplateHandlerSpec.js
@@ -208,6 +208,42 @@ describe('element-templates - cmd', function() {
             $type: 'camunda:InputParameter',
             name: 'hiddenField',
             value: 'SECRET'
+          },
+          {
+            $type: 'camunda:InputParameter',
+            name: 'copyRecipients',
+            definition: {
+              $type: 'camunda:List',
+              items: [
+                {
+                  $type: 'camunda:Value',
+                  value: 'user1@test.com'
+                },
+                {
+                  $type: 'camunda:Value',
+                  value: 'user2@test.com'
+                }
+              ]
+            }
+          },
+          {
+            $type: 'camunda:InputParameter',
+            name: 'headers',
+            definition: {
+              $type: 'camunda:Map',
+              entries: [
+                {
+                  $type: 'camunda:Entry',
+                  key: 'X-Mailer',
+                  value: 'Thunderbird'
+                },
+                {
+                  $type: 'camunda:Entry',
+                  key: 'DKIM-Signature',
+                  value: 'v=1; ...'
+                }
+              ]
+            }
           }
         ]);
 
@@ -748,6 +784,42 @@ describe('element-templates - cmd', function() {
             $type: 'camunda:InputParameter',
             name: 'hiddenField',
             value: 'SECRET'
+          },
+          {
+            $type: 'camunda:InputParameter',
+            name: 'copyRecipients',
+            definition: {
+              $type: 'camunda:List',
+              items: [
+                {
+                  $type: 'camunda:Value',
+                  value: 'user1@test.com'
+                },
+                {
+                  $type: 'camunda:Value',
+                  value: 'user2@test.com'
+                }
+              ]
+            }
+          },
+          {
+            $type: 'camunda:InputParameter',
+            name: 'headers',
+            definition: {
+              $type: 'camunda:Map',
+              entries: [
+                {
+                  $type: 'camunda:Entry',
+                  key: 'X-Mailer',
+                  value: 'Thunderbird'
+                },
+                {
+                  $type: 'camunda:Entry',
+                  key: 'DKIM-Signature',
+                  value: 'v=1; ...'
+                }
+              ]
+            }
           }
         ]);
 

--- a/test/spec/provider/camunda/element-templates/cmd/mail-task.json
+++ b/test/spec/provider/camunda/element-templates/cmd/mail-task.json
@@ -50,6 +50,28 @@
         "type": "camunda:inputParameter",
         "name": "hiddenField"
       }
+    },
+    {
+      "type": "List",
+      "value": [
+        "user1@test.com",
+        "user2@test.com"
+      ],
+      "binding": {
+        "type": "camunda:inputParameter",
+        "name": "copyRecipients"
+      }
+    },
+    {
+      "type": "Map",
+      "value": [
+        { "key": "X-Mailer", "value": "Thunderbird" },
+        { "key": "DKIM-Signature", "value": "v=1; ..." }
+      ],
+      "binding": {
+        "type": "camunda:inputParameter",
+        "name": "headers"
+      }
     }
   ]
 }

--- a/test/spec/provider/camunda/element-templates/fixtures/error-list-value-invalid.json
+++ b/test/spec/provider/camunda/element-templates/fixtures/error-list-value-invalid.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "Task",
+    "id": "bar",
+    "appliesTo": [
+      "bpmn:UserTask"
+    ],
+    "properties": [
+      {
+        "label": "FOO",
+        "type": "List",
+        "value": [
+          "Low",
+          "Medium",
+          [ "High" ]
+        ],
+        "binding": {
+          "type": "camunda:inputParameter",
+          "name": "headers"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/provider/camunda/element-templates/fixtures/error-map-value-invalid.json
+++ b/test/spec/provider/camunda/element-templates/fixtures/error-map-value-invalid.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "Task",
+    "id": "bar",
+    "appliesTo": [
+      "bpmn:UserTask"
+    ],
+    "properties": [
+      {
+        "label": "FOO",
+        "type": "Map",
+        "value": [
+          { "key": "low", "x": "50" },
+          { "key": "medium", "value": "100" },
+          { "key": "high", "value": "150" }
+        ],
+        "binding": {
+          "type": "camunda:inputParameter",
+          "name": "headers"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/provider/camunda/element-templates/fixtures/list.json
+++ b/test/spec/provider/camunda/element-templates/fixtures/list.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "Task",
+    "id": "bar",
+    "appliesTo": [
+      "bpmn:UserTask"
+    ],
+    "properties": [
+      {
+        "label": "FOO",
+        "type": "List",
+        "value": [
+          "Low",
+          "Medium",
+          "High"
+        ],
+        "binding": {
+          "type": "camunda:inputParameter",
+          "name": "headers"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/provider/camunda/element-templates/fixtures/map.json
+++ b/test/spec/provider/camunda/element-templates/fixtures/map.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "Task",
+    "id": "bar",
+    "appliesTo": [
+      "bpmn:UserTask"
+    ],
+    "properties": [
+      {
+        "label": "FOO",
+        "type": "Map",
+        "value": [
+          { "key": "low", "value": "50" },
+          { "key": "medium", "value": "100" },
+          { "key": "high", "value": "150" }
+        ],
+        "binding": {
+          "type": "camunda:inputParameter",
+          "name": "headers"
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Issue: https://github.com/camunda/camunda-modeler/issues/497

- [x] Users are able to configure Maps as a type for input/output mappings
- [ ] The modeler displays an editor for key/values configured as part of the map similar to the map editor in 

Not ready to merge.
There is missing the list and map editor in the panel

