### PR TITLE
feat(usertask): add hint about task definition key

### DIFF
--- a/lib/provider/camunda/CamundaPropertiesProvider.js
+++ b/lib/provider/camunda/CamundaPropertiesProvider.js
@@ -137,6 +137,7 @@ var getListenerLabel = function(param, translate) {
 };
 
 var PROCESS_KEY_HINT = 'This maps to the process definition key.';
+var TASK_KEY_HINT = 'This maps to the task definition key.';
 
 function createGeneralTabGroups(element, bpmnFactory, elementRegistry, elementTemplates, translate) {
 
@@ -154,6 +155,10 @@ function createGeneralTabGroups(element, bpmnFactory, elementRegistry, elementTe
 
   if (is(element, 'bpmn:Process')) {
     idOptions = { description: PROCESS_KEY_HINT };
+  }
+
+  if (is(element, 'bpmn:UserTask')) {
+    idOptions = { description: TASK_KEY_HINT };
   }
 
   if (is(element, 'bpmn:Participant')) {


### PR DESCRIPTION
<!--

Thanks for filing a pull request!

Make sure you've read through [our contributing guide](https://github.com/bpmn-io/bpmn-js/blob/master/CONTRIBUTING.md#creating-a-pull-request) before you continue.

-->

### Proposed Changes

* Add a hint that a user task's BPMN id maps to the Task Definition Key in the Java API.