### PR TITLE
Localize literals, which are not yet localized.

### DIFF
--- a/lib/factory/EntryFactory.js
+++ b/lib/factory/EntryFactory.js
@@ -125,7 +125,7 @@ EntryFactory.validationAwareTextField = function(options) {
  *
  * - get: getter method - Function
  *
- * - validate: validation mehtod - Function
+ * - validate: validation method - Function
  *
  * - modelProperty: name of the model property - String
  *

--- a/lib/provider/bpmn/parts/EventProps.js
+++ b/lib/provider/bpmn/parts/EventProps.js
@@ -33,11 +33,11 @@ module.exports = function(group, element, bpmnFactory, elementRegistry, translat
           signalEventDefinition = eventDefinitionHelper.getSignalEventDefinition(element);
 
       if (messageEventDefinition) {
-        message(group, element, bpmnFactory, messageEventDefinition);
+        message(group, element, bpmnFactory, messageEventDefinition, translate);
       }
 
       if (signalEventDefinition) {
-        signal(group, element, bpmnFactory, signalEventDefinition);
+        signal(group, element, bpmnFactory, signalEventDefinition, translate);
       }
 
     }
@@ -45,7 +45,7 @@ module.exports = function(group, element, bpmnFactory, elementRegistry, translat
 
   // Special Case: Receive Task
   if (is(element, 'bpmn:ReceiveTask')) {
-    message(group, element, bpmnFactory, getBusinessObject(element));
+    message(group, element, bpmnFactory, getBusinessObject(element), translate);
   }
 
   // Error Event Definition
@@ -66,7 +66,8 @@ module.exports = function(group, element, bpmnFactory, elementRegistry, translat
         var showErrorCodeVariable = isCatchingErrorEvent,
             showErrorMessageVariable = isCatchingErrorEvent;
 
-        error(group, element, bpmnFactory, errorEventDefinition, showErrorCodeVariable, showErrorMessageVariable);
+        error(group, element, bpmnFactory, errorEventDefinition, showErrorCodeVariable, showErrorMessageVariable,
+          translate);
       }
     }
   });
@@ -88,7 +89,8 @@ module.exports = function(group, element, bpmnFactory, elementRegistry, translat
       var escalationEventDefinition = eventDefinitionHelper.getEscalationEventDefinition(element);
 
       if (escalationEventDefinition) {
-        escalation(group, element, bpmnFactory, escalationEventDefinition, showEscalationCodeVariable);
+        escalation(group, element, bpmnFactory, escalationEventDefinition, showEscalationCodeVariable,
+          translate);
       }
     }
 
@@ -108,7 +110,7 @@ module.exports = function(group, element, bpmnFactory, elementRegistry, translat
       var timerEventDefinition = eventDefinitionHelper.getTimerEventDefinition(element);
 
       if (timerEventDefinition) {
-        timer(group, element, bpmnFactory, timerEventDefinition);
+        timer(group, element, bpmnFactory, timerEventDefinition, translate);
       }
     }
   });
@@ -126,13 +128,13 @@ module.exports = function(group, element, bpmnFactory, elementRegistry, translat
       var compensateEventDefinition = eventDefinitionHelper.getCompensateEventDefinition(element);
 
       if (compensateEventDefinition) {
-        compensation(group, element, bpmnFactory, compensateEventDefinition, elementRegistry);
+        compensation(group, element, bpmnFactory, compensateEventDefinition, elementRegistry, translate);
       }
     }
   });
 
 
-  // Conditional Event Defintion
+  // Conditional Event Definition
   var conditionalEvents = [
     'bpmn:StartEvent',
     'bpmn:BoundaryEvent',
@@ -146,7 +148,7 @@ module.exports = function(group, element, bpmnFactory, elementRegistry, translat
     var conditionalEventDefinition = eventDefinitionHelper.getConditionalEventDefinition(element);
 
     if (conditionalEventDefinition) {
-      condition(group, element, bpmnFactory, conditionalEventDefinition, elementRegistry);
+      condition(group, element, bpmnFactory, conditionalEventDefinition, elementRegistry, translate);
     }
   }
 

--- a/lib/provider/bpmn/parts/implementation/CompensateEventDefinition.js
+++ b/lib/provider/bpmn/parts/implementation/CompensateEventDefinition.js
@@ -85,11 +85,11 @@ function createActivityRefOptions(element) {
 }
 
 
-module.exports = function(group, element, bpmnFactory, compensateEventDefinition, elementRegistry) {
+module.exports = function(group, element, bpmnFactory, compensateEventDefinition, elementRegistry, translate) {
 
   group.entries.push(entryFactory.checkbox({
     id: 'wait-for-completion',
-    label: 'Wait for Completion',
+    label: translate('Wait for Completion'),
     modelProperty: 'waitForCompletion',
 
     get: function(element, node) {
@@ -106,7 +106,7 @@ module.exports = function(group, element, bpmnFactory, compensateEventDefinition
 
   group.entries.push(entryFactory.selectBox({
     id: 'activity-ref',
-    label: 'Activity Ref',
+    label: translate('Activity Ref'),
     selectOptions: createActivityRefOptions(element),
     modelProperty: 'activityRef',
 

--- a/lib/provider/bpmn/parts/implementation/ConditionalEventDefinition.js
+++ b/lib/provider/bpmn/parts/implementation/ConditionalEventDefinition.js
@@ -6,7 +6,7 @@ var entryFactory = require('../../../../factory/EntryFactory'),
 var is = require('bpmn-js/lib/util/ModelUtil').is,
     isEventSubProcess = require('bpmn-js/lib/util/DiUtil').isEventSubProcess;
 
-module.exports = function(group, element, bpmnFactory, conditionalEventDefinition) {
+module.exports = function(group, element, bpmnFactory, conditionalEventDefinition, elementRegistry, translate) {
 
   var getValue = function(modelProperty) {
     return function(element) {
@@ -29,8 +29,8 @@ module.exports = function(group, element, bpmnFactory, conditionalEventDefinitio
   };
 
   group.entries.push(entryFactory.textField({
-    id : 'variableName',
-    label : 'Variable Name',
+    id: 'variableName',
+    label: translate('Variable Name'),
     modelProperty : 'variableName',
 
     get: getValue('variableName'),
@@ -42,9 +42,9 @@ module.exports = function(group, element, bpmnFactory, conditionalEventDefinitio
 
   if (!isConditionalStartEvent) {
     group.entries.push(entryFactory.textField({
-      id : 'variableEvent',
-      label : 'Variable Event',
-      description: 'Specify more than one variable change event as a comma separated list.',
+      id: 'variableEvent',
+      label: translate('Variable Event'),
+      description: translate('Specify more than one variable change event as a comma separated list.'),
       modelProperty : 'variableEvent',
 
       get: getValue('variableEvent'),

--- a/lib/provider/bpmn/parts/implementation/ErrorEventDefinition.js
+++ b/lib/provider/bpmn/parts/implementation/ErrorEventDefinition.js
@@ -8,7 +8,7 @@ var eventDefinitionReference = require('./EventDefinitionReference'),
 
 
 module.exports = function(group, element, bpmnFactory, errorEventDefinition, showErrorCodeVariable,
-    showErrorMessageVariable) {
+    showErrorMessageVariable, translate) {
 
 
   var getValue = function(modelProperty) {
@@ -33,7 +33,7 @@ module.exports = function(group, element, bpmnFactory, errorEventDefinition, sho
 
 
   group.entries = group.entries.concat(eventDefinitionReference(element, errorEventDefinition, bpmnFactory, {
-    label: 'Error',
+    label: translate('Error'),
     elementName: 'error',
     elementType: 'bpmn:Error',
     referenceProperty: 'errorRef',
@@ -43,7 +43,7 @@ module.exports = function(group, element, bpmnFactory, errorEventDefinition, sho
 
   group.entries = group.entries.concat(elementReferenceProperty(element, errorEventDefinition, bpmnFactory, {
     id: 'error-element-name',
-    label: 'Error Name',
+    label: translate('Error Name'),
     referenceProperty: 'errorRef',
     modelProperty: 'name',
     shouldValidate: true
@@ -52,7 +52,7 @@ module.exports = function(group, element, bpmnFactory, errorEventDefinition, sho
 
   group.entries = group.entries.concat(elementReferenceProperty(element, errorEventDefinition, bpmnFactory, {
     id: 'error-element-code',
-    label: 'Error Code',
+    label: translate('Error Code'),
     referenceProperty: 'errorRef',
     modelProperty: 'errorCode'
   }));
@@ -60,8 +60,8 @@ module.exports = function(group, element, bpmnFactory, errorEventDefinition, sho
 
   if (showErrorCodeVariable) {
     group.entries.push(entryFactory.textField({
-      id : 'errorCodeVariable',
-      label : 'Error Code Variable',
+      id: 'errorCodeVariable',
+      label: translate('Error Code Variable'),
       modelProperty : 'errorCodeVariable',
 
       get: getValue('errorCodeVariable'),
@@ -71,9 +71,9 @@ module.exports = function(group, element, bpmnFactory, errorEventDefinition, sho
 
   if (showErrorMessageVariable) {
     group.entries.push(entryFactory.textField({
-      id : 'errorMessageVariable',
-      label : 'Error Message Variable',
-      modelProperty : 'errorMessageVariable',
+      id: 'errorMessageVariable',
+      label: translate('Error Message Variable'),
+      modelProperty: 'errorMessageVariable',
 
       get: getValue('errorMessageVariable'),
       set: setValue('errorMessageVariable')

--- a/lib/provider/bpmn/parts/implementation/EscalationEventDefinition.js
+++ b/lib/provider/bpmn/parts/implementation/EscalationEventDefinition.js
@@ -7,10 +7,10 @@ var eventDefinitionReference = require('./EventDefinitionReference'),
     elementReferenceProperty = require('./ElementReferenceProperty');
 
 
-module.exports = function(group, element, bpmnFactory, escalationEventDefinition, showEscalationCodeVariable) {
+module.exports = function(group, element, bpmnFactory, escalationEventDefinition, showEscalationCodeVariable, translate) {
 
   group.entries = group.entries.concat(eventDefinitionReference(element, escalationEventDefinition, bpmnFactory, {
-    label: 'Escalation',
+    label: translate('Escalation'),
     elementName: 'escalation',
     elementType: 'bpmn:Escalation',
     referenceProperty: 'escalationRef',
@@ -20,7 +20,7 @@ module.exports = function(group, element, bpmnFactory, escalationEventDefinition
 
   group.entries = group.entries.concat(elementReferenceProperty(element, escalationEventDefinition, bpmnFactory, {
     id: 'escalation-element-name',
-    label: 'Escalation Name',
+    label: translate('Escalation Name'),
     referenceProperty: 'escalationRef',
     modelProperty: 'name',
     shouldValidate: true
@@ -29,7 +29,7 @@ module.exports = function(group, element, bpmnFactory, escalationEventDefinition
 
   group.entries = group.entries.concat(elementReferenceProperty(element, escalationEventDefinition, bpmnFactory, {
     id: 'escalation-element-code',
-    label: 'Escalation Code',
+    label: translate('Escalation Code'),
     referenceProperty: 'escalationRef',
     modelProperty: 'escalationCode'
   }));
@@ -38,7 +38,7 @@ module.exports = function(group, element, bpmnFactory, escalationEventDefinition
   if (showEscalationCodeVariable) {
     group.entries.push(entryFactory.textField({
       id : 'escalationCodeVariable',
-      label : 'Escalation Code Variable',
+      label : translate('Escalation Code Variable'),
       modelProperty : 'escalationCodeVariable',
 
       get: function(element) {

--- a/lib/provider/bpmn/parts/implementation/MessageEventDefinition.js
+++ b/lib/provider/bpmn/parts/implementation/MessageEventDefinition.js
@@ -4,10 +4,10 @@ var eventDefinitionReference = require('./EventDefinitionReference'),
     elementReferenceProperty = require('./ElementReferenceProperty');
 
 
-module.exports = function(group, element, bpmnFactory, messageEventDefinition) {
+module.exports = function(group, element, bpmnFactory, messageEventDefinition, translate) {
 
   group.entries = group.entries.concat(eventDefinitionReference(element, messageEventDefinition, bpmnFactory, {
-    label: 'Message',
+    label: translate('Message'),
     elementName: 'message',
     elementType: 'bpmn:Message',
     referenceProperty: 'messageRef',
@@ -17,7 +17,7 @@ module.exports = function(group, element, bpmnFactory, messageEventDefinition) {
 
   group.entries = group.entries.concat(elementReferenceProperty(element, messageEventDefinition, bpmnFactory, {
     id: 'message-element-name',
-    label: 'Message Name',
+    label: translate('Message Name'),
     referenceProperty: 'messageRef',
     modelProperty: 'name',
     shouldValidate: true

--- a/lib/provider/bpmn/parts/implementation/SignalEventDefinition.js
+++ b/lib/provider/bpmn/parts/implementation/SignalEventDefinition.js
@@ -4,10 +4,10 @@ var eventDefinitionReference = require('./EventDefinitionReference'),
     elementReferenceProperty = require('./ElementReferenceProperty');
 
 
-module.exports = function(group, element, bpmnFactory, signalEventDefinition) {
+module.exports = function(group, element, bpmnFactory, signalEventDefinition, translate) {
 
   group.entries = group.entries.concat(eventDefinitionReference(element, signalEventDefinition, bpmnFactory, {
-    label: 'Signal',
+    label: translate('Signal'),
     elementName: 'signal',
     elementType: 'bpmn:Signal',
     referenceProperty: 'signalRef',
@@ -17,7 +17,7 @@ module.exports = function(group, element, bpmnFactory, signalEventDefinition) {
 
   group.entries = group.entries.concat(elementReferenceProperty(element, signalEventDefinition, bpmnFactory, {
     id: 'signal-element-name',
-    label: 'Signal Name',
+    label: translate('Signal Name'),
     referenceProperty: 'signalRef',
     modelProperty: 'name',
     shouldValidate: true

--- a/lib/provider/bpmn/parts/implementation/TimerEventDefinition.js
+++ b/lib/provider/bpmn/parts/implementation/TimerEventDefinition.js
@@ -43,17 +43,17 @@ function createFormalExpression(parent, body, bpmnFactory) {
   return elementHelper.createElement('bpmn:FormalExpression', { body: body }, parent, bpmnFactory);
 }
 
-function TimerEventDefinition(group, element, bpmnFactory, timerEventDefinition) {
+function TimerEventDefinition(group, element, bpmnFactory, timerEventDefinition, translate) {
 
   var selectOptions = [
-    { value: 'timeDate', name: 'Date' },
-    { value: 'timeDuration', name: 'Duration' },
-    { value: 'timeCycle', name: 'Cycle' }
+    { value: 'timeDate', name: translate('Date') },
+    { value: 'timeDuration', name: translate('Duration') },
+    { value: 'timeCycle', name: translate('Cycle') }
   ];
 
   group.entries.push(entryFactory.selectBox({
     id: 'timer-event-definition-type',
-    label: 'Timer Definition Type',
+    label: translate('Timer Definition Type'),
     selectOptions: selectOptions,
     emptyParameter: true,
     modelProperty: 'timerDefinitionType',
@@ -92,7 +92,7 @@ function TimerEventDefinition(group, element, bpmnFactory, timerEventDefinition)
 
   group.entries.push(entryFactory.textField({
     id: 'timer-event-definition',
-    label: 'Timer Definition',
+    label: translate('Timer Definition'),
     modelProperty: 'timerDefinition',
 
     get: function(element, node) {
@@ -122,7 +122,7 @@ function TimerEventDefinition(group, element, bpmnFactory, timerEventDefinition)
         var value = definition.get('body');
         if (!value) {
           return {
-            timerDefinition: 'Must provide a value'
+            timerDefinition: translate('Must provide a value')
           };
         }
       }

--- a/lib/provider/camunda/element-templates/parts/ChooserProps.js
+++ b/lib/provider/camunda/element-templates/parts/ChooserProps.js
@@ -18,7 +18,7 @@ function isAny(element, types) {
 
 module.exports = function(group, element, elementTemplates, translate) {
 
-  var options = getTemplateOptions(element, elementTemplates);
+  var options = getTemplateOptions(element, elementTemplates, translate);
 
   if (options.length === 1 && !options[0].isDefault) {
     return;
@@ -72,7 +72,7 @@ function applyTemplate(element, newTemplateId, elementTemplates) {
   };
 }
 
-function getTemplateOptions(element, elementTemplates) {
+function getTemplateOptions(element, elementTemplates, translate) {
 
   var currentTemplateId = getTemplateId(element);
 
@@ -87,7 +87,7 @@ function getTemplateOptions(element, elementTemplates) {
     }
 
     return templates.concat({
-      name: t.name,
+      name: translate(t.name),
       value: t.id,
       isDefault: t.isDefault
     });
@@ -103,7 +103,7 @@ function getTemplateOptions(element, elementTemplates) {
   });
 
   if (currentTemplateId && !currentOption) {
-    currentOption = unknownTemplate(currentTemplateId);
+    currentOption = unknownTemplate(currentTemplateId, translate);
 
     allOptions.push(currentOption);
   }
@@ -139,9 +139,9 @@ function getTemplateOptions(element, elementTemplates) {
   return options;
 }
 
-function unknownTemplate(templateId) {
+function unknownTemplate(templateId, translate) {
   return {
-    name: '[unknown template: ' + templateId + ']',
+    name: translate('[unknown template: {templateId}]', { templateId: templateId }),
     value: templateId
   };
 }

--- a/lib/provider/camunda/element-templates/parts/CustomProps.js
+++ b/lib/provider/camunda/element-templates/parts/CustomProps.js
@@ -62,10 +62,10 @@ var IN_OUT_BINDING_TYPES = [
 /**
  * Injects custom properties into the given group.
  *
- * @param {GroupDescriptor} group
  * @param {djs.model.Base} element
  * @param {ElementTemplates} elementTemplates
  * @param {BpmnFactory} bpmnFactory
+ * @param {Function} translate
  */
 module.exports = function(element, elementTemplates, bpmnFactory, translate) {
 
@@ -81,11 +81,11 @@ module.exports = function(element, elementTemplates, bpmnFactory, translate) {
     var entryOptions = {
       id: id,
       description: p.description,
-      label: p.label,
+      label: p.label ? translate(p.label) : p.label,
       modelProperty: id,
       get: propertyGetter(id, p),
       set: propertySetter(id, p, bpmnFactory),
-      validate: propertyValidator(id, p)
+      validate: propertyValidator(id, p, translate)
     };
 
     var entry;
@@ -212,16 +212,17 @@ function propertySetter(name, property, bpmnFactory) {
  *
  * @param {String} name
  * @param {PropertyDescriptor} property
+ * @param {Function} translate
  *
  * @return {Function}
  */
-function propertyValidator(name, property) {
+function propertyValidator(name, property, translate) {
 
   /* validator */
   return function validate(element, values) {
     var value = values[name];
 
-    var error = validateValue(value, property);
+    var error = validateValue(value, property, translate);
 
     if (error) {
       return objectWithKey(name, error);
@@ -669,23 +670,24 @@ module.exports.setPropertyValue = setPropertyValue;
  *
  * @param {String} value
  * @param {PropertyDescriptor} property
+ * @param {Function} translate
  *
  * @return {Object} with validation errors
  */
-function validateValue(value, property) {
+function validateValue(value, property, translate) {
 
   var constraints = property.constraints || {};
 
   if (constraints.notEmpty && isEmpty(value)) {
-    return 'Must not be empty';
+    return translate('Must not be empty');
   }
 
   if (constraints.maxLength && value.length > constraints.maxLength) {
-    return 'Must have max length ' + constraints.maxLength;
+    return translate('Must have max length {length}', { length: constraints.maxLength });
   }
 
   if (constraints.minLength && value.length < constraints.minLength) {
-    return 'Must have min length ' + constraints.minLength;
+    return translate('Must have min length {length}', { length: constraints.minLength });
   }
 
   var pattern = constraints.pattern,
@@ -699,7 +701,7 @@ function validateValue(value, property) {
     }
 
     if (!matchesPattern(value, pattern)) {
-      return message || 'Must match pattern ' + pattern;
+      return message || translate('Must match pattern {pattern}', { pattern: pattern });
     }
   }
 }

--- a/lib/provider/camunda/parts/ConditionalProps.js
+++ b/lib/provider/camunda/parts/ConditionalProps.js
@@ -7,7 +7,7 @@ var is = require('bpmn-js/lib/util/ModelUtil').is,
     cmdHelper = require('../../../helper/CmdHelper'),
     elementHelper = require('../../../helper/ElementHelper'),
     eventDefinitionHelper = require('../../../helper/EventDefinitionHelper'),
-    script = require('./implementation/Script')('language', 'body', true);
+    scriptImplementation = require('./implementation/Script');
 
 
 module.exports = function(group, element, bpmnFactory, translate) {
@@ -24,6 +24,7 @@ module.exports = function(group, element, bpmnFactory, translate) {
     return;
   }
 
+  var script = scriptImplementation('language', 'body', true, translate);
   group.entries.push({
     id: 'condition',
     label: translate('Condition'),
@@ -126,7 +127,7 @@ module.exports = function(group, element, bpmnFactory, translate) {
       var validationResult = {};
 
       if (!values.condition && values.conditionType === 'expression') {
-        validationResult.condition = 'Must provide a value';
+        validationResult.condition = translate('Must provide a value');
       }
       else if (values.conditionType === 'script') {
         validationResult = script.validate(element, values);

--- a/lib/provider/camunda/parts/ListenerDetailProps.js
+++ b/lib/provider/camunda/parts/ListenerDetailProps.js
@@ -5,17 +5,17 @@ var entryFactory = require('../../../factory/EntryFactory');
 var cmdHelper = require('../../../helper/CmdHelper'),
     ImplementationTypeHelper = require('../../../helper/ImplementationTypeHelper'),
 
-    script = require('./implementation/Script')('scriptFormat', 'value', true);
+    scriptImplementation = require('./implementation/Script');
 
-
-var LISTENER_TYPE_LABEL = {
-  class: 'Java Class',
-  expression: 'Expression',
-  delegateExpression: 'Delegate Expression',
-  script: 'Script'
-};
 
 module.exports = function(group, element, bpmnFactory, options, translate) {
+
+  var LISTENER_TYPE_LABEL = {
+    class: translate('Java Class'),
+    expression: translate('Expression'),
+    delegateExpression: translate('Delegate Expression'),
+    script: translate('Script')
+  };
 
   options = options || {};
 
@@ -27,17 +27,17 @@ module.exports = function(group, element, bpmnFactory, options, translate) {
       scriptProp = 'script';
 
   var executionListenerEventTypeOptions = ImplementationTypeHelper.isSequenceFlow(element) ? [
-    { name: 'take', value: 'take' }
+    { name: translate('take'), value: 'take' }
   ] : [
-    { name: 'start', value: 'start' },
-    { name: 'end', value: 'end' }
+    { name: translate('start'), value: 'start' },
+    { name: translate('end'), value: 'end' }
   ];
 
   var taskListenerEventTypeOptions = [
-    { name: 'create', value: 'create' },
-    { name: 'assignment', value: 'assignment' },
-    { name: 'complete', value: 'complete' },
-    { name: 'delete', value: 'delete' }
+    { name: translate('create'), value: 'create' },
+    { name: translate('assignment'), value: 'assignment' },
+    { name: translate('complete'), value: 'complete' },
+    { name: translate('delete'), value: 'delete' }
   ];
 
   var isSelected = function(element, node) {
@@ -172,6 +172,7 @@ module.exports = function(group, element, bpmnFactory, options, translate) {
 
   }));
 
+  var script = scriptImplementation('scriptFormat', 'value', true, translate);
 
   group.entries.push({
     id: 'listener-script-value',

--- a/lib/provider/camunda/parts/ScriptTaskProps.js
+++ b/lib/provider/camunda/parts/ScriptTaskProps.js
@@ -4,7 +4,7 @@ var getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject,
     is = require('bpmn-js/lib/util/ModelUtil').is,
     entryFactory = require('../../../factory/EntryFactory'),
     cmdHelper = require('../../../helper/CmdHelper'),
-    script = require('./implementation/Script')('scriptFormat', 'script', false);
+    scriptImplementation = require('./implementation/Script');
 
 
 module.exports = function(group, element, bpmnFactory, translate) {
@@ -18,6 +18,7 @@ module.exports = function(group, element, bpmnFactory, translate) {
     return;
   }
 
+  var script = scriptImplementation('scriptFormat', 'script', false, translate);
   group.entries.push({
     id: 'script-implementation',
     label: translate('Script'),

--- a/lib/provider/camunda/parts/ServiceTaskDelegateProps.js
+++ b/lib/provider/camunda/parts/ServiceTaskDelegateProps.js
@@ -125,7 +125,7 @@ module.exports = function(group, element, bpmnFactory, translate) {
         if (connectorId) {
           link.textContent = translate('Configure Connector');
         } else {
-          link.innerHTML = '<span class="bpp-icon-warning"></span> Must configure Connector';
+          link.innerHTML = '<span class="bpp-icon-warning"></span> ' + translate('Must configure Connector');
           domClasses(link).add('bpp-error-message');
         }
 

--- a/lib/provider/camunda/parts/VariableMappingProps.js
+++ b/lib/provider/camunda/parts/VariableMappingProps.js
@@ -15,22 +15,6 @@ var extensionElementsEntry = require('./implementation/ExtensionElements');
 
 var entryFactory = require('../../../factory/EntryFactory');
 
-
-var inOutTypeOptions = [
-  {
-    name: 'Source',
-    value: 'source'
-  },
-  {
-    name: 'Source Expression',
-    value: 'sourceExpression'
-  },
-  {
-    name: 'All',
-    value: 'variables'
-  }
-];
-
 /**
   * return depend on parameter 'type' camunda:in or camunda:out extension elements
   */
@@ -77,6 +61,22 @@ var WHITESPACE_REGEX = /\s/;
 
 
 module.exports = function(group, element, bpmnFactory, translate) {
+
+  var inOutTypeOptions = [
+    {
+      name: translate('Source'),
+      value: 'source'
+    },
+    {
+      name: translate('Source Expression'),
+      value: 'sourceExpression'
+    },
+    {
+      name: translate('All'),
+      value: 'variables'
+    }
+  ];
+
   var signalEventDefinition = eventDefinitionHelper.getSignalEventDefinition(element);
 
   if (!is(element, 'camunda:CallActivity') && !signalEventDefinition) {
@@ -281,10 +281,10 @@ module.exports = function(group, element, bpmnFactory, translate) {
       var label = '';
       var inOutType = getInOutType(mapping);
       if (inOutType === 'source') {
-        label = 'Source';
+        label = translate('Source');
       }
       else if (inOutType === 'sourceExpression') {
-        label = 'Source Expression';
+        label = translate('Source Expression');
       }
 
       return {
@@ -313,13 +313,15 @@ module.exports = function(group, element, bpmnFactory, translate) {
       if (mapping) {
         if (!values.source) {
           validation.source =
-            'Mapping must have a ' + (values.sourceLabel.toLowerCase() || 'value');
+          validation.source = values.sourceLabel ?
+            translate('Mapping must have a {value}', { value: values.sourceLabel.toLowerCase() }) :
+            translate('Mapping must have a value');
         }
 
         var inOutType = getInOutType(mapping);
 
         if (WHITESPACE_REGEX.test(values.source) && inOutType !== 'sourceExpression') {
-          validation.source = values.sourceLabel + ' must not contain whitespace';
+          validation.source = translate('{label} must not contain whitespace', { label: values.sourceLabel });
         }
       }
 
@@ -354,13 +356,13 @@ module.exports = function(group, element, bpmnFactory, translate) {
         var mappingType = getInOutType(mapping);
 
         if (!values.target && mappingType !== 'variables') {
-          validation.target = 'Mapping must have a target';
+          validation.target = translate('Mapping must have a target');
         }
 
         if (values.target
           && WHITESPACE_REGEX.test(values.target)
           && mappingType !== 'variables') {
-          validation.target = 'Target must not contain whitespace';
+          validation.target = translate('Target must not contain whitespace');
         }
       }
 

--- a/lib/provider/camunda/parts/implementation/Callable.js
+++ b/lib/provider/camunda/parts/implementation/Callable.js
@@ -38,25 +38,6 @@ var attributeInfo = {
   }
 };
 
-var bindingOptions = [
-  {
-    name: 'latest',
-    value: 'latest'
-  },
-  {
-    name: 'deployment',
-    value: 'deployment'
-  },
-  {
-    name: 'version',
-    value: 'version'
-  },
-  {
-    name: 'versionTag',
-    value: 'versionTag'
-  }
-];
-
 var mapDecisionResultOptions = [
   {
     name: 'singleEntry (TypedValue)',
@@ -154,6 +135,25 @@ function isSupportedCallableType(type) {
 
 module.exports = function(element, bpmnFactory, options, translate) {
 
+  var bindingOptions = [
+    {
+      name: translate('latest'),
+      value: 'latest'
+    },
+    {
+      name: translate('deployment'),
+      value: 'deployment'
+    },
+    {
+      name: translate('version'),
+      value: 'version'
+    },
+    {
+      name: translate('versionTag'),
+      value: 'versionTag'
+    }
+  ];
+
   var getCallableType = options.getCallableType;
 
   var entries = [];
@@ -234,7 +234,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
     validate: function(element, values, node) {
       var elementRef = values.callableElementRef;
       var type = getCallableType(element);
-      return isSupportedCallableType(type) && !elementRef ? { callableElementRef: 'Must provide a value.' } : {};
+      return isSupportedCallableType(type) && !elementRef ? { callableElementRef: translate('Must provide a value') } : {};
     },
 
     hidden: function(element, node) {
@@ -248,14 +248,16 @@ module.exports = function(element, bpmnFactory, options, translate) {
     label: translate('Binding'),
     selectOptions: function(element) {
       var type = getCallableType(element);
+      var options;
 
       if (type === 'cmmn') {
-        return bindingOptions.filter(function(bindingOption) {
+        options = bindingOptions.filter(function(bindingOption) {
           return bindingOption.value !== 'versionTag';
         });
       } else {
-        return bindingOptions;
+        options = bindingOptions;
       }
+      return options;
     },
     modelProperty: 'callableBinding',
 
@@ -331,7 +333,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
       return (
         isSupportedCallableType(type) &&
         getCallActivityBindingValue(element) === 'version' && (
-          !version ? { callableVersion: translate('Must provide a value.') } : {}
+          !version ? { callableVersion: translate('Must provide a value') } : {}
         )
       );
     },
@@ -384,7 +386,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
       return (
         isSupportedCallableType(type) &&
         getCallActivityBindingValue(element) === 'versionTag' && (
-          !versionTag ? { versionTag: translate('Must provide a value.') } : {}
+          !versionTag ? { versionTag: translate('Must provide a value') } : {}
         )
       );
     },
@@ -483,7 +485,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
     validate: function(element, values, node) {
       var businessKey = values.businessKey;
 
-      return businessKey === '' ? { businessKey: 'Must provide a value.' } : {};
+      return businessKey === '' ? { businessKey: translate('Must provide a value') } : {};
     },
 
     hidden: function(element, node) {
@@ -608,7 +610,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
       var delegateVariableMapping = values.delegateVariableMapping;
       return (
         getCallableType(element) === 'bpmn' && (
-          !delegateVariableMapping ? { delegateVariableMapping: translate('Must provide a value.') } : {}
+          !delegateVariableMapping ? { delegateVariableMapping: translate('Must provide a value') } : {}
         )
       );
     },

--- a/lib/provider/camunda/parts/implementation/CandidateStarter.js
+++ b/lib/provider/camunda/parts/implementation/CandidateStarter.js
@@ -12,7 +12,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
     id: 'candidateStarterGroups',
     label: translate('Candidate Starter Groups'),
     modelProperty: 'candidateStarterGroups',
-    description: 'Specify more than one group as a comma separated list.',
+    description: translate('Specify more than one group as a comma separated list.'),
 
     get: function(element, node) {
       var bo = getBusinessObject(element);
@@ -36,7 +36,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
     id: 'candidateStarterUsers',
     label: translate('Candidate Starter Users'),
     modelProperty: 'candidateStarterUsers',
-    description: 'Specify more than one user as a comma separated list.',
+    description: translate('Specify more than one user as a comma separated list.'),
 
     get: function(element, node) {
       var bo = getBusinessObject(element);

--- a/lib/provider/camunda/parts/implementation/Delegate.js
+++ b/lib/provider/camunda/parts/implementation/Delegate.js
@@ -69,7 +69,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
     },
 
     validate: function(element, values, node) {
-      return isDelegate(getImplementationType(element)) && !values.delegate ? { delegate: 'Must provide a value' } : {};
+      return isDelegate(getImplementationType(element)) && !values.delegate ? { delegate: translate('Must provide a value') } : {};
     },
 
     hidden: function(element, node) {

--- a/lib/provider/camunda/parts/implementation/External.js
+++ b/lib/provider/camunda/parts/implementation/External.js
@@ -30,7 +30,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
     },
 
     validate: function(element, values, node) {
-      return isExternal(element) && !values.externalTopic ? { externalTopic: 'Must provide a value' } : {};
+      return isExternal(element) && !values.externalTopic ? { externalTopic: translate('Must provide a value') } : {};
     },
 
     hidden: function(element, node) {

--- a/lib/provider/camunda/parts/implementation/InputOutputParameter.js
+++ b/lib/provider/camunda/parts/implementation/InputOutputParameter.js
@@ -8,7 +8,7 @@ var elementHelper = require('../../../../helper/ElementHelper'),
     utils = require('../../../../Utils');
 
 var entryFactory = require('../../../../factory/EntryFactory'),
-    script = require('./Script')('scriptFormat', 'value', true);
+    scriptImplementation = require('./Script');
 
 
 function createElement(type, parent, factory, properties) {
@@ -70,7 +70,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
 
   entries.push(entryFactory.validationAwareTextField({
     id: idPrefix + 'parameterName',
-    label: 'Name',
+    label: translate('Name'),
     modelProperty: 'name',
 
     getProperty: function(element, node) {
@@ -91,10 +91,10 @@ module.exports = function(element, bpmnFactory, options, translate) {
 
         if (nameValue) {
           if (utils.containsSpace(nameValue)) {
-            validation.name = 'Name must not contain spaces';
+            validation.name = translate('Name must not contain spaces');
           }
         } else {
-          validation.name = 'Parameter must have a name';
+          validation.name = translate('Parameter must have a name');
         }
       }
 
@@ -110,15 +110,15 @@ module.exports = function(element, bpmnFactory, options, translate) {
   // parameter type //////////////////////////////////////////////////////
 
   var selectOptions = [
-    { value: 'text', name: 'Text' },
-    { value: 'script', name: 'Script' },
-    { value: 'list', name: 'List' },
-    { value: 'map', name: 'Map' }
+    { value: 'text', name: translate('Text') },
+    { value: 'script', name: translate('Script') },
+    { value: 'list', name: translate('List') },
+    { value: 'map', name: translate('Map') }
   ];
 
   entries.push(entryFactory.selectBox({
     id : idPrefix + 'parameterType',
-    label: 'Type',
+    label: translate('Type'),
     selectOptions: selectOptions,
     modelProperty: 'parameterType',
 
@@ -178,7 +178,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
 
   entries.push(entryFactory.textBox({
     id : idPrefix + 'parameterType-text',
-    label : 'Value',
+    label : translate('Value'),
     modelProperty: 'value',
     get: function(element, node) {
       return {
@@ -201,7 +201,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
 
 
   // parameter value (type = script) ///////////////////////////////////////////////////////
-
+  var script = scriptImplementation('scriptFormat', 'value', true, translate);
   entries.push({
     id: idPrefix + 'parameterType-script',
     html: '<div data-show="isScript">' +
@@ -238,7 +238,8 @@ module.exports = function(element, bpmnFactory, options, translate) {
   entries.push(entryFactory.table({
     id: idPrefix + 'parameterType-list',
     modelProperties: [ 'value' ],
-    labels: [ 'Value' ],
+    labels: [ translate('Value') ],
+    addLabel: translate('Add Value'),
 
     getElements: function(element, node) {
       var bo = getSelected(element, node);
@@ -297,8 +298,8 @@ module.exports = function(element, bpmnFactory, options, translate) {
   entries.push(entryFactory.table({
     id: idPrefix + 'parameterType-map',
     modelProperties: [ 'key', 'value' ],
-    labels: [ 'Key', 'Value' ],
-    addLabel: 'Add Entry',
+    labels: [ translate('Key'), translate('Value') ],
+    addLabel: translate('Add Entry'),
 
     getElements: function(element, node) {
       var bo = getSelected(element, node);

--- a/lib/provider/camunda/parts/implementation/Script.js
+++ b/lib/provider/camunda/parts/implementation/Script.js
@@ -10,12 +10,12 @@ function getScriptType(node) {
 }
 
 
-module.exports = function(scriptLanguagePropName, scriptValuePropName, isFormatRequired) {
+module.exports = function(scriptLanguagePropName, scriptValuePropName, isFormatRequired, translate) {
 
   return {
     template:
     '<div class="bpp-row bpp-textfield">' +
-      '<label for="cam-script-format">Script Format</label>' +
+      '<label for="cam-script-format">' + translate('Script Format') + '</label>' +
       '<div class="bpp-field-wrapper">' +
         '<input id="cam-script-format" type="text" name="scriptFormat" />' +
         '<button class="clear" data-action="script.clearScriptFormat" data-show="script.canClearScriptFormat">' +
@@ -25,17 +25,17 @@ module.exports = function(scriptLanguagePropName, scriptValuePropName, isFormatR
     '</div>' +
 
     '<div class="bpp-row">' +
-      '<label for="cam-script-type">Script Type</label>' +
+      '<label for="cam-script-type">' + translate('Script Type') + '</label>' +
       '<div class="bpp-field-wrapper">' +
         '<select id="cam-script-type" name="scriptType" data-value>' +
-          '<option value="script" selected>Inline Script</option>' +
-          '<option value="scriptResource">External Resource</option>' +
+          '<option value="script" selected>' + translate('Inline Script') + '</option>' +
+          '<option value="scriptResource">' + translate('External Resource') + '</option>' +
         '</select>' +
       '</div>' +
     '</div>' +
 
     '<div class="bpp-row bpp-textfield">' +
-      '<label for="cam-script-resource-val" data-show="script.isScriptResource">Resource</label>' +
+      '<label for="cam-script-resource-val" data-show="script.isScriptResource">' + translate('Resource') + '</label>' +
       '<div class="bpp-field-wrapper" data-show="script.isScriptResource">' +
         '<input id="cam-script-resource-val" type="text" name="scriptResourceValue" />' +
         '<button class="clear" data-action="script.clearScriptResource" data-show="script.canClearScriptResource">' +
@@ -45,7 +45,7 @@ module.exports = function(scriptLanguagePropName, scriptValuePropName, isFormatR
     '</div>' +
 
     '<div class="bpp-row">' +
-      '<label for="cam-script-val" data-show="script.isScript">Script</label>' +
+      '<label for="cam-script-val" data-show="script.isScript">' + translate('Script') + '</label>' +
       '<div class="bpp-field-wrapper" data-show="script.isScript">' +
         '<textarea id="cam-script-val" type="text" name="scriptValue"></textarea>' +
       '</div>'+
@@ -108,15 +108,15 @@ module.exports = function(scriptLanguagePropName, scriptValuePropName, isFormatR
       var validationResult = {};
 
       if (values.scriptType === 'script' && !values.scriptValue) {
-        validationResult.scriptValue = 'Must provide a value';
+        validationResult.scriptValue = translate('Must provide a value');
       }
 
       if (values.scriptType === 'scriptResource' && !values.scriptResourceValue) {
-        validationResult.scriptResourceValue = 'Must provide a value';
+        validationResult.scriptResourceValue = translate('Must provide a value');
       }
 
       if (isFormatRequired && (!values.scriptFormat || values.scriptFormat.length === 0)) {
-        validationResult.scriptFormat = 'Must provide a value';
+        validationResult.scriptFormat = translate('Must provide a value');
       }
 
       return validationResult;


### PR DESCRIPTION
- use "translate" where it is available
- Script.js changed to accept "translate" as an input parameter of exported function
  - Changed 3 places, which used the "Script.js", so that the "translate" module passed as a parameter down to function as a parameter value
- Listener.js - refactored, so that translation would be obtained on rendering, not on module loading.  Language switching would work correctly that way.

Closes https://github.com/bpmn-io/bpmn-js-properties-panel/issues/297