### PR TITLE
Add 'participant-' prefix to name and id inputs for clarity

### DIFF
--- a/lib/provider/bpmn/BpmnPropertiesProvider.js
+++ b/lib/provider/bpmn/BpmnPropertiesProvider.js
@@ -14,15 +14,15 @@ var processProps = require('./parts/ProcessProps'),
     nameProps = require('./parts/NameProps'),
     executableProps = require('./parts/ExecutableProps');
 
-function getIdOptions(element, translate) {
+function getIdOptions(element) {
   if (is(element, 'bpmn:Participant')) {
-    return { id: 'participant-id', label: translate('Participant Id') };
+    return { id: 'participant-id', label: 'Participant Id' };
   }
 }
 
-function getNameOptions(element, translate) {
+function getNameOptions(element) {
   if (is(element, 'bpmn:Participant')) {
-    return { id: 'participant-name', label: translate('Participant Name') };
+    return { id: 'participant-name', label: 'Participant Name' };
   }
 }
 
@@ -35,8 +35,8 @@ function createGeneralTabGroups(
     label: translate('General'),
     entries: []
   };
-  idProps(generalGroup, element, translate, getIdOptions(element, translate));
-  nameProps(generalGroup, element, bpmnFactory, canvas, translate, getNameOptions(element, translate));
+  idProps(generalGroup, element, translate, getIdOptions(element));
+  nameProps(generalGroup, element, bpmnFactory, canvas, translate, getNameOptions(element));
   processProps(generalGroup, element, translate);
   executableProps(generalGroup, element, translate);
 

--- a/lib/provider/bpmn/BpmnPropertiesProvider.js
+++ b/lib/provider/bpmn/BpmnPropertiesProvider.js
@@ -1,7 +1,8 @@
 'use strict';
 
 
-var inherits = require('inherits');
+var inherits = require('inherits'),
+    is = require('bpmn-js/lib/util/ModelUtil').is;
 
 var PropertiesActivator = require('../../PropertiesActivator');
 
@@ -13,6 +14,18 @@ var processProps = require('./parts/ProcessProps'),
     nameProps = require('./parts/NameProps'),
     executableProps = require('./parts/ExecutableProps');
 
+function getIdOptions(element, translate) {
+  if (is(element, 'bpmn:Participant')) {
+    return { id: 'participant-id', label: translate('Participant Id') };
+  }
+}
+
+function getNameOptions(element, translate) {
+  if (is(element, 'bpmn:Participant')) {
+    return { id: 'participant-name', label: translate('Participant Name') };
+  }
+}
+
 function createGeneralTabGroups(
     element, canvas, bpmnFactory,
     elementRegistry, translate) {
@@ -22,8 +35,8 @@ function createGeneralTabGroups(
     label: translate('General'),
     entries: []
   };
-  idProps(generalGroup, element, translate);
-  nameProps(generalGroup, element, bpmnFactory, canvas, translate);
+  idProps(generalGroup, element, translate, getIdOptions(element, translate));
+  nameProps(generalGroup, element, bpmnFactory, canvas, translate, getNameOptions(element, translate));
   processProps(generalGroup, element, translate);
   executableProps(generalGroup, element, translate);
 

--- a/lib/provider/bpmn/parts/IdProps.js
+++ b/lib/provider/bpmn/parts/IdProps.js
@@ -10,13 +10,11 @@ module.exports = function(group, element, translate, options) {
     options = {};
   }
 
-  var description = options && options.description;
-
   // Id
   group.entries.push(entryFactory.validationAwareTextField(translate, {
     id: options.id || 'id',
-    label: options.label || translate('Id'),
-    description: description && translate(description),
+    label: translate(options.label || 'Id'),
+    description: options.description && translate(options.description),
     modelProperty: 'id',
     getProperty: function(element) {
       return getBusinessObject(element).id;

--- a/lib/provider/bpmn/parts/IdProps.js
+++ b/lib/provider/bpmn/parts/IdProps.js
@@ -15,7 +15,7 @@ module.exports = function(group, element, translate, options) {
   // Id
   group.entries.push(entryFactory.validationAwareTextField(translate, {
     id: options.id || 'id',
-    label: translate('Id'),
+    label: options.label || translate('Id'),
     description: description && translate(description),
     modelProperty: 'id',
     getProperty: function(element) {

--- a/lib/provider/bpmn/parts/NameProps.js
+++ b/lib/provider/bpmn/parts/NameProps.js
@@ -47,7 +47,7 @@ module.exports = function(group, element, bpmnFactory, canvas, translate, option
   if (!is(element, 'bpmn:Collaboration')) {
     var nameOptions = {
       id: options.id,
-      label: options.label
+      label: options.label && translate(options.label)
     };
 
     if (is(element, 'bpmn:TextAnnotation')) {

--- a/lib/provider/bpmn/parts/NameProps.js
+++ b/lib/provider/bpmn/parts/NameProps.js
@@ -46,7 +46,8 @@ module.exports = function(group, element, bpmnFactory, canvas, translate, option
 
   if (!is(element, 'bpmn:Collaboration')) {
     var nameOptions = {
-      id: options.id
+      id: options.id,
+      label: options.label
     };
 
     if (is(element, 'bpmn:TextAnnotation')) {

--- a/lib/provider/camunda/CamundaPropertiesProvider.js
+++ b/lib/provider/camunda/CamundaPropertiesProvider.js
@@ -133,12 +133,23 @@ var PROCESS_KEY_HINT = 'This maps to the process definition key.';
 var TASK_KEY_HINT = 'This maps to the task definition key.';
 
 function getIdOptions(element) {
+
+  if (is(element, 'bpmn:Participant')) {
+    return { id: 'participant-id', label: 'Participant Id' };
+  }
+
   if (is(element, 'bpmn:Process')) {
     return { description: PROCESS_KEY_HINT };
   }
 
   if (is(element, 'bpmn:UserTask')) {
     return { description: TASK_KEY_HINT };
+  }
+}
+
+function getNameOptions(element) {
+  if (is(element, 'bpmn:Participant')) {
+    return { id: 'participant-name', label: 'Participant Name' };
   }
 }
 
@@ -214,7 +225,7 @@ function createGeneralTabGroups(
   };
 
   idProps(generalGroup, element, translate, getIdOptions(element));
-  nameProps(generalGroup, element, bpmnFactory, canvas, translate);
+  nameProps(generalGroup, element, bpmnFactory, canvas, translate, getNameOptions(element));
   processProps(generalGroup, element, translate, getProcessOptions(element));
   versionTag(generalGroup, element, translate);
   executableProps(generalGroup, element, translate);

--- a/test/spec/provider/bpmn/ProcessParticipantCollapsedSpec.js
+++ b/test/spec/provider/bpmn/ProcessParticipantCollapsedSpec.js
@@ -62,7 +62,7 @@ describe('process-participant-collapsed-properties', function() {
 
 
     // then
-    var input = domQuery('div[data-entry=id] input[name=id]', propertiesPanel._container);
+    var input = domQuery('div[data-entry=participant-id] input[name=id]', propertiesPanel._container);
     expect(input.value).to.equal(participant.get('id'));
   }));
 
@@ -78,7 +78,7 @@ describe('process-participant-collapsed-properties', function() {
 
 
     // then
-    var input = domQuery('div[data-entry=name] div[name=name]', propertiesPanel._container);
+    var input = domQuery('div[data-entry=participant-name] div[name=name]', propertiesPanel._container);
     expect(input.textContent).to.equal(participant.get('name'));
   }));
 
@@ -94,7 +94,7 @@ describe('process-participant-collapsed-properties', function() {
       selection.select(shape);
 
       participant = getBusinessObject(shape);
-      textbox = domQuery('div[data-entry=name] div[name=name]');
+      textbox = domQuery('div[data-entry=participant-name] div[name=name]');
 
       // when
       TestHelper.triggerValue(textbox, 'foo', 'change');

--- a/test/spec/provider/bpmn/ProcessParticipantExpandedSpec.js
+++ b/test/spec/provider/bpmn/ProcessParticipantExpandedSpec.js
@@ -146,7 +146,7 @@ describe('process-participant-expanded-properties', function() {
 
 
     // then
-    var input = domQuery('div[data-entry=id] input[name=id]', propertiesPanel._container);
+    var input = domQuery('div[data-entry=participant-id] input[name=id]', propertiesPanel._container);
     expect(input.value).to.equal(participant.get('id'));
   }));
 
@@ -162,7 +162,7 @@ describe('process-participant-expanded-properties', function() {
 
 
     // then
-    var input = domQuery('div[data-entry=name] div[name=name]', propertiesPanel._container);
+    var input = domQuery('div[data-entry=participant-name] div[name=name]', propertiesPanel._container);
     expect(input.textContent).to.equal(participant.get('name'));
   }));
 
@@ -178,7 +178,7 @@ describe('process-participant-expanded-properties', function() {
       selection.select(shape);
 
       participant = getBusinessObject(shape);
-      textbox = domQuery('div[data-entry=name] div[name=name]');
+      textbox = domQuery('div[data-entry=participant-name] div[name=name]');
 
       // when
       TestHelper.triggerValue(textbox, 'foo', 'change');

--- a/test/spec/provider/bpmn/ProcessParticipantSpec.js
+++ b/test/spec/provider/bpmn/ProcessParticipantSpec.js
@@ -148,7 +148,7 @@ describe('process-participant-properties', function() {
 
 
     // then
-    var input = domQuery('div[data-entry=id] input[name=id]', propertiesPanel._container);
+    var input = domQuery('div[data-entry=participant-id] input[name=id]', propertiesPanel._container);
     expect(input.value).to.equal(participant.get('id'));
   }));
 
@@ -164,7 +164,7 @@ describe('process-participant-properties', function() {
 
 
     // then
-    var input = domQuery('div[data-entry=name] div[name=name]', propertiesPanel._container);
+    var input = domQuery('div[data-entry=participant-name] div[name=name]', propertiesPanel._container);
     expect(input.textContent).to.equal(participant.get('name'));
   }));
 
@@ -180,7 +180,7 @@ describe('process-participant-properties', function() {
       selection.select(shape);
 
       participant = getBusinessObject(shape);
-      textbox = domQuery('div[data-entry=name] div[name=name]');
+      textbox = domQuery('div[data-entry=participant-name] div[name=name]');
 
       // when
       TestHelper.triggerValue(textbox, 'foo', 'change');


### PR DESCRIPTION
This PR adds a "participant-" prefix to the input labels defining the name and id of a participant in the properties panel.

Closes #327 (again)

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js-properties-panel/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
