### PR TITLE
fix(element-templates): correct removal of event template

### DIFF
--- a/lib/provider/camunda/element-templates/parts/DescriptionProps.js
+++ b/lib/provider/camunda/element-templates/parts/DescriptionProps.js
@@ -168,7 +168,7 @@ function getEventDefinitionType(businessObject) {
     return null;
   }
 
-  var eventDefinition = businessObject.eventDefinition[ 0 ];
+  var eventDefinition = businessObject.eventDefinitions[ 0 ];
 
   if (!eventDefinition) {
     return null;

--- a/test/spec/provider/camunda/element-templates/parts/DescriptionProps.bpmn
+++ b/test/spec/provider/camunda/element-templates/parts/DescriptionProps.bpmn
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1ysjldv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.3.0-nightly.20200918">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1ysjldv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.0.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:task id="Task" name="Task" camunda:modelerTemplate="task" />
     <bpmn:task id="Task_Description" name="Task_Description" camunda:modelerTemplate="task.description" camunda:asyncBefore="true" />
     <bpmn:task id="Task_TemplateNotFound" name="Task_TemplateNotFound" camunda:modelerTemplate="task.noTemplate" />
+    <bpmn:startEvent id="StartEvent_Template" name="StartEvent_Template" camunda:modelerTemplate="StartEvent_Template" camunda:asyncBefore="true">
+      <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_1iu9k3o">
+        <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+      </bpmn:conditionalEventDefinition>
+    </bpmn:startEvent>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -15,6 +20,12 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_01zv0pp_di" bpmnElement="Task_TemplateNotFound">
         <dc:Bounds x="540" y="60" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10cvtz7_di" bpmnElement="StartEvent_Template">
+        <dc:Bounds x="192" y="232" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="167" y="275" width="87" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/camunda/element-templates/parts/DescriptionProps.json
+++ b/test/spec/provider/camunda/element-templates/parts/DescriptionProps.json
@@ -28,5 +28,27 @@
         }
       }
     ]
+  },
+  {
+    "name": "StartEvent_Template",
+    "description": "Description",
+    "metadata": {
+      "lastModified": 1000000000000
+    },
+    "id": "startEvent.template",
+    "appliesTo": [
+      "bpmn:StartEvent"
+    ],
+    "properties": [
+      {
+        "label": "Async Before",
+        "type": "Boolean",
+        "value": true,
+        "binding": {
+          "type": "property",
+          "name": "camunda:asyncBefore"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/provider/camunda/element-templates/parts/DescriptionPropsSpec.js
+++ b/test/spec/provider/camunda/element-templates/parts/DescriptionPropsSpec.js
@@ -99,7 +99,7 @@ describe('element-templates/parts - Description Properties', function() {
 
   describe('dropdown', function() {
 
-    it('should unlink template', inject(function(elementRegistry) {
+    it('should unlink task template', inject(function(elementRegistry) {
 
       // given
       selectAndGet('Task_Description');
@@ -115,7 +115,7 @@ describe('element-templates/parts - Description Properties', function() {
     }));
 
 
-    it('should remove template', inject(function(elementRegistry) {
+    it('should remove task template', inject(function(elementRegistry) {
 
       // given
       selectAndGet('Task_Description');
@@ -129,6 +129,24 @@ describe('element-templates/parts - Description Properties', function() {
 
       expect(taskBo.modelerTemplate).not.to.exist;
       expect(taskBo.asyncBefore).to.be.false;
+    }));
+
+
+    it('should remove conditional event template', inject(function(elementRegistry) {
+
+      // given
+      selectAndGet('StartEvent_Template');
+
+      // when
+      clickDropdownMenuItem('elementTemplateDescription', 'element-template-remove');
+
+      // then
+      var event = elementRegistry.get('StartEvent_Template'),
+          eventBo = getBusinessObject(event);
+
+      expect(eventBo.modelerTemplate).not.to.exist;
+      expect(eventBo.eventDefinitions).to.have.length(1);
+      expect(eventBo.asyncBefore).to.be.false;
     }));
 
   });


### PR DESCRIPTION
Properly retrieve event definition from template.

Related to https://github.com/camunda/camunda-modeler/issues/1990

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js-properties-panel/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
