### PR TITLE
Show correct name properties

### DIFF
--- a/lib/helper/CategoryHelper.js
+++ b/lib/helper/CategoryHelper.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var collectionAdd = require('diagram-js/lib/util/Collections').add,
+    getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
+
+var CategoryHelper = {};
+
+module.exports = CategoryHelper;
+
+/**
+ * Creates a new bpmn:CategoryValue inside a new bpmn:Category
+ *
+ * @param {ModdleElement} definitions
+ * @param {BpmnFactory} bpmnFactory
+ *
+ * @return {ModdleElement} categoryValue.
+ */
+CategoryHelper.createCategoryValue = function(definitions, bpmnFactory) {
+  var categoryValue = bpmnFactory.create('bpmn:CategoryValue'),
+      category = bpmnFactory.create('bpmn:Category', {
+        categoryValue: [ categoryValue ]
+      });
+
+  // add to correct place
+  collectionAdd(definitions.get('rootElements'), category);
+  getBusinessObject(category).$parent = definitions;
+  getBusinessObject(categoryValue).$parent = category;
+
+  return categoryValue;
+
+};

--- a/lib/provider/bpmn/BpmnPropertiesProvider.js
+++ b/lib/provider/bpmn/BpmnPropertiesProvider.js
@@ -13,7 +13,9 @@ var processProps = require('./parts/ProcessProps'),
     nameProps = require('./parts/NameProps'),
     executableProps = require('./parts/ExecutableProps');
 
-function createGeneralTabGroups(element, bpmnFactory, elementRegistry, translate) {
+function createGeneralTabGroups(
+    element, canvas, bpmnFactory,
+    elementRegistry, translate) {
 
   var generalGroup = {
     id: 'general',
@@ -21,7 +23,7 @@ function createGeneralTabGroups(element, bpmnFactory, elementRegistry, translate
     entries: []
   };
   idProps(generalGroup, element, translate);
-  nameProps(generalGroup, element, translate);
+  nameProps(generalGroup, element, bpmnFactory, canvas, translate);
   processProps(generalGroup, element, translate);
   executableProps(generalGroup, element, translate);
 
@@ -49,7 +51,8 @@ function createGeneralTabGroups(element, bpmnFactory, elementRegistry, translate
 
 }
 
-function BpmnPropertiesProvider(eventBus, bpmnFactory, elementRegistry, translate) {
+function BpmnPropertiesProvider(
+    eventBus, canvas, bpmnFactory, elementRegistry, translate) {
 
   PropertiesActivator.call(this, eventBus);
 
@@ -58,7 +61,8 @@ function BpmnPropertiesProvider(eventBus, bpmnFactory, elementRegistry, translat
     var generalTab = {
       id: 'general',
       label: translate('General'),
-      groups: createGeneralTabGroups(element, bpmnFactory, elementRegistry, translate)
+      groups: createGeneralTabGroups(
+        element, canvas, bpmnFactory, elementRegistry, translate)
     };
 
     return [
@@ -67,7 +71,13 @@ function BpmnPropertiesProvider(eventBus, bpmnFactory, elementRegistry, translat
   };
 }
 
-BpmnPropertiesProvider.$inject = [ 'eventBus', 'bpmnFactory', 'elementRegistry', 'translate' ];
+BpmnPropertiesProvider.$inject = [
+  'eventBus',
+  'canvas',
+  'bpmnFactory',
+  'elementRegistry',
+  'translate'
+];
 
 inherits(BpmnPropertiesProvider, PropertiesActivator);
 

--- a/lib/provider/bpmn/parts/NameProps.js
+++ b/lib/provider/bpmn/parts/NameProps.js
@@ -9,7 +9,7 @@ module.exports = function(group, element, translate) {
 
     var options;
     if (is(element, 'bpmn:TextAnnotation')) {
-      options = { modelProperty: 'text' };
+      options = { modelProperty: 'text', label: 'Text' };
     }
 
     // name

--- a/lib/provider/bpmn/parts/NameProps.js
+++ b/lib/provider/bpmn/parts/NameProps.js
@@ -1,15 +1,58 @@
 'use strict';
 
 var nameEntryFactory = require('./implementation/Name'),
-    is = require('bpmn-js/lib/util/ModelUtil').is;
+    createCategoryValue = require('../../../helper/CategoryHelper').createCategoryValue,
+    is = require('bpmn-js/lib/util/ModelUtil').is,
+    getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
 
-module.exports = function(group, element, translate) {
+module.exports = function(group, element, bpmnFactory, canvas, translate) {
+
+  function initializeCategory(semantic) {
+    var rootElement = canvas.getRootElement(),
+        definitions = getBusinessObject(rootElement).$parent,
+        categoryValue = createCategoryValue(definitions, bpmnFactory);
+
+    semantic.categoryValueRef = categoryValue;
+
+  }
+
+  function setGroupName(element, values) {
+    var bo = getBusinessObject(element),
+        categoryValueRef = bo.categoryValueRef;
+
+    if (!categoryValueRef) {
+      initializeCategory(bo);
+    }
+
+    // needs direct call to update categoryValue properly
+    return {
+      cmd: 'element.updateLabel',
+      context: {
+        element: element,
+        newLabel: values.categoryValue
+      }
+    };
+  }
+
+  function getGroupName(element) {
+    var bo = getBusinessObject(element),
+        value = (bo.categoryValueRef || {}).value;
+
+    return { categoryValue: value };
+  }
 
   if (!is(element, 'bpmn:Collaboration')) {
 
     var options;
     if (is(element, 'bpmn:TextAnnotation')) {
-      options = { modelProperty: 'text', label: 'Text' };
+      options = { modelProperty: 'text', label: translate('Text') };
+    } else if (is(element, 'bpmn:Group')) {
+      options = {
+        modelProperty: 'categoryValue',
+        label: translate('Category Value'),
+        get: getGroupName,
+        set: setGroupName
+      };
     }
 
     // name

--- a/lib/provider/bpmn/parts/implementation/Name.js
+++ b/lib/provider/bpmn/parts/implementation/Name.js
@@ -23,7 +23,9 @@ module.exports = function(element, options, translate) {
   var nameEntry = entryFactory.textBox({
     id: id,
     label: label,
-    modelProperty: modelProperty
+    modelProperty: modelProperty,
+    get: options.get,
+    set: options.set
   });
 
   return [ nameEntry ];

--- a/lib/provider/camunda/CamundaPropertiesProvider.js
+++ b/lib/provider/camunda/CamundaPropertiesProvider.js
@@ -139,7 +139,9 @@ var getListenerLabel = function(param, translate) {
 var PROCESS_KEY_HINT = 'This maps to the process definition key.';
 var TASK_KEY_HINT = 'This maps to the task definition key.';
 
-function createGeneralTabGroups(element, bpmnFactory, elementRegistry, elementTemplates, translate) {
+function createGeneralTabGroups(
+    element, canvas, bpmnFactory,
+    elementRegistry, elementTemplates, translate) {
 
   // refer to target element for external labels
   element = element.labelTarget || element;
@@ -166,7 +168,7 @@ function createGeneralTabGroups(element, bpmnFactory, elementRegistry, elementTe
   }
 
   idProps(generalGroup, element, translate, idOptions);
-  nameProps(generalGroup, element, translate);
+  nameProps(generalGroup, element, bpmnFactory, canvas, translate);
   processProps(generalGroup, element, translate, processOptions);
   versionTag(generalGroup, element, translate);
   executableProps(generalGroup, element, translate);
@@ -437,11 +439,15 @@ function createExtensionElementsGroups(element, bpmnFactory, elementRegistry, tr
  * A properties provider for Camunda related properties.
  *
  * @param {EventBus} eventBus
+ * @param {Canvas} canvas
  * @param {BpmnFactory} bpmnFactory
  * @param {ElementRegistry} elementRegistry
  * @param {ElementTemplates} elementTemplates
+ * @param {Translate} translate
  */
-function CamundaPropertiesProvider(eventBus, bpmnFactory, elementRegistry, elementTemplates, translate) {
+function CamundaPropertiesProvider(
+    eventBus, canvas, bpmnFactory,
+    elementRegistry, elementTemplates, translate) {
 
   PropertiesActivator.call(this, eventBus);
 
@@ -451,7 +457,7 @@ function CamundaPropertiesProvider(eventBus, bpmnFactory, elementRegistry, eleme
       id: 'general',
       label: translate('General'),
       groups: createGeneralTabGroups(
-        element, bpmnFactory,
+        element, canvas, bpmnFactory,
         elementRegistry, elementTemplates, translate)
     };
 
@@ -522,6 +528,7 @@ function CamundaPropertiesProvider(eventBus, bpmnFactory, elementRegistry, eleme
 
 CamundaPropertiesProvider.$inject = [
   'eventBus',
+  'canvas',
   'bpmnFactory',
   'elementRegistry',
   'elementTemplates',

--- a/test/spec/provider/bpmn/ElementName.bpmn
+++ b/test/spec/provider/bpmn/ElementName.bpmn
@@ -16,8 +16,9 @@
     <bpmn:task id="FOUR_LINES" name="a&#10;b&#10;c&#10;d" />
     <bpmn:task id="ONE_LINE" name="a" />
     <bpmn:textAnnotation id="TEXTANNOTATION_WITH_NAME">    <bpmn:text>text for name</bpmn:text>
-</bpmn:textAnnotation>
+    </bpmn:textAnnotation>
     <bpmn:association id="Association_10y192l" sourceRef="TASK_WITHOUT_NAME" targetRef="TEXTANNOTATION_WITH_NAME" />
+    <bpmn:group id="GROUP" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -57,12 +58,18 @@
         <dc:Bounds x="354" y="353" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_11kvt4v_di" bpmnElement="TEXTANNOTATION_WITH_NAME">
-        <dc:Bounds x="539" y="101" width="100" height="38" />
+        <dc:Bounds x="592" y="120" width="100" height="38" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Association_10y192l_di" bpmnElement="Association_10y192l">
-        <di:waypoint xsi:type="dc:Point" x="502" y="213" />
-        <di:waypoint xsi:type="dc:Point" x="571" y="139" />
+        <di:waypoint x="514" y="222" />
+        <di:waypoint x="613" y="158" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Group_di" bpmnElement="GROUP">
+        <dc:Bounds x="180" y="105" width="188" height="154" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="200" y="113" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/spec/provider/bpmn/ElementNameSpec.js
+++ b/test/spec/provider/bpmn/ElementNameSpec.js
@@ -67,7 +67,7 @@ describe('element-name-properties', function() {
 
   describe('change name', function() {
 
-    var container, element, nameField;
+    var container, element, nameField, label;
 
     beforeEach(inject(function(propertiesPanel) {
       container = propertiesPanel._container;
@@ -302,9 +302,11 @@ describe('element-name-properties', function() {
         element = getBusinessObject(shape);
 
         nameField = domQuery('div[name=text]', getEntry(container, 'name'));
+        label = domQuery('label[for=camunda-name]', getEntry(container, 'name'));
 
         expect(element.text).to.equal('text for name');
         expect(nameField.textContent).to.equal('text for name');
+        expect(label.textContent).to.equal('Text');
 
         // when
         TestHelper.triggerValue(nameField, 'foo', 'change');

--- a/test/spec/provider/bpmn/ElementNameSpec.js
+++ b/test/spec/provider/bpmn/ElementNameSpec.js
@@ -370,6 +370,108 @@ describe('element-name-properties', function() {
 
     });
 
+    describe('of a group', function() {
+
+      var categoryValueRef;
+
+      beforeEach(inject(function(elementRegistry, selection) {
+        // given
+        var shape = elementRegistry.get('GROUP');
+        selection.select(shape);
+
+        element = getBusinessObject(shape);
+
+        // assure
+        expect(element.categoryValueRef).to.not.exist;
+
+        nameField = domQuery('div[name=categoryValue]', getEntry(container, 'name'));
+        label = domQuery('label[for=camunda-name]', getEntry(container, 'name'));
+
+        // when
+        TestHelper.triggerValue(nameField, 'foo', 'change');
+
+        categoryValueRef = element.categoryValueRef;
+
+      }));
+
+      it('should initialize category value if needed', inject(function(canvas) {
+        // then
+        var rootElement = canvas.getRootElement(),
+            definitons = getBusinessObject(rootElement).$parent;
+
+        expect(categoryValueRef).to.exist;
+        expect(categoryValueRef.value).to.equal('foo');
+
+        expect(categoryValueRef.$parent).to.exist;
+        expect(definitons.get('rootElements')).to.include(categoryValueRef.$parent);
+
+      }));
+
+
+      it('should have correct label', function() {
+        // then
+        expect(label.textContent).to.equal('Category Value');
+      });
+
+
+      describe('in the DOM', function() {
+
+        it('should execute', function() {
+          // then
+          expect(nameField.textContent).to.equal('foo');
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+          // when
+          commandStack.undo();
+
+          // then
+          expect(nameField.textContent).to.equal('');
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expect(nameField.textContent).to.equal('foo');
+        }));
+
+      });
+
+
+      describe('on the business object', function() {
+
+        it('should execute', function() {
+          // then
+          expect(categoryValueRef.value).to.equal('foo');
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+          // when
+          commandStack.undo();
+
+          // then
+          expect(categoryValueRef.value).to.equal('');
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expect(categoryValueRef.value).to.equal('foo');
+        }));
+
+      });
+    });
+
   });
 
 


### PR DESCRIPTION
Fixes #278 

* Show correct name-labels for `bpmn:TextAnnotation` (Text) and `bpmn:Group` (Category Value)
* Make `bpmn:CategoryValue` for `bpmn:Group` editable in properties panel
* Initializes `bpmn:CategoryValue` if needed, via `CategoryHelper` (depends on  https://github.com/bpmn-io/bpmn-js/pull/1040)