### PR TITLE
Promise polyfill for phantom-js

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -33,6 +33,7 @@ module.exports = function(karma) {
     ],
 
     files: [
+      'node_modules/promise-polyfill/dist/polyfill.js',
       'test/suite.js'
     ],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5627,6 +5627,12 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
+    "promise-polyfill": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
+      "dev": true
+    },
     "prop-types": {
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "mocha": "^5.2.0",
     "mocha-test-container-support": "0.2.0",
     "npm-run-all": "^4.1.5",
+    "promise-polyfill": "^8.1.3",
     "puppeteer": "^1.18.0",
     "raw-loader": "^0.5.1",
     "sinon": "^4.5.0",


### PR DESCRIPTION
This PR fixes our broken CI pipeline (promises are not supported by default in phantom-js, the latest bpmn-js version requires promises).

We'll get rid of callback deprecation warning logs in CI output with #329.