### PR TITLE
feat(variable-mapping): show target variable name

### DIFF
--- a/lib/provider/camunda/parts/VariableMappingProps.js
+++ b/lib/provider/camunda/parts/VariableMappingProps.js
@@ -110,14 +110,14 @@ module.exports = function(group, element, bpmnFactory, translate) {
 
   var setOptionLabelValue = function(type) {
     return function(element, node, option, property, value, idx) {
-      var label = idx + ' : ';
+      var label = (mappingValue.target || '<undefined>') + ' := ';
 
       var variableMappings = getVariableMappings(element, type);
       var mappingValue = variableMappings[idx];
       var mappingType = getInOutType(mappingValue);
 
       if (mappingType === 'variables') {
-        label = label + 'all';
+        label = 'all';
       }
       else if (mappingType === 'source') {
         label = label + (mappingValue.source || '<empty>');


### PR DESCRIPTION
### Proposed Changes

- Show target variable names instead of the index in the lists of defined variable mappings.

The index that is currently displayed is just reflecting the order in the XML and therefore meaningless for users and process engine. The target value instead is important to see which variables are set in e.g. a child or parent process. For example the current implementation would show `0 : ${true}`. The changed code would display it as `myVar := ${true}`. The current implementation forces users to click on each entry in the list in order to see the target variable names.