### PR TITLE
fix(styles): do not restrict container height

### DIFF
--- a/styles/groups.less
+++ b/styles/groups.less
@@ -1,7 +1,6 @@
 .bpp-properties-group {
   padding: 6px 15px 6px 15px;
   position: relative;
-  max-height: 2000px;
   overflow: hidden;
   transition: max-height 0.218s ease-in-out,
               padding-top 0.218s ease-in-out,


### PR DESCRIPTION
This pull request removes a CSS rule that has no obvious benefits and results in hidden entries if there are a lot of them.

Related to #282

Support: https://app.camunda.com/jira/browse/SUPPORT-5085