### PR TITLE
Wire deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ node_js: '10'
 
 script:
   - npm run all
+before_script:
+  - ./tasks/wiredeps
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1087,9 +1087,9 @@
       }
     },
     "bpmn-font": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/bpmn-font/-/bpmn-font-0.8.0.tgz",
-      "integrity": "sha512-j8u5k7EcGkmg7WkPgObxyvMEccr0qyiCuvXGnM5G2Q+kza119vVq3gblt0Rro/UDjl7i3VmfG3ojeZ04VHeVFg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/bpmn-font/-/bpmn-font-0.9.0.tgz",
+      "integrity": "sha512-Pug+qMkarD0GUZ9z16cUkM3fYz7TZ6Or8bS1vQVrOCH/u8bC3m4ewoexs46H0OA1neFUZrdRwWSKXXkz574wzg==",
       "dev": true
     },
     "bpmn-js": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "bpmn-font": "^0.9.0",
     "bpmn-js": "^3.1.0",
     "bpmn-moddle": "^5.1.6",
     "camunda-bpmn-moddle": "^3.2.0",

--- a/tasks/wiredeps
+++ b/tasks/wiredeps
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+wire() {
+  echo "Attempting to install $1@$2";
+
+  npm install "$1@bpmn-io/$1#$2";
+
+  if [ $? -ne 0 ]; then
+    echo "Falling back to $1@master";
+
+    npm install "$1@bpmn-io/$1#master";
+  fi
+}
+
+FEATURE_BRANCH=
+
+if [ "$TRAVIS_TAG" == "" ]; then
+  if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then
+    FEATURE_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH";
+  else
+    FEATURE_BRANCH="$TRAVIS_BRANCH";
+  fi
+
+  wire "diagram-js" "$FEATURE_BRANCH";
+  wire "bpmn-js" "$FEATURE_BRANCH";
+
+fi

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -7,8 +7,8 @@ var domQuery = require('min-dom').query,
     domAttr = require('min-dom').attr;
 
 
-TestHelper.insertCSS('diagram-js.css', require('bpmn-js/dist/assets/diagram-js.css'));
-TestHelper.insertCSS('bpmn-embedded.css', require('bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css'));
+TestHelper.insertCSS('diagram-js.css', require('diagram-js/assets/diagram-js.css'));
+TestHelper.insertCSS('bpmn-embedded.css', require('bpmn-font/dist/css/bpmn-embedded.css'));
 TestHelper.insertCSS('properties.css', require('./assets/properties.css'));
 
 TestHelper.insertCSS('diagram-js-testing.css',


### PR DESCRIPTION
To use `$FEATURE_BRANCH` (or `master`) of the dependencies, I added the `wiredeps` script from `bpmn-js` (cf. https://github.com/bpmn-io/bpmn-js/commit/e9f99b00c72f8e79609771b77e4a2c410bdd6b97). This will help us to test with latest deps changes.

### Proposed Changes

* Use original style sheets in tests, cf. 146fcd5, since the `dist` folder will not be available on `$FEATURE_BRANCH`
* Wire dependencies branches on CI, cf. a063f8b