### PR TITLE
Bump bpmn-js to v7.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -977,45 +977,38 @@
       "dev": true
     },
     "bpmn-js": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-5.1.2.tgz",
-      "integrity": "sha512-s674cn+N4zhmlGMBOBFp6zAGV3Qd23ss13bW+Hy6gg23wxExVqlY/xRwE/FnrfvYmRag4Pz1c+lyP7OYD8VwuA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-7.0.1.tgz",
+      "integrity": "sha512-UHDPCquych4OklVqKqg3xDZbMERKKvX7kU9KqgEhXnIXqkLZSDcnTmISkjTvy6PRhsIN+bu7yEF/Om7BSEw6Og==",
       "dev": true,
       "requires": {
-        "bpmn-font": "^0.9.3",
-        "bpmn-moddle": "^6.0.0",
+        "bpmn-moddle": "^7.0.3",
         "css.escape": "^1.5.1",
-        "diagram-js": "^5.1.1",
-        "diagram-js-direct-editing": "^1.6.0",
+        "diagram-js": "^6.6.1",
+        "diagram-js-direct-editing": "^1.6.1",
         "ids": "^1.0.0",
         "inherits": "^2.0.1",
         "min-dash": "^3.5.1",
-        "min-dom": "^3.0.0",
+        "min-dom": "^3.1.2",
         "object-refs": "^0.3.0",
         "tiny-svg": "^2.2.1"
       },
       "dependencies": {
-        "bpmn-font": {
-          "version": "0.9.3",
-          "resolved": "https://registry.npmjs.org/bpmn-font/-/bpmn-font-0.9.3.tgz",
-          "integrity": "sha512-kzRGXGLzTROLRNCSskkOyj/+SbtTAn2unKfgB9tNt7RWJFybg/Wbe9YjK2ALotI3b64wwlCTkAalXiTiskP6dg==",
-          "dev": true
-        },
         "bpmn-moddle": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-6.0.0.tgz",
-          "integrity": "sha512-/yi7LBT4MFWsv5fmQD7/aeCZC94Ot8onADiJMQkosY2XGN85cVmOpPdmo8FfBu+6gjI9EWUnnUWjjY1SDVLeXw==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-7.0.3.tgz",
+          "integrity": "sha512-DylEgndbBNm37v/jEdZTUD1i7XzbpCA5mIAFqkbqof3nYbIOAIycIrkhnRIaBJPvtlxTd3wDdG1ts1IzUfEduA==",
           "dev": true,
           "requires": {
             "min-dash": "^3.0.0",
             "moddle": "^5.0.1",
-            "moddle-xml": "^8.0.1"
+            "moddle-xml": "^9.0.3"
           }
         },
         "diagram-js": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-5.1.1.tgz",
-          "integrity": "sha512-SLxHOfEDLBC7LBjQFmXyvQXt4P5yZYFnTvhsCZZtJyQCadrVs71cUlchMmH+kUS/zaga/BkPWFbnV1d+4MsF8A==",
+          "version": "6.6.1",
+          "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-6.6.1.tgz",
+          "integrity": "sha512-3SlXwT2ieXCZkQn8dVZWfNry9+6d4R+0Q57Oz9t/SfIyNIrRPg0c9IlsaTHpGUhPE3fossXPDjmvqjJD0lmBLw==",
           "dev": true,
           "requires": {
             "css.escape": "^1.5.1",
@@ -1023,9 +1016,9 @@
             "hammerjs": "^2.0.1",
             "inherits": "^2.0.1",
             "min-dash": "^3.5.0",
-            "min-dom": "^3.0.0",
+            "min-dom": "^3.1.2",
             "object-refs": "^0.3.0",
-            "path-intersection": "^1.0.2",
+            "path-intersection": "^2.2.0",
             "tiny-svg": "^2.2.1"
           }
         },
@@ -1034,6 +1027,18 @@
           "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.5.2.tgz",
           "integrity": "sha512-YVbJZUtnzT5QsgJUp9H9uyJTW6NJgswFqI27RI/+MSox860uIjaGMbSQBftEzbMXiJVRG24hpoIh3SG666SHgA==",
           "dev": true
+        },
+        "min-dom": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.1.3.tgz",
+          "integrity": "sha512-Lbi1NZjLV9Hg6/bEe2Lfk2Fzsv1MwheR61whqTLP+FxLndYo9TxpksEgM5Kr1khjfCtFTMr0waeEfwIpStkRdw==",
+          "dev": true,
+          "requires": {
+            "component-event": "^0.1.4",
+            "domify": "^1.3.1",
+            "indexof": "0.0.1",
+            "matches-selector": "^1.2.0"
+          }
         },
         "moddle": {
           "version": "5.0.1",
@@ -1045,15 +1050,27 @@
           }
         },
         "moddle-xml": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-8.0.1.tgz",
-          "integrity": "sha512-aeMpZTFv5Vm5sKXtRRIoXb/4eMssNWjsvb0MNPe7g8x3F2cRmQa2AwT8gnjtlefHwmCxQRbIoP2kutmqfgoKzg==",
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-9.0.3.tgz",
+          "integrity": "sha512-3r1c+CA7k9GLqONKtM87DltyLmeWtqz6wbw+SQWNJd66iidmYL4VudN/qpJHt6TP8qxeQrZLTpEYkDQgW6HIDQ==",
           "dev": true,
           "requires": {
             "min-dash": "^3.0.0",
             "moddle": "^5.0.1",
-            "saxen": "^8.1.0"
+            "saxen": "^8.1.2"
           }
+        },
+        "path-intersection": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.0.tgz",
+          "integrity": "sha512-1qchRuLKhRt3qYePf9CU/74fLrBo9OTiKYNn5fxfuHJW6kTThEk04ql7w8JwOgZjNANAGp1052tWGpwZ7ItNRA==",
+          "dev": true
+        },
+        "saxen": {
+          "version": "8.1.2",
+          "resolved": "https://registry.npmjs.org/saxen/-/saxen-8.1.2.tgz",
+          "integrity": "sha512-xUOiiFbc3Ow7p8KMxwsGICPx46ZQvy3+qfNVhrkwfz3Vvq45eGt98Ft5IQaA1R/7Tb5B5MKh9fUR9x3c3nDTxw==",
+          "dev": true
         }
       }
     },
@@ -1914,9 +1931,9 @@
       }
     },
     "diagram-js-direct-editing": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-1.6.0.tgz",
-      "integrity": "sha512-bO9FqB6lJm+kaA6tSrXO0jT+Fu++yJTHbBf/wYb+AfJYAB92zZJrxwHRPTRhZGB4Md7XMEba5LAuNL8u9bjf3w==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-1.6.1.tgz",
+      "integrity": "sha512-FOW2qp7yT/L3Go/YfBOfnWrV2pc2PPoTSSRIg2nnld8pQDTnMaqKPva9GZEoCtcTJzPV4ctZX52ZdkJ3C7aWaA==",
       "dev": true,
       "requires": {
         "min-dash": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "devDependencies": {
     "bpmn-font": "^0.9.0",
-    "bpmn-js": "^5.1.2",
+    "bpmn-js": "^7.0.1",
     "bpmn-moddle": "^5.1.6",
     "camunda-bpmn-moddle": "^4.3.0",
     "chai": "^4.1.2",

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -31,7 +31,7 @@ var bootstrapModeler = TestHelper.bootstrapModeler;
  * is necessary to speed the test execution up.
  */
 TestHelper.bootstrapModeler = function(diagram, options, locals) {
-  return function(done) {
+  return function() {
     var previousInstance = TestHelper.getBpmnJS();
 
     if (previousInstance) {
@@ -41,7 +41,7 @@ TestHelper.bootstrapModeler = function(diagram, options, locals) {
 
       previousInstance.destroy();
     }
-    return bootstrapModeler(diagram, options, locals).apply(this, [ done ]);
+    return bootstrapModeler(diagram, options, locals).apply(this);
   };
 };
 

--- a/test/helper/index.js
+++ b/test/helper/index.js
@@ -43,7 +43,7 @@ var OPTIONS, BPMN_JS;
 
 function bootstrapBpmnJS(BpmnJS, diagram, options, locals) {
 
-  return function(done) {
+  return function() {
     var testContainer;
 
     // Make sure the test container is an optional dependency and we fall back
@@ -107,7 +107,7 @@ function bootstrapBpmnJS(BpmnJS, diagram, options, locals) {
 
     BPMN_JS = new BpmnJS(_options);
 
-    BPMN_JS.importXML(diagram, done);
+    return BPMN_JS.importXML(diagram);
   };
 }
 

--- a/test/spec/provider/camunda/element-templates/CreateHelperSpec.js
+++ b/test/spec/provider/camunda/element-templates/CreateHelperSpec.js
@@ -25,13 +25,13 @@ var testModules = [
 
 function bootstrap(diagramXML) {
 
-  return function(done) {
-    bootstrapModeler(diagramXML, {
+  return function() {
+    return bootstrapModeler(diagramXML, {
       modules: testModules,
       moddleExtensions: {
         camunda: camundaModdlePackage
       }
-    })(done);
+    })();
   };
 }
 

--- a/test/spec/provider/camunda/element-templates/parts/Helper.js
+++ b/test/spec/provider/camunda/element-templates/parts/Helper.js
@@ -72,8 +72,8 @@ var camundaModdlePackage = require('camunda-bpmn-moddle/resources/camunda');
 
 function bootstrap(diagramXML, elementTemplates) {
 
-  return function(done) {
-    TestHelper.bootstrapModeler(diagramXML, {
+  return function() {
+    return TestHelper.bootstrapModeler(diagramXML, {
       modules: testModules,
       elementTemplates: elementTemplates,
       moddleExtensions: {
@@ -82,7 +82,7 @@ function bootstrap(diagramXML, elementTemplates) {
       propertiesPanel: {
         parent: document.querySelector('body')
       }
-    })(done);
+    })();
   };
 }
 


### PR DESCRIPTION
Closes #329 

This PR bumps bpmn-js to v7.0.1 and fixes the deprecation warnings in tests.