### PR TITLE
fix(auto-suggest): create description field inside show-wrapper

### DIFF
--- a/lib/factory/AutoSuggestTextBoxFactory.js
+++ b/lib/factory/AutoSuggestTextBoxFactory.js
@@ -47,12 +47,8 @@ var autoSuggestTextBox = function(options, defaultParameters) {
         'data-blur="handleFocusLeave"' +
       '></div>' +
       '<div class="bpp-autosuggest-list"></div>' +
-  '</div>';
-
-  // add description below text box entry field
-  if (description) {
-    resource.html += entryFieldDescription(description);
-  }
+      (description ? entryFieldDescription(description) : '') +
+    '</div>';
 
   if (canBeShown) {
     resource.isShown = function() {


### PR DESCRIPTION
To ensure descriptions for auto-suggest textboxes got wrapped with the `[data-show]` we have to create it inside the wrapper.

__Which issue does this PR address?__

_No issue_

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js-properties-panel/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
