### PR TITLE
fix(styles): prevent hiding group-headers

### DIFF
--- a/styles/groups.less
+++ b/styles/groups.less
@@ -57,7 +57,7 @@
       background-color: @bpp-group-toggle-hover-color;
     }
 
-    > div {
+    > div:not(.group-header) {
       display: none;
     }
 


### PR DESCRIPTION
With https://github.com/bpmn-io/bpmn-js-properties-panel/commit/f53fd5c890dd90b3624574d9c71e9199c3596658 we introduced the `group-header` selector, which is also used in `div` elements. Therefore the bug results because all `div` elements got hidden on the toggle. This fixes this behavior.

![Kapture 2020-10-01 at 11 16 02](https://user-images.githubusercontent.com/9433996/94791145-863e1680-03d7-11eb-8d23-5c77bec4fce9.gif)

<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

Closes #373

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js-properties-panel/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
