### PR TITLE
deps: remove bpmn-font dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,3 @@ node_js: 14
 
 script:
   - npm run all
-before_script:
-  - ./tasks/wiredeps
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1210,12 +1210,6 @@
         "type-is": "~1.6.17"
       }
     },
-    "bpmn-font": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/bpmn-font/-/bpmn-font-0.9.0.tgz",
-      "integrity": "sha512-Pug+qMkarD0GUZ9z16cUkM3fYz7TZ6Or8bS1vQVrOCH/u8bC3m4ewoexs46H0OA1neFUZrdRwWSKXXkz574wzg==",
-      "dev": true
-    },
     "bpmn-js": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-7.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "bpmn-font": "^0.9.0",
     "bpmn-js": "^7.4.0",
     "bpmn-moddle": "^7.0.3",
     "camunda-bpmn-moddle": "^4.4.1",

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -8,7 +8,7 @@ var domQuery = require('min-dom').query,
 
 
 TestHelper.insertCSS('diagram-js.css', require('diagram-js/assets/diagram-js.css'));
-TestHelper.insertCSS('bpmn-embedded.css', require('bpmn-font/dist/css/bpmn-embedded.css'));
+TestHelper.insertCSS('bpmn-embedded.css', require('bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css'));
 TestHelper.insertCSS('properties.css', require('./assets/properties.css'));
 
 TestHelper.insertCSS('diagram-js-testing.css',

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -7,7 +7,7 @@ var domQuery = require('min-dom').query,
     domAttr = require('min-dom').attr;
 
 
-TestHelper.insertCSS('diagram-js.css', require('diagram-js/assets/diagram-js.css'));
+TestHelper.insertCSS('diagram-js.css', require('bpmn-js/dist/assets/diagram-js.css'));
 TestHelper.insertCSS('bpmn-embedded.css', require('bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css'));
 TestHelper.insertCSS('properties.css', require('./assets/properties.css'));
 


### PR DESCRIPTION
This removes the `bpmn-font` dependency that is not needed anymore, as the required assets are inlined / shipped with bpmn-js.