### PR TITLE
fix(helper): disallow inputOutput on bpmn:Gateway

### DIFF
--- a/lib/helper/InputOutputHelper.js
+++ b/lib/helper/InputOutputHelper.js
@@ -111,12 +111,23 @@ InputOutputHelper.getOutputParameter = function(element, insideConnector, idx) {
  * @return {boolean} a boolean value
  */
 InputOutputHelper.isInputOutputSupported = function(element, insideConnector) {
+
+  if (insideConnector) {
+    return true;
+  }
+
   var bo = getBusinessObject(element);
-  return insideConnector ||
-         (is(bo, 'bpmn:FlowNode') &&
-         !is(bo, 'bpmn:StartEvent') &&
-         !is(bo, 'bpmn:BoundaryEvent') &&
-         !(is(bo, 'bpmn:SubProcess') && bo.get('triggeredByEvent')));
+
+  return (
+    is(bo, 'bpmn:FlowNode') && !(
+      is(bo, 'bpmn:StartEvent') ||
+      is(bo, 'bpmn:Gateway') ||
+      is(bo, 'bpmn:BoundaryEvent') ||
+      (
+        is(bo, 'bpmn:SubProcess') && bo.get('triggeredByEvent')
+      )
+    )
+  );
 };
 
 /**

--- a/test/spec/helper/InputOutputHelperSpec.js
+++ b/test/spec/helper/InputOutputHelperSpec.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var BpmnModdle = require('bpmn-moddle').default;
+var CamundaBpmnModdle = require('camunda-bpmn-moddle/resources/camunda');
+
+var InputOutputHelper = require('lib/helper/InputOutputHelper');
+
+
+describe('inputOutput', function() {
+
+  var moddle = new BpmnModdle({
+    camunda: CamundaBpmnModdle
+  });
+
+
+  it('should NOT be supported on bpmn:Gateway', function() {
+
+    // given
+    var element = moddle.create('bpmn:Gateway');
+
+    // then
+    expect(InputOutputHelper.isInputOutputSupported(element, false)).to.be.false;
+  });
+
+
+  it('should be supported inside camunda:Connector', function() {
+
+    // given
+    var element = moddle.create('bpmn:ServiceTask');
+
+    // then
+    expect(InputOutputHelper.isInputOutputSupported(element, true)).to.be.true;
+  });
+
+});


### PR DESCRIPTION
The Input Output tab should not be shown for Gateways, it does not make sense from the engine perspective. 

Closes https://github.com/bpmn-io/bpmn-js-properties-panel/issues/221