### PR TITLE
fix(PropertiesPanel): activate first tab when active tab was removed

### DIFF
--- a/lib/PropertiesPanel.js
+++ b/lib/PropertiesPanel.js
@@ -424,6 +424,12 @@ PropertiesPanel.prototype.activateTab = function(tab) {
 
     domClasses(tabLinkNode).toggle('bpp-active', tabId === currentTabId);
   });
+
+  // verify that the activate tab was found, otherwise activate the first tab
+  var activeTabNode = domQuery('.bpp-properties-tab.bpp-active', panelNode);
+  if (!activeTabNode && current.tabs.length > 0) {
+    this.activateTab(current.tabs[0]);
+  }
 };
 
 /**


### PR DESCRIPTION
Fixes an issue where the panel was activating a tab that was removed; in case the saved active tab doesn't exists, activate the first tab.