### PR TITLE
Template Parameter Toggle

### DIFF
--- a/lib/factory/EntryFactory.js
+++ b/lib/factory/EntryFactory.js
@@ -13,7 +13,8 @@ var textInputField = require('./TextInputEntryFactory'),
     labelEntry = require('./LabelFactory'),
     link = require('./LinkEntryFactory'),
     autoSuggestTextBoxField = require('./AutoSuggestTextBoxFactory'),
-    collapsible = require('./CollapsibleEntryFactory');
+    collapsible = require('./CollapsibleEntryFactory'),
+    toggleSwtich = require('./ToggleSwitchEntryFactory');
 
 var cmdHelper = require('../helper/CmdHelper');
 
@@ -168,6 +169,10 @@ EntryFactory.autoSuggest = function(options) {
 
 EntryFactory.collapsible = function(options) {
   return collapsible(options);
+};
+
+EntryFactory.toggleSwtich = function(options) {
+  return toggleSwtich(options, setDefaultParameters(options));
 };
 
 module.exports = EntryFactory;

--- a/lib/factory/ToggleSwitchEntryFactory.js
+++ b/lib/factory/ToggleSwitchEntryFactory.js
@@ -1,0 +1,101 @@
+'use strict';
+
+var getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject,
+    cmdHelper = require('../helper/CmdHelper'),
+    escapeHTML = require('../Utils').escapeHTML;
+
+var entryFieldDescription = require('./EntryFieldDescription');
+
+
+var toggleSwitch = function(options, defaultParameters) {
+  var resource = defaultParameters,
+      id = resource.id,
+      label = options.label || id,
+      canBeHidden = !!options.hidden && typeof options.hidden === 'function',
+      isOn = options.isOn,
+      descriptionOn = options.descriptionOn,
+      descriptionOff = options.descriptionOff,
+      labelOn = options.labelOn,
+      labelOff = options.labelOff;
+
+  resource.html = '<label for="' + escapeHTML(id) + '" ' +
+      (canBeHidden ? 'data-show="shouldShow"' : '') +
+      '>' + escapeHTML(label) + '</label>' +
+    '<div class="bpp-field-wrapper"' +
+    (canBeHidden ? 'data-show="shouldShow"' : '') +
+    '>' +
+      '<label class="bpp-toggle-switch__switcher">' +
+        '<input id="' + escapeHTML(id) + '" ' +
+            'type="checkbox" ' +
+            'name="' + escapeHTML(options.modelProperty) + '" />' +
+        '<span class="bpp-toggle-switch__slider"></span>' +
+      '</label>' +
+      '<p class="bpp-toggle-switch__label" data-show="isOn">' +
+        escapeHTML(labelOn) +
+      '</p>' +
+      '<p class="bpp-toggle-switch__label" data-show="isOff">' +
+        escapeHTML(labelOff) +
+      '</p>' +
+    '</div>';
+
+  if (descriptionOn) {
+    resource.html += entryFieldDescription(descriptionOn, { show: 'isOn' });
+  }
+
+  if (descriptionOff) {
+    resource.html += entryFieldDescription(descriptionOff, { show: 'isOff' });
+  }
+
+  resource.get = function(element) {
+    var bo = getBusinessObject(element),
+        res = {};
+
+    res[options.modelProperty] = bo.get(options.modelProperty);
+
+    return res;
+  };
+
+  resource.set = function(element, values) {
+    var res = {};
+
+    res[options.modelProperty] = !!values[options.modelProperty];
+
+    return cmdHelper.updateProperties(element, res);
+  };
+
+  if (typeof options.set === 'function') {
+    resource.set = options.set;
+  }
+
+  if (typeof options.get === 'function') {
+    resource.get = options.get;
+  }
+
+  if (canBeHidden) {
+    resource.shouldShow = function() {
+      return !options.hidden.apply(resource, arguments);
+    };
+  }
+
+  resource.isOn = function() {
+    if (canBeHidden && !resource.shouldShow()) {
+      return false;
+    }
+
+    return isOn.apply(resource, arguments);
+  };
+
+  resource.isOff = function() {
+    if (canBeHidden && !resource.shouldShow()) {
+      return false;
+    }
+
+    return !resource.isOn();
+  };
+
+  resource.cssClasses = ['bpp-toggle-switch'];
+
+  return resource;
+};
+
+module.exports = toggleSwitch;

--- a/lib/provider/camunda/CamundaPropertiesProvider.js
+++ b/lib/provider/camunda/CamundaPropertiesProvider.js
@@ -381,7 +381,7 @@ function createListenersTabGroups(element, bpmnFactory, elementRegistry, transla
   ];
 }
 
-function createInputOutputTabGroups(element, bpmnFactory, elementRegistry, translate) {
+function createInputOutputTabGroups(element, bpmnFactory, elementTemplates, translate) {
 
   var inputParametersGroup = {
     id: 'input-parameters',
@@ -389,7 +389,7 @@ function createInputOutputTabGroups(element, bpmnFactory, elementRegistry, trans
     entries: []
   };
 
-  inputParameters(inputParametersGroup, element, bpmnFactory, translate);
+  inputParameters(inputParametersGroup, element, bpmnFactory, elementTemplates, translate);
 
   var outputParametersGroup = {
     id: 'output-parameters',
@@ -397,7 +397,7 @@ function createInputOutputTabGroups(element, bpmnFactory, elementRegistry, trans
     entries: []
   };
 
-  outputParameters(outputParametersGroup, element, bpmnFactory, translate);
+  outputParameters(outputParametersGroup, element, bpmnFactory, elementTemplates, translate);
 
   return [
     inputParametersGroup,
@@ -544,7 +544,7 @@ function CamundaPropertiesProvider(
     var inputOutputTab = {
       id: 'input-output',
       label: translate('Input/Output'),
-      groups: createInputOutputTabGroups(element, bpmnFactory, elementRegistry, translate)
+      groups: createInputOutputTabGroups(element, bpmnFactory, elementTemplates, translate)
     };
 
     var connectorTab = {

--- a/lib/provider/camunda/element-templates/parts/InputParametersProps.js
+++ b/lib/provider/camunda/element-templates/parts/InputParametersProps.js
@@ -18,13 +18,25 @@ var getTemplate = require('../Helper').getTemplate;
 var findExtension = require('../Helper').findExtension,
     findInputParameter = require('../Helper').findInputParameter;
 
+var createInputParameter = require('../CreateHelper').createInputParameter;
+
 var escapeHTML = require('../../../../Utils').escapeHTML;
+
+var entryFactory = require('../../../../factory/EntryFactory');
+
+var cmdHelper = require('../../../../helper/CmdHelper'),
+    elementHelper = require('../../../../helper/ElementHelper');
 
 var InputOutputParameter = require('../../parts/implementation/InputOutputParameter');
 
 var CAMUNDA_INPUT_PARAMETER_TYPE = 'camunda:inputParameter';
 
 var MAX_DESCRIPTION_LENGTH = 200;
+
+var EMPTY_PARAMETER = {
+  get: function() {},
+  set: function() {}
+};
 
 
 /**
@@ -69,9 +81,9 @@ module.exports = function(group, element, elementTemplates, bpmnFactory, transla
 
   function renderInputParameter(id, templateProperty) {
 
-    var parameterEntries = [];
+    var parameterEntries = [],
+        collapsibleEntry;
 
-    // find input parameter first
     var bo = getBusinessObject(element),
         inputOutput = findExtension(bo, 'camunda:InputOutput');
 
@@ -79,25 +91,44 @@ module.exports = function(group, element, elementTemplates, bpmnFactory, transla
       return parameterEntries;
     }
 
-    // assumption: input parameter got created once template is applied
     var parameter = findInputParameter(inputOutput, templateProperty.binding);
 
     if (!parameter) {
-      return parameterEntries;
+      parameter = EMPTY_PARAMETER;
     }
+
+    var getParameter = function() {
+      return parameter;
+    };
+
+    var isOpen = function() {
+      return collapsibleEntry.isOpen();
+    };
+
+    var assignmentIsOn = function() {
+      var inputOutput = findExtension(getBusinessObject(element), 'camunda:InputOutput'),
+          parameter = findInputParameter(inputOutput, templateProperty.binding);
+
+      return !!parameter;
+    };
 
     var options = {
       idPrefix: id + '-',
-      onToggle: onToggle
+      onToggle: onToggle,
+      getParameter: getParameter,
+      isOpen: function() {
+        return isOpen() && assignmentIsOn();
+      }
     };
+
 
     // (1) use input parameter implementation
     var inputImplementation = InputOutputParameter(parameter, bpmnFactory, options, translate);
-
     parameterEntries = inputImplementation.entries;
 
-    var nameIdx = findEntry(parameterEntries, id + '-parameterName'),
-        collapsibleEntry = parameterEntries[findEntry(parameterEntries, id + '-collapsible')];
+    var nameIdx = findEntry(parameterEntries, id + '-parameterName');
+
+    collapsibleEntry = parameterEntries[findEntry(parameterEntries, id + '-collapsible')];
 
     // (2) update title getter
     var defaultGet = collapsibleEntry.get;
@@ -121,6 +152,39 @@ module.exports = function(group, element, elementTemplates, bpmnFactory, transla
         translate
       ));
     }
+
+    // (5) add parameter toggle
+    parameterEntries.splice(templateProperty.description ? 2 : 1, 0, entryFactory.toggleSwtich({
+      id: id + '-assignment-toggle',
+      label: translate('Local Variable Assignment'),
+      modelProperty: 'isActive',
+      labelOn: translate('On'),
+      labelOff: translate('Off'),
+      descriptionOff: translate('The parameter won\'t be created as local variable.'),
+      isOn: assignmentIsOn,
+      get: function(element, node) {
+        return { isActive: assignmentIsOn() };
+      },
+      set: function(element, values, node) {
+        var isActive = values.isActive || false;
+
+        if (isActive) {
+          var created
+            = createNewInputParameter(element, templateProperty.binding, bpmnFactory);
+
+          parameter = created.inputParameter;
+
+          return created.updates;
+        } else {
+          parameter = EMPTY_PARAMETER;
+          return removeInputParameter(element, templateProperty.binding);
+        }
+
+      },
+      hidden: function(element, node) {
+        return !isOpen();
+      }
+    }));
 
     return parameterEntries;
   }
@@ -207,4 +271,74 @@ function createDescriptionEntry(description, id, show, translate) {
     show: show
   };
 }
+
+function removeInputParameter(element, binding) {
+  var bo = getBusinessObject(element),
+      updates = [],
+      extensionElements = bo.get('extensionElements');
+
+  if (!extensionElements) {
+    return updates;
+  }
+
+  var inputOutput = findExtension(extensionElements, 'camunda:InputOutput');
+
+  if (!inputOutput) {
+    return updates;
+  }
+
+  var inputParameter = findInputParameter(inputOutput, binding);
+
+  if (!inputParameter) {
+    return updates;
+  }
+
+  updates.push(cmdHelper.removeElementsFromList(element, inputOutput, 'inputParameters', null, [inputParameter]));
+
+  return updates;
+}
+
+function createNewInputParameter(element, binding, bpmnFactory) {
+  var bo = getBusinessObject(element),
+      updates = [],
+      extensionElements = bo.get('extensionElements');
+
+  // (1) ensure extension elements
+  if (!extensionElements) {
+    extensionElements = elementHelper.createElement('bpmn:ExtensionElements', null, element, bpmnFactory);
+
+    updates.push(cmdHelper.updateBusinessObject(
+      element, bo, { extensionElements: extensionElements }
+    ));
+  }
+
+  var inputOutput = findExtension(extensionElements, 'camunda:InputOutput');
+
+  // (2) ensure inputOutput element
+  if (!inputOutput) {
+    inputOutput = elementHelper.createElement('camunda:InputOutput', null, bo, bpmnFactory);
+
+    updates.push(cmdHelper.addElementsTolist(
+      element, extensionElements, 'values', inputOutput
+    ));
+  }
+
+  // (3) create input parameter
+  var inputParameter = createInputParameter(binding, null, bpmnFactory);
+
+  updates.push(cmdHelper.addAndRemoveElementsFromList(
+    element,
+    inputOutput,
+    'inputParameters',
+    null,
+    [ inputParameter ],
+    [ ]
+  ));
+
+  return {
+    updates: updates,
+    inputParameter: inputParameter
+  };
+}
+
 

--- a/lib/provider/camunda/element-templates/parts/OutputParametersProps.js
+++ b/lib/provider/camunda/element-templates/parts/OutputParametersProps.js
@@ -7,10 +7,13 @@ var flatten = require('min-dash').flatten,
 var entryFactory = require('../../../../factory/EntryFactory'),
     getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject,
     getTemplate = require('../Helper').getTemplate,
-    cmdHelper = require('../../../../helper/CmdHelper');
+    cmdHelper = require('../../../../helper/CmdHelper'),
+    elementHelper = require('../../../../helper/ElementHelper');
 
 var findExtension = require('../Helper').findExtension,
     findOutputParameter = require('../Helper').findOutputParameter;
+
+var createOutputParameter = require('../CreateHelper').createOutputParameter;
 
 var domClasses = require('min-dom').classes,
     domEvent = require('min-dom').event,
@@ -24,6 +27,11 @@ var utils = require('../../../../Utils');
 var CAMUNDA_OUTPUT_PARAMETER_TYPE = 'camunda:outputParameter';
 
 var MAX_DESCRIPTION_LENGTH = 200;
+
+var EMPTY_PARAMETER = {
+  get: function() {},
+  set: function() {}
+};
 
 /**
  * Injects element template output parameters into the given group.
@@ -81,7 +89,7 @@ module.exports = function(group, element, elementTemplates, bpmnFactory, transla
     var parameter = findOutputParameter(inputOutput, templateProperty.binding);
 
     if (!parameter) {
-      return parameterEntries;
+      parameter = EMPTY_PARAMETER;
     }
 
     // (1) add collapsible header
@@ -105,6 +113,13 @@ module.exports = function(group, element, elementTemplates, bpmnFactory, transla
 
     var isOpen = collapsible.isOpen;
 
+    var assignmentIsOn = function() {
+      var inputOutput = findExtension(getBusinessObject(element), 'camunda:InputOutput'),
+          parameter = findOutputParameter(inputOutput, templateProperty.binding);
+
+      return !!parameter;
+    };
+
     // (2) add description
     if (templateProperty.description) {
       parameterEntries.push(createDescriptionEntry(
@@ -115,7 +130,40 @@ module.exports = function(group, element, elementTemplates, bpmnFactory, transla
       ));
     }
 
-    // (3) add process variable name field
+    // (3) add parameter toggle
+    parameterEntries.splice(templateProperty.description ? 2 : 1, 0, entryFactory.toggleSwtich({
+      id: id + '-assignment-toggle',
+      label: translate('Process Variable Assignment'),
+      modelProperty: 'isActive',
+      labelOn: translate('On'),
+      labelOff: translate('Off'),
+      descriptionOff: translate('The parameter won\'t be available in the process scope.'),
+      isOn: assignmentIsOn,
+      get: function(element, node) {
+        return { isActive: assignmentIsOn() };
+      },
+      set: function(element, values, node) {
+        var isActive = values.isActive || false;
+
+        if (isActive) {
+          var created =
+            createNewOutputParameter(element, templateProperty.binding, bpmnFactory);
+
+          parameter = created.outputParameter;
+
+          return created.updates;
+        } else {
+          parameter = EMPTY_PARAMETER;
+          return removeOutputParameter(element, templateProperty.binding);
+        }
+
+      },
+      hidden: function(element, node) {
+        return !isOpen();
+      }
+    }));
+
+    // (4) add process variable name field
     parameterEntries.push(entryFactory.validationAwareTextField({
       id: id + '-variableName',
       label: translate('Assign to Process Variable'),
@@ -141,7 +189,7 @@ module.exports = function(group, element, elementTemplates, bpmnFactory, transla
         return validation;
       },
       hidden: function(element, node) {
-        return !isOpen();
+        return !isOpen() || !assignmentIsOn();
       }
     }));
 
@@ -216,5 +264,74 @@ function createDescriptionEntry(description, id, show, translate) {
     id: id + '-description',
     html: html,
     show: show
+  };
+}
+
+function removeOutputParameter(element, binding) {
+  var bo = getBusinessObject(element),
+      updates = [],
+      extensionElements = bo.get('extensionElements');
+
+  if (!extensionElements) {
+    return updates;
+  }
+
+  var inputOutput = findExtension(extensionElements, 'camunda:InputOutput');
+
+  if (!inputOutput) {
+    return updates;
+  }
+
+  var outputParameter = findOutputParameter(inputOutput, binding);
+
+  if (!outputParameter) {
+    return updates;
+  }
+
+  updates.push(cmdHelper.removeElementsFromList(element, inputOutput, 'outputParameters', null, [outputParameter]));
+
+  return updates;
+}
+
+function createNewOutputParameter(element, binding, bpmnFactory) {
+  var bo = getBusinessObject(element),
+      updates = [],
+      extensionElements = bo.get('extensionElements');
+
+  // (1) ensure extension elements
+  if (!extensionElements) {
+    extensionElements = elementHelper.createElement('bpmn:ExtensionElements', null, element, bpmnFactory);
+
+    updates.push(cmdHelper.updateBusinessObject(
+      element, bo, { extensionElements: extensionElements }
+    ));
+  }
+
+  var inputOutput = findExtension(extensionElements, 'camunda:InputOutput');
+
+  // (2) ensure inputOutput element
+  if (!inputOutput) {
+    inputOutput = elementHelper.createElement('camunda:InputOutput', null, bo, bpmnFactory);
+
+    updates.push(cmdHelper.addElementsTolist(
+      element, extensionElements, 'values', inputOutput
+    ));
+  }
+
+  // (3) create output parameter
+  var outputParameter = createOutputParameter(binding, null, bpmnFactory);
+
+  updates.push(cmdHelper.addAndRemoveElementsFromList(
+    element,
+    inputOutput,
+    'outputParameters',
+    null,
+    [ outputParameter ],
+    [ ]
+  ));
+
+  return {
+    updates: updates,
+    outputParameter: outputParameter
   };
 }

--- a/lib/provider/camunda/parts/InputParametersProps.js
+++ b/lib/provider/camunda/parts/InputParametersProps.js
@@ -1,8 +1,16 @@
 'use strict';
 
+var getTemplate = require('../element-templates/Helper').getTemplate;
+
 var inputParameters = require('./implementation/InputParameters');
 
-module.exports = function(group, element, bpmnFactory, translate) {
+module.exports = function(group, element, bpmnFactory, elementTemplates, translate) {
+
+  var template = getTemplate(element, elementTemplates);
+
+  if (template) {
+    return;
+  }
 
   var inputParametersEntry = inputParameters(element, bpmnFactory, {}, translate);
 

--- a/lib/provider/camunda/parts/OutputParametersProps.js
+++ b/lib/provider/camunda/parts/OutputParametersProps.js
@@ -1,8 +1,15 @@
 'use strict';
+var getTemplate = require('../element-templates/Helper').getTemplate;
 
 var outputParameters = require('./implementation/OutputParameters');
 
-module.exports = function(group, element, bpmnFactory, translate) {
+module.exports = function(group, element, bpmnFactory, elementTemplates, translate) {
+
+  var template = getTemplate(element, elementTemplates);
+
+  if (template) {
+    return;
+  }
 
   var outputParametersEntry = outputParameters(element, bpmnFactory, {}, translate);
 

--- a/lib/provider/camunda/parts/implementation/InputOutputParameter.js
+++ b/lib/provider/camunda/parts/implementation/InputOutputParameter.js
@@ -41,6 +41,15 @@ module.exports = function(parameter, bpmnFactory, options, translate) {
 
   var idPrefix = options.idPrefix || '';
 
+  var getParameter =
+    (options.getParameter && typeof options.getParameter === 'function') ?
+      function() {
+        return options.getParameter();
+      } :
+      function() {
+        return parameter;
+      };
+
   var result = {},
       entries = [];
 
@@ -57,13 +66,13 @@ module.exports = function(parameter, bpmnFactory, options, translate) {
     onToggle: options.onToggle,
     get: function() {
       return {
-        title: parameter.name,
-        description: getDescription(parameter)
+        title: getParameter().name,
+        description: getDescription(getParameter())
       };
     }
   });
 
-  var isOpen = collapsible.isOpen;
+  var isOpen = options.isOpen || collapsible.isOpen;
 
   result.setOpen = function(value) {
     var entryNode = domQuery('[data-entry="' + collapsible.id + '"]');
@@ -126,7 +135,7 @@ module.exports = function(parameter, bpmnFactory, options, translate) {
     get: function(element, node) {
       var parameterType = 'text';
 
-      var definition = parameter.get('definition');
+      var definition = getParameter().get('definition');
       if (typeof definition !== 'undefined') {
         var type = definition.$type;
         parameterType = typeInfo[type].value;
@@ -144,7 +153,7 @@ module.exports = function(parameter, bpmnFactory, options, translate) {
       };
 
       var createParameterTypeElem = function(type) {
-        return createElement(type, parameter, bpmnFactory);
+        return createElement(type, getParameter(), bpmnFactory);
       };
 
       var parameterType = values.parameterType;
@@ -159,7 +168,7 @@ module.exports = function(parameter, bpmnFactory, options, translate) {
         properties.definition = createParameterTypeElem('camunda:Map');
       }
 
-      return cmdHelper.updateBusinessObject(element, parameter, properties);
+      return cmdHelper.updateBusinessObject(element, getParameter(), properties);
     },
 
     hidden: function(element, node) {
@@ -178,17 +187,17 @@ module.exports = function(parameter, bpmnFactory, options, translate) {
     modelProperty: 'value',
     get: function(element, node) {
       return {
-        value: parameter.value
+        value: getParameter().value
       };
     },
 
     set: function(element, values, node) {
       values.value = values.value || undefined;
-      return cmdHelper.updateBusinessObject(element, parameter, values);
+      return cmdHelper.updateBusinessObject(element, getParameter(), values);
     },
 
     show: function(element, node) {
-      return isOpen() && !parameter.definition;
+      return isOpen() && !getParameter().definition;
     },
 
     getItems: function(element) {
@@ -242,21 +251,21 @@ module.exports = function(parameter, bpmnFactory, options, translate) {
             script.template +
           '</div>',
     get: function(element, node) {
-      return isScript(parameter.definition) ? script.get(element, parameter.definition) : {};
+      return isScript(getParameter().definition) ? script.get(element, getParameter().definition) : {};
     },
 
     set: function(element, values, node) {
       var update = script.set(element, values);
-      return cmdHelper.updateBusinessObject(element, parameter.definition, update);
+      return cmdHelper.updateBusinessObject(element, getParameter().definition, update);
     },
 
     validate: function(element, values, node) {
-      return isScript(parameter.definition) ? script.validate(element, parameter.definition) : {};
+      return isScript(getParameter().definition) ? script.validate(element, getParameter().definition) : {};
     },
 
     script: script,
     show: function(element, node) {
-      return isOpen() && parameter.definition && isScript(parameter.definition);
+      return isOpen() && getParameter().definition && isScript(getParameter().definition);
     }
   });
 
@@ -271,34 +280,34 @@ module.exports = function(parameter, bpmnFactory, options, translate) {
 
     getElements: function(element, node) {
 
-      if (isList(parameter.definition)) {
-        return parameter.definition.items;
+      if (isList(getParameter().definition)) {
+        return getParameter().definition.items;
       }
 
       return [];
     },
 
     updateElement: function(element, values, node, idx) {
-      var item = parameter.definition.items[idx];
+      var item = getParameter().definition.items[idx];
       return cmdHelper.updateBusinessObject(element, item, values);
     },
 
     addElement: function(element, node) {
-      var newValue = createElement('camunda:Value', parameter.definition, bpmnFactory, { value: undefined });
-      return cmdHelper.addElementsTolist(element, parameter.definition, 'items', [ newValue ]);
+      var newValue = createElement('camunda:Value', getParameter().definition, bpmnFactory, { value: undefined });
+      return cmdHelper.addElementsTolist(element, getParameter().definition, 'items', [ newValue ]);
     },
 
     removeElement: function(element, node, idx) {
-      return cmdHelper.removeElementsFromList(element, parameter.definition, 'items', null, [ parameter.definition.items[idx] ]);
+      return cmdHelper.removeElementsFromList(element, getParameter().definition, 'items', null, [ getParameter().definition.items[idx] ]);
     },
 
     editable: function(element, node, prop, idx) {
-      var item = parameter.definition.items[idx];
+      var item = getParameter().definition.items[idx];
       return !isMap(item) && !isList(item) && !isScript(item);
     },
 
     setControlValue: function(element, node, input, prop, value, idx) {
-      var item = parameter.definition.items[idx];
+      var item = getParameter().definition.items[idx];
 
       if (!isMap(item) && !isList(item) && !isScript(item)) {
         input.value = value;
@@ -308,7 +317,7 @@ module.exports = function(parameter, bpmnFactory, options, translate) {
     },
 
     show: function(element, node) {
-      return isOpen() && parameter.definition && isList(parameter.definition);
+      return isOpen() && getParameter().definition && isList(getParameter().definition);
     }
 
   }));
@@ -324,15 +333,15 @@ module.exports = function(parameter, bpmnFactory, options, translate) {
 
     getElements: function(element, node) {
 
-      if (parameter && isMap(parameter.definition)) {
-        return parameter.definition.entries;
+      if (getParameter() && isMap(getParameter().definition)) {
+        return getParameter().definition.entries;
       }
 
       return [];
     },
 
     updateElement: function(element, values, node, idx) {
-      var entry = parameter.definition.entries[idx];
+      var entry = getParameter().definition.entries[idx];
 
       if (isMap(entry.definition) || isList(entry.definition) || isScript(entry.definition)) {
         values = {
@@ -344,21 +353,21 @@ module.exports = function(parameter, bpmnFactory, options, translate) {
     },
 
     addElement: function(element, node) {
-      var newEntry = createElement('camunda:Entry', parameter.definition, bpmnFactory, { key: undefined, value: undefined });
-      return cmdHelper.addElementsTolist(element, parameter.definition, 'entries', [ newEntry ]);
+      var newEntry = createElement('camunda:Entry', getParameter().definition, bpmnFactory, { key: undefined, value: undefined });
+      return cmdHelper.addElementsTolist(element, getParameter().definition, 'entries', [ newEntry ]);
     },
 
     removeElement: function(element, node, idx) {
-      return cmdHelper.removeElementsFromList(element, parameter.definition, 'entries', null, [ parameter.definition.entries[idx] ]);
+      return cmdHelper.removeElementsFromList(element, getParameter().definition, 'entries', null, [ getParameter().definition.entries[idx] ]);
     },
 
     editable: function(element, node, prop, idx) {
-      var entry = parameter.definition.entries[idx];
+      var entry = getParameter().definition.entries[idx];
       return prop === 'key' || (!isMap(entry.definition) && !isList(entry.definition) && !isScript(entry.definition));
     },
 
     setControlValue: function(element, node, input, prop, value, idx) {
-      var entry = parameter.definition.entries[idx];
+      var entry = getParameter().definition.entries[idx];
 
       if (prop === 'key' || (!isMap(entry.definition) && !isList(entry.definition) && !isScript(entry.definition))) {
         input.value = value;
@@ -368,7 +377,7 @@ module.exports = function(parameter, bpmnFactory, options, translate) {
     },
 
     show: function(element, node) {
-      return isOpen() && parameter.definition && isMap(parameter.definition);
+      return isOpen() && getParameter().definition && isMap(getParameter().definition);
     }
 
   }));

--- a/styles/properties.less
+++ b/styles/properties.less
@@ -524,6 +524,72 @@ label.bpp-hidden {
   content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpolygon fill='%23909090' fill-rule='evenodd' points='15 8 9 13 9 9 2 9 2 7 9 7 9 3'/%3E%3C/svg%3E");
 }
 
+.bpp-toggle-switch {
+
+  .bpp-field-wrapper {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .bpp-field-wrapper.bpp-hidden {
+    .bpp-hidden;
+  }
+
+  .bpp-toggle-switch__label {
+    margin: 0;
+    margin-left: 6px;
+  }
+
+  .bpp-toggle-switch__switcher {
+    position: relative;
+    width: 48px;
+    height: 20px;
+
+    input[type='checkbox'] {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    .bpp-toggle-switch__slider {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: @silver-darken-80;
+      -webkit-transition: 0.4s;
+      transition: 0.4s;
+      border-radius: 34px;
+
+      &:before {
+        position: absolute;
+        content: "";
+        height: 16px;
+        width: 16px;
+        left: 2px;
+        bottom: 2px;
+        background-color: white;
+        -webkit-transition: 0.4s;
+        transition: 0.4s;
+        border-radius: 50%;
+      }
+    }
+
+    input[type='checkbox']:checked + .bpp-toggle-switch__slider {
+      background-color: @blue-base-65;
+      box-shadow: 0 0 1px @blue-base-65;
+
+      &:before {
+        -webkit-transform: translateX(28px);
+        -ms-transform: translateX(28px);
+        transform: translateX(28px);
+      }
+    }
+  }
+}
+
 @import "./header";
 @import "./groups";
 @import "./listeners";

--- a/test/spec/factory/ToggleSwitchEntryFactorySpec.js
+++ b/test/spec/factory/ToggleSwitchEntryFactorySpec.js
@@ -1,0 +1,39 @@
+var EntryFactory = require('lib/factory/EntryFactory'),
+    ToggleSwitchEntry = EntryFactory.toggleSwtich;
+
+
+describe('factory/ToggleSwitchEntry', function() {
+
+  describe('rendering', function() {
+
+    it('should render', function() {
+
+      // when
+      var html = ToggleSwitchEntry({
+        id: 'foo',
+        label: 'label',
+        labelOff: 'off',
+        labelOn: 'on',
+        descriptionOff: 'this is off',
+        descriptionOn: 'this is on',
+        modelProperty: 'toggle'
+      }).html;
+
+
+      // then
+      expect(html).to.eql('<label for="foo" >label</label>' +
+      '<div class="bpp-field-wrapper">' +
+        '<label class="bpp-toggle-switch__switcher">' +
+          '<input id="foo" type="checkbox" name="toggle" />' +
+          '<span class="bpp-toggle-switch__slider"></span>' +
+        '</label>'+
+        '<p class="bpp-toggle-switch__label" data-show="isOn">on</p>' +
+        '<p class="bpp-toggle-switch__label" data-show="isOff">off</p>' +
+      '</div>' +
+      '<div class="bpp-field-description"data-show="isOn">this is on</div>' +
+      '<div class="bpp-field-description"data-show="isOff">this is off</div>');
+    });
+
+  });
+
+});

--- a/test/spec/provider/camunda/element-templates/parts/InputParametersProps.json
+++ b/test/spec/provider/camunda/element-templates/parts/InputParametersProps.json
@@ -33,6 +33,13 @@
           "name": "template",
           "scriptFormat": "freemarker"
         }
+      },
+      {
+        "label": "notCreated",
+        "binding": {
+          "type": "camunda:inputParameter",
+          "name": "notCreated"
+        }
       }
     ]
   }

--- a/test/spec/provider/camunda/element-templates/parts/InputParametersPropsSpec.js
+++ b/test/spec/provider/camunda/element-templates/parts/InputParametersPropsSpec.js
@@ -215,6 +215,142 @@ describe('element-templates/parts - Collapsible Input Parameters', function() {
   });
 
 
+  describe('parameter toggle', function() {
+
+    describe('toggle off', function() {
+
+      var task;
+
+      beforeEach(inject(function() {
+
+        // given
+        task = selectAndGet('SimpleTask');
+
+        var toggle = entrySelect(
+          'template-inputs-my.domain.SimpleWorkerTask-0-assignment-toggle',
+          'input'
+        );
+
+        var collapsibleTitle = entrySelect(
+          'template-inputs-my.domain.SimpleWorkerTask-0-collapsible',
+          '.bpp-collapsible__title'
+        );
+
+        // assure item is collapsed
+        TestHelper.triggerEvent(collapsibleTitle, 'click');
+
+        // when
+        TestHelper.triggerEvent(toggle, 'click');
+      }));
+
+
+      it('should remove', function() {
+
+        // then
+        var inputParameter = getParameter(task, 'recipient');
+
+        expect(inputParameter).to.not.exist;
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        var inputParameter = getParameter(task, 'recipient');
+
+        expect(inputParameter).to.exist;
+        expect(inputParameter.name).to.equal('recipient');
+        expect(inputParameter.value).to.equal('recipient');
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        var inputParameter = getParameter(task, 'recipient');
+
+        expect(inputParameter).to.not.exist;
+      }));
+
+    });
+
+
+    describe('toggle on', function() {
+
+      var task;
+
+      beforeEach(inject(function() {
+
+        // given
+        task = selectAndGet('SimpleTask');
+
+        var toggle = entrySelect(
+          'template-inputs-my.domain.SimpleWorkerTask-4-assignment-toggle',
+          'input'
+        );
+
+        var collapsibleTitle = entrySelect(
+          'template-inputs-my.domain.SimpleWorkerTask-4-collapsible',
+          '.bpp-collapsible__title'
+        );
+
+        // assure item is collapsed
+        TestHelper.triggerEvent(collapsibleTitle, 'click');
+
+        // when
+        TestHelper.triggerEvent(toggle, 'click');
+      }));
+
+
+      it('should create', function() {
+
+        // then
+        var inputParameter = getParameter(task, 'notCreated');
+
+        expect(inputParameter).to.exist;
+        expect(inputParameter.name).to.equal('notCreated');
+        expect(inputParameter.value).to.be.null;
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        var inputParameter = getParameter(task, 'notCreated');
+
+        expect(inputParameter).to.not.exist;
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        var inputParameter = getParameter(task, 'notCreated');
+
+        expect(inputParameter).to.exist;
+        expect(inputParameter.name).to.equal('notCreated');
+        expect(inputParameter.value).to.be.null;
+      }));
+
+    });
+
+  });
+
+
   describe('should update parameter value', function() {
     var task;
 
@@ -242,8 +378,7 @@ describe('element-templates/parts - Collapsible Input Parameters', function() {
     it('should execute', function() {
 
       // then
-      var inputOutput = findExtension(task, 'camunda:InputOutput'),
-          inputParameter = findInputParameter(inputOutput, { name: 'recipient' });
+      var inputParameter = getParameter(task, 'recipient');
 
       expect(inputParameter.value).to.equal('bar');
     });
@@ -254,8 +389,7 @@ describe('element-templates/parts - Collapsible Input Parameters', function() {
       // when
       commandStack.undo();
 
-      var inputOutput = findExtension(task, 'camunda:InputOutput'),
-          inputParameter = findInputParameter(inputOutput, { name: 'recipient' });
+      var inputParameter = getParameter(task, 'recipient');
 
       // then
       expect(inputParameter.value).to.equal('recipient');
@@ -268,8 +402,7 @@ describe('element-templates/parts - Collapsible Input Parameters', function() {
       commandStack.undo();
       commandStack.redo();
 
-      var inputOutput = findExtension(task, 'camunda:InputOutput'),
-          inputParameter = findInputParameter(inputOutput, { name: 'recipient' });
+      var inputParameter = getParameter(task, 'recipient');
 
       // then
       expect(inputParameter.value).to.equal('bar');
@@ -278,3 +411,12 @@ describe('element-templates/parts - Collapsible Input Parameters', function() {
   });
 
 });
+
+
+// helper ////////////////////
+
+function getParameter(task, parameterName) {
+  var inputOutput = findExtension(task, 'camunda:InputOutput');
+
+  return findInputParameter(inputOutput, { name: parameterName });
+}

--- a/test/spec/provider/camunda/element-templates/parts/OutputParametersProps.json
+++ b/test/spec/provider/camunda/element-templates/parts/OutputParametersProps.json
@@ -35,6 +35,13 @@
           "type": "camunda:outputParameter",
           "source": "spaces"
         }
+      },
+      {
+        "label": "notCreated",
+        "binding": {
+          "type": "camunda:outputParameter",
+          "source": "notCreated"
+        }
       }
     ]
   }

--- a/test/spec/provider/camunda/element-templates/parts/OutputParametersPropsSpec.js
+++ b/test/spec/provider/camunda/element-templates/parts/OutputParametersPropsSpec.js
@@ -70,6 +70,143 @@ describe('element-templates/parts - Collapsible Output Parameters', function() {
   }));
 
 
+
+  describe('parameter toggle', function() {
+
+    describe('toggle off', function() {
+
+      var task;
+
+      beforeEach(inject(function() {
+
+        // given
+        task = selectAndGet('SimpleTask');
+
+        var toggle = entrySelect(
+          'template-outputs-my.domain.SimpleWorkerTask-0-assignment-toggle',
+          'input'
+        );
+
+        var collapsibleTitle = entrySelect(
+          'template-outputs-my.domain.SimpleWorkerTask-0-collapsible',
+          '.bpp-collapsible__title'
+        );
+
+        // assure item is collapsed
+        TestHelper.triggerEvent(collapsibleTitle, 'click');
+
+        // when
+        TestHelper.triggerEvent(toggle, 'click');
+      }));
+
+
+      it('should remove', function() {
+
+        // then
+        var outputParameter = getParameter(task, '${resultStatus}');
+
+        expect(outputParameter).to.not.exist;
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        var inputParameter = getParameter(task, '${resultStatus}');
+
+        expect(inputParameter).to.exist;
+        expect(inputParameter.name).to.equal('resultStatus');
+        expect(inputParameter.value).to.equal('${resultStatus}');
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        var outputParameter = getParameter(task, '${resultStatus}');
+
+        expect(outputParameter).to.not.exist;
+      }));
+
+    });
+
+
+    describe('toggle on', function() {
+
+      var task;
+
+      beforeEach(inject(function() {
+
+        // given
+        task = selectAndGet('SimpleTask');
+
+        var toggle = entrySelect(
+          'template-outputs-my.domain.SimpleWorkerTask-4-assignment-toggle',
+          'input'
+        );
+
+        var collapsibleTitle = entrySelect(
+          'template-outputs-my.domain.SimpleWorkerTask-4-collapsible',
+          '.bpp-collapsible__title'
+        );
+
+        // assure item is collapsed
+        TestHelper.triggerEvent(collapsibleTitle, 'click');
+
+        // when
+        TestHelper.triggerEvent(toggle, 'click');
+      }));
+
+
+      it('should create', function() {
+
+        // then
+        var outputParameter = getParameter(task, 'notCreated');
+
+        expect(outputParameter).to.exist;
+        expect(outputParameter.value).to.equal('notCreated');
+        expect(outputParameter.name).to.be.null;
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        var outputParameter = getParameter(task, 'notCreated');
+
+        expect(outputParameter).to.not.exist;
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        var outputParameter = getParameter(task, 'notCreated');
+
+        expect(outputParameter).to.exist;
+        expect(outputParameter.value).to.equal('notCreated');
+        expect(outputParameter.name).to.be.null;
+      }));
+
+    });
+
+  });
+
+
   describe('should update parameter value', function() {
     var task;
 
@@ -97,8 +234,7 @@ describe('element-templates/parts - Collapsible Output Parameters', function() {
     it('should execute', function() {
 
       // then
-      var inputOutput = findExtension(task, 'camunda:InputOutput'),
-          outputParameter = findOutputParameter(inputOutput, { source: '${resultStatus}' });
+      var outputParameter = getParameter(task, '${resultStatus}');
 
       expect(outputParameter.name).to.equal('bar');
     });
@@ -109,8 +245,7 @@ describe('element-templates/parts - Collapsible Output Parameters', function() {
       // when
       commandStack.undo();
 
-      var inputOutput = findExtension(task, 'camunda:InputOutput'),
-          outputParameter = findOutputParameter(inputOutput, { source: '${resultStatus}' });
+      var outputParameter = getParameter(task, '${resultStatus}');
 
       // then
       expect(outputParameter.name).to.equal('resultStatus');
@@ -123,8 +258,7 @@ describe('element-templates/parts - Collapsible Output Parameters', function() {
       commandStack.undo();
       commandStack.redo();
 
-      var inputOutput = findExtension(task, 'camunda:InputOutput'),
-          outputParameter = findOutputParameter(inputOutput, { source: '${resultStatus}' });
+      var outputParameter = getParameter(task, '${resultStatus}');
 
       // then
       expect(outputParameter.name).to.equal('bar');
@@ -197,3 +331,12 @@ describe('element-templates/parts - Collapsible Output Parameters', function() {
   });
 
 });
+
+
+// helper ////////////////////
+
+function getParameter(task, source) {
+  var inputOutput = findExtension(task, 'camunda:InputOutput');
+
+  return findOutputParameter(inputOutput, { source: source });
+}


### PR DESCRIPTION
* Do not render IO tab items when a template is applied (avoid unnecessary rerendering)
* Make InputOutputParameter implementation more configurable for reusability
* Add Parameter Toggle

![Kapture 2020-09-30 at 14 42 30](https://user-images.githubusercontent.com/9433996/94686530-402b7900-032b-11eb-86c4-a4b233bc16bc.gif)


__Which issue does this PR address?__

Closes #365

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js-properties-panel/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
