### PR TITLE
Export setPropertyValue from element templates helpers

### DIFF
--- a/lib/provider/camunda/element-templates/parts/CustomProps.js
+++ b/lib/provider/camunda/element-templates/parts/CustomProps.js
@@ -662,6 +662,8 @@ function setPropertyValue(element, property, value, bpmnFactory) {
   console.warn('no update', element, property, value);
 }
 
+module.exports.setPropertyValue = setPropertyValue;
+
 /**
  * Validate value of a given property.
  *


### PR DESCRIPTION
### Proposed Changes

I'm creating my own properties panel in React with element template support. It is backed by these core getters and setters. `getPropertyValue` is already exported whilst `setPropertyValue` is not. This just exports the setter so it can be used directly if needed.