### PR TITLE
feat(camunda): add update event to task listener

### DIFF
--- a/lib/provider/camunda/parts/ListenerDetailProps.js
+++ b/lib/provider/camunda/parts/ListenerDetailProps.js
@@ -37,7 +37,8 @@ module.exports = function(group, element, bpmnFactory, options, translate) {
     { name: translate('create'), value: 'create' },
     { name: translate('assignment'), value: 'assignment' },
     { name: translate('complete'), value: 'complete' },
-    { name: translate('delete'), value: 'delete' }
+    { name: translate('delete'), value: 'delete' },
+    { name: translate('update'), value: 'update' }
   ];
 
   var isSelected = function(element, node) {


### PR DESCRIPTION
Related to camunda/camunda-modeler#1517

![Kapture 2019-10-25 at 9 14 15](https://user-images.githubusercontent.com/9433996/67550871-d6acee80-f707-11e9-861e-ffcc8295f8c4.gif)

We don't cover the other event types in separate test cases, so I think the current tests are covering this one as well.