### PR TITLE
Add errors group to input output tab

### DIFF
--- a/lib/provider/bpmn/parts/implementation/ElementReferenceProperty.js
+++ b/lib/provider/bpmn/parts/implementation/ElementReferenceProperty.js
@@ -28,6 +28,7 @@ module.exports = function(element, definition, bpmnFactory, translate, options) 
   var modelProperty = options.modelProperty || 'name';
   var shouldValidate = options.shouldValidate || false;
   var description = options.description;
+  var canBeHidden = !!options.hidden && typeof options.hidden === 'function';
 
   var entry = entryFactory.textField(translate, {
     id: id,
@@ -50,6 +51,9 @@ module.exports = function(element, definition, bpmnFactory, translate, options) 
     },
 
     hidden: function(element, node) {
+      if (canBeHidden) {
+        return options.hidden.apply(definition, arguments) || !definition.get(referenceProperty);
+      }
       return !definition.get(referenceProperty);
     }
   });

--- a/lib/provider/bpmn/parts/implementation/ErrorEventDefinition.js
+++ b/lib/provider/bpmn/parts/implementation/ErrorEventDefinition.js
@@ -19,7 +19,7 @@ module.exports = function(group, element, bpmnFactory, errorEventDefinition, tra
   group.entries = group.entries.concat(
     elementReferenceProperty(element, errorEventDefinition, bpmnFactory, translate, {
       id: 'error-element-name',
-      label: translate('Global Error Name'),
+      label: translate('Name'),
       referenceProperty: 'errorRef',
       modelProperty: 'name',
       shouldValidate: true
@@ -30,7 +30,7 @@ module.exports = function(group, element, bpmnFactory, errorEventDefinition, tra
   group.entries = group.entries.concat(
     elementReferenceProperty(element, errorEventDefinition, bpmnFactory, translate, {
       id: 'error-element-code',
-      label: translate('Global Error Code'),
+      label: translate('Code'),
       referenceProperty: 'errorRef',
       modelProperty: 'errorCode'
     })

--- a/lib/provider/bpmn/parts/implementation/EventDefinitionReference.js
+++ b/lib/provider/bpmn/parts/implementation/EventDefinitionReference.js
@@ -23,7 +23,7 @@ var selector = 'select[name=selectedElement]';
  * @return {DOMElement} the select box
  */
 function getSelectBox(node) {
-  return domQuery(selector, node.parentElement);
+  return domQuery(selector, node);
 }
 
 /**
@@ -70,11 +70,19 @@ module.exports = function(element, definition, bpmnFactory, options) {
 
   var entries = [];
 
+  var canBeHidden = !!options.hidden && typeof options.hidden === 'function';
+
   entries.push({
 
-    id: 'event-definitions-' + elementName,
+    id: options.id || 'event-definitions-' + elementName,
     description: description,
-    html: '<div class="bpp-row bpp-select">' +
+    isShown: function() {
+      if (canBeHidden) {
+        return !options.hidden.apply(definition, arguments);
+      }
+      return !options.hidden;
+    },
+    html: '<div class="bpp-row bpp-select" data-show="isShown">' +
              '<label for="camunda-' + escapeHTML(elementName) + '">' + escapeHTML(label) + '</label>' +
              '<div class="bpp-field-wrapper">' +
                '<select id="camunda-' + escapeHTML(elementName) + '" name="selectedElement" data-value>' +

--- a/lib/provider/camunda/CamundaPropertiesProvider.js
+++ b/lib/provider/camunda/CamundaPropertiesProvider.js
@@ -46,7 +46,8 @@ var elementTemplateDescriptionProps = require('./element-templates/parts/Descrip
 
 // Input/Output
 var inputParameters = require('./parts/InputParametersProps'),
-    outputParameters = require('./parts/OutputParametersProps');
+    outputParameters = require('./parts/OutputParametersProps'),
+    errorsProps = require('./parts/ErrorsProps');
 
 // Connector
 var connectorDetails = require('./parts/ConnectorDetailProps'),
@@ -420,9 +421,25 @@ function createInputOutputTabGroups(element, bpmnFactory, elementTemplates, tran
 
   outputParameters(outputParametersGroup, element, bpmnFactory, elementTemplates, translate);
 
+  var errorsGroup = {
+    id: 'errors',
+    label: translate('Errors'),
+    entries: [],
+
+    enabled: function(element, node) {
+      var businessObject = getBusinessObject(element);
+      var isExternal = ImplementationTypeHelper.getImplementationType(businessObject) === 'external';
+
+      return is(element, 'bpmn:ServiceTask') && isExternal;
+    },
+  };
+
+  errorsProps(errorsGroup, element, bpmnFactory, elementTemplates, translate);
+
   return [
     inputParametersGroup,
-    outputParametersGroup
+    outputParametersGroup,
+    errorsGroup
   ];
 }
 

--- a/lib/provider/camunda/parts/ErrorsProps.js
+++ b/lib/provider/camunda/parts/ErrorsProps.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var errors = require('./implementation/Errors');
+
+module.exports = function(group, element, bpmnFactory, elementTemplates, translate) {
+
+  var template = elementTemplates.get(element);
+
+  if (template) {
+    return;
+  }
+
+  var errorsEntry = errors(element, bpmnFactory, {}, translate);
+
+  group.entries = group.entries.concat(errorsEntry.entries);
+};

--- a/lib/provider/camunda/parts/implementation/ErrorEventDefinition.js
+++ b/lib/provider/camunda/parts/implementation/ErrorEventDefinition.js
@@ -32,7 +32,7 @@ module.exports = function(
   group.entries = group.entries.concat(
     elementReferenceProperty(element, errorEventDefinition, bpmnFactory, translate, {
       id: 'error-element-message',
-      label: translate('Global Error Message'),
+      label: translate('Message'),
       referenceProperty: 'errorRef',
       modelProperty: 'errorMessage'
     })
@@ -41,7 +41,7 @@ module.exports = function(
   if (showErrorCodeVariable) {
     group.entries.push(entryFactory.validationAwareTextField(translate, {
       id: 'errorCodeVariable',
-      label: translate('Error Code Variable'),
+      label: translate('Code Variable'),
       modelProperty : 'errorCodeVariable',
       description: translate('Define the name of the variable that will contain the error code'),
 
@@ -64,7 +64,7 @@ module.exports = function(
   if (showErrorMessageVariable) {
     group.entries.push(entryFactory.validationAwareTextField(translate, {
       id: 'errorMessageVariable',
-      label: translate('Error Message Variable'),
+      label: translate('Message Variable'),
       modelProperty: 'errorMessageVariable',
 
       getProperty: getValue('errorMessageVariable'),

--- a/lib/provider/camunda/parts/implementation/Errors.js
+++ b/lib/provider/camunda/parts/implementation/Errors.js
@@ -1,0 +1,175 @@
+'use strict';
+
+var getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
+
+
+var entryFieldDescription = require('../../../../factory/EntryFieldDescription');
+
+var elementHelper = require('../../../../helper/ElementHelper'),
+    extensionElementsHelper = require('../../../../helper/ExtensionElementsHelper'),
+    cmdHelper = require('../../../../helper/CmdHelper');
+
+var ErrorsEntries = require('./ErrorsEntries');
+
+var domQuery = require('min-dom').query;
+
+module.exports = function(element, bpmnFactory, options, translate) {
+
+  options = options || {};
+
+  var result = {};
+
+  var entries = result.entries = [];
+
+  entries.push(
+    getErrorsHeading(element, bpmnFactory, {
+      type: 'camunda:ErrorEventDefinition',
+      prop: 'errorEventDefinition',
+      prefix: 'Error'
+    }));
+
+  append(entries,
+    getErrorsEntries(element, bpmnFactory, {}, translate)
+  );
+
+  return result;
+};
+
+function getErrorsHeading(element, bpmnFactory, options) {
+  var prefix = options.prefix;
+
+  var entry = {
+    id: prefix + '-heading',
+    cssClasses: [ 'bpp-error' ],
+    html: '<div class="bpp-field-wrapper">' +
+            '<button type="button" class="bpp-error__add add action-button" ' + 'data-action="createElement">' +
+            '</button><input name="hidden" type="hidden">' +
+          '</div>'
+  };
+
+  entry.createElement = function(_, entryNode) {
+    var commands = createElement();
+
+    if (commands) {
+      scheduleCommands(commands, entryNode);
+      return true;
+    }
+  };
+
+  entry.set = function() {
+    var commands = entry._commands;
+
+    if (commands) {
+      delete entry._commands;
+      return commands;
+    }
+  };
+
+  function createElement() {
+    var commands = [];
+    var bo = getBusinessObject(element);
+    var extensionElements = bo.get('extensionElements');
+
+    if (!extensionElements) {
+      extensionElements = elementHelper.createElement('bpmn:ExtensionElements', { values: [] }, bo, bpmnFactory);
+      commands.push(cmdHelper.updateBusinessObject(element, bo, { extensionElements: extensionElements }));
+    }
+    var newElem = elementHelper.createElement('camunda:ErrorEventDefinition', {}, extensionElements, bpmnFactory);
+    commands.push(cmdHelper.addElementsTolist(element, extensionElements, 'values', [ newElem ]));
+
+    return commands;
+  }
+
+  /**
+   * Schedule commands to be run with next `set` method call.
+   *
+   * @param {Array<any>} commands
+   * @param {HTMLElement} entryNode
+   */
+  function scheduleCommands(commands, entryNode) {
+    entry._commands = commands;
+
+    // @barmac: hack to make properties panel call `set`
+    var input = domQuery('input[type="hidden"]', entryNode);
+    input.value = 1;
+  }
+
+  return entry;
+}
+
+function getErrors(bo) {
+  return extensionElementsHelper.getExtensionElements(bo, 'camunda:ErrorEventDefinition') || [];
+}
+
+
+function getErrorsEntries(element, bpmnFactory, options, translate) {
+  var idPrefix = options.idPrefix || '',
+      bo = getBusinessObject(element),
+      errorEventDefinitions = getErrors(bo),
+      extensionElements = bo.get('extensionElements'),
+      entries;
+
+  if (errorEventDefinitions && !errorEventDefinitions.length) {
+    var description = entryFieldDescription(translate, translate('No errors defined.'));
+
+    return [{
+      id: idPrefix + 'error-placeholder',
+      cssClasses: [ 'bpp-error-placeholder' ],
+      html: description
+    }];
+  }
+
+  var errorsEntries = errorEventDefinitions.map(function(definition, index) {
+
+    function onRemove() {
+      var commands = [];
+
+      commands.push(cmdHelper.removeElementsFromList(element, extensionElements, 'values', 'extensionElements', [definition]));
+      return commands;
+    }
+
+    return ErrorsEntries(definition, bpmnFactory, element,
+      {
+        idPrefix: idPrefix + 'error-' + index,
+        onRemove: onRemove,
+        onToggle: onToggle
+      }, translate);
+
+    /**
+     * Close remaining collapsible entries within group.
+     *
+     * @param {boolean} value
+     * @param {HTMLElement} entryNode
+     */
+    function onToggle(value, entryNode) {
+      if (!value) {
+        return;
+      }
+
+      var currentEntryId = entryNode.dataset.entry;
+
+      errorsEntries.forEach(function(entry) {
+        if (entry.entries[0].id === currentEntryId) {
+          return;
+        }
+
+        entry.setOpen(false);
+      });
+
+    }
+  });
+
+  entries = errorsEntries.map(function(input) {
+    return input.entries;
+  });
+
+  return flatten(entries);
+}
+
+function flatten(arrays) {
+  return Array.prototype.concat.apply([], arrays);
+}
+
+function append(array, items) {
+  Array.prototype.push.apply(array, items);
+}

--- a/lib/provider/camunda/parts/implementation/ErrorsEntries.js
+++ b/lib/provider/camunda/parts/implementation/ErrorsEntries.js
@@ -1,0 +1,153 @@
+'use strict';
+
+var cmdHelper = require('../../../../helper/CmdHelper');
+
+var entryFactory = require('../../../../factory/EntryFactory');
+
+var eventDefinitionReference = require('../../../bpmn/parts/implementation/EventDefinitionReference'),
+    elementReferenceProperty = require('../../../bpmn/parts/implementation/ElementReferenceProperty');
+
+var domQuery = require('min-dom').query;
+
+module.exports = function(error, bpmnFactory, element, options, translate) {
+
+  options = options || {};
+
+  var idPrefix = options.idPrefix || '';
+
+  var getError =
+    (options.getError && typeof options.getError === 'function') ?
+      function() {
+        return options.getError();
+      } :
+      function() {
+        return error;
+      };
+
+  var result = {},
+      entries = [];
+
+  result.entries = entries;
+
+  var getCollapsibleTitle = function() {
+    var error = getError();
+    var title = 'No Error referenced';
+
+    if (error.errorRef) {
+      title = error.errorRef.name;
+      if (error.errorRef.errorCode) {
+        title += ' (code = ' + error.errorRef.errorCode + ')';
+      }
+    }
+    return title;
+  };
+
+  // heading ////////////////////////////////////////////////////////
+  var collapsible = entryFactory.collapsible({
+    id: idPrefix + 'collapsible',
+    title: getCollapsibleTitle(),
+    description: getError().expression || '',
+    cssClasses: [ 'bpp-collapsible-error' ],
+    open: false,
+    onRemove: options.onRemove,
+    onToggle: options.onToggle,
+    get: function() {
+      return {
+        title: getCollapsibleTitle(),
+        description: getError().expression || '',
+      };
+    }
+  });
+
+  var isOpen = options.isOpen || collapsible.isOpen;
+
+  result.setOpen = function(value) {
+    var entryNode = domQuery('[data-entry="' + collapsible.id + '"]');
+    collapsible.setOpen(value, entryNode);
+  };
+
+  entries.push(collapsible);
+
+  entries.push(entryFactory.validationAwareTextField(translate, {
+    id: idPrefix + 'error-expression',
+    label: translate('Throw Expression'),
+    modelProperty: 'expression',
+
+    getProperty: function(element, node) {
+      return error.expression;
+    },
+
+    setProperty: function(element, values, node) {
+      return cmdHelper.updateBusinessObject(element, error, values);
+    },
+
+    validate: function(element, values, node) {
+      var validation = {};
+      var expressionValue = values.expression;
+
+      if (!expressionValue) {
+        validation.expression = translate('Error must have an expression');
+      }
+
+      return validation;
+    },
+
+    hidden: function(element, node) {
+      return !isOpen();
+    }
+  }));
+
+
+  entries.push.apply(entries, eventDefinitionReference(element, error, bpmnFactory, {
+    id: idPrefix + 'error-reference',
+    label: translate('Global Error referenced'),
+    elementName: 'error',
+    elementType: 'bpmn:Error',
+    referenceProperty: 'errorRef',
+    newElementIdPrefix: 'Error_',
+
+    hidden: function(element, node) {
+      return !isOpen();
+    }
+  }));
+
+
+  entries.push.apply(entries, elementReferenceProperty(element, error, bpmnFactory, translate, {
+    id: idPrefix + 'error-element-name',
+    label: translate('Name'),
+    referenceProperty: 'errorRef',
+    modelProperty: 'name',
+    shouldValidate: true,
+
+    hidden: function(element, node) {
+      return !isOpen();
+    }
+  }));
+
+
+  entries.push.apply(entries, elementReferenceProperty(element, error, bpmnFactory, translate, {
+    id: idPrefix + 'error-element-code',
+    label: translate('Code'),
+    referenceProperty: 'errorRef',
+    modelProperty: 'errorCode',
+    shouldValidate: true,
+
+    hidden: function(element, node) {
+      return !isOpen();
+    }
+  }));
+
+
+  entries.push.apply(entries, elementReferenceProperty(element, error, bpmnFactory, translate, {
+    id: idPrefix + 'error-element-message',
+    label: translate('Message'),
+    referenceProperty: 'errorRef',
+    modelProperty: 'errorMessage',
+
+    hidden: function(element, node) {
+      return !isOpen();
+    }
+  }));
+
+  return result;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -848,12 +848,12 @@
       "dev": true
     },
     "camunda-bpmn-moddle": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-4.5.0.tgz",
-      "integrity": "sha512-g3d2ZaCac52WIXP3kwmYrBEkhm0nnXcWYNj5STDkmiWpDTKUzTj4ZIt38IRpci1Uj3a/rZACvXLnQj8xKFyp/w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-5.0.0.tgz",
+      "integrity": "sha512-GZ5Gv8T9NudQ6y28cVqW8XUZGlor0ZBnrEKMANYmcXF2TeSTi8nAZ/4KOBfcRdfd0FcpxKwfY0ictYGfULLoww==",
       "dev": true,
       "requires": {
-        "min-dash": "^3.0.0"
+        "min-dash": "^3.5.2"
       }
     },
     "caniuse-lite": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "bpmn-js": "^8.2.0",
     "bpmn-moddle": "^7.0.4",
-    "camunda-bpmn-moddle": "^4.5.0",
+    "camunda-bpmn-moddle": "5.0.0",
     "chai": "^4.1.2",
     "diagram-js": "^7.2.0",
     "eslint": "^7.12.1",

--- a/styles/properties.less
+++ b/styles/properties.less
@@ -499,6 +499,10 @@ label.bpp-hidden {
   margin-left: 0;
 }
 
+.bpp-collapsible ~ .bpp-properties-entry.bpp-error {
+  margin-left: 0;
+}
+
 .bpp-collapsible--with-mapping .bpp-collapsible__description:not(:empty) {
   position: relative;
 
@@ -520,6 +524,27 @@ label.bpp-hidden {
   opacity: 0.7;
 }
 
+.bpp-collapsible-error .bpp-collapsible__description:not(:empty) {
+  position: relative;
+
+  // make space for icon
+  text-indent: 24px;
+  padding-right: 24px;
+}
+
+.bpp-collapsible-error .bpp-collapsible__description:not(:empty):before {
+  position: absolute;
+  top: -1px;
+  left: -24px;
+
+  display: block;
+  width: 16px;
+  height: 16px;
+
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpolygon fill='%23909090' fill-rule='evenodd' points='8 3 8 7 15 7 15 9 8 9 8 13 2 8'/%3E%3C/svg%3E");
+  opacity: 0.7;
+}
+
 .bpp-input-output {
   .bpp-input-output__add {
     top: -28px;
@@ -527,7 +552,19 @@ label.bpp-hidden {
   }
 }
 
+.bpp-error {
+  .bpp-error__add {
+    top: -28px;
+    right: 0;
+  }
+}
+
 .bpp-input-output-placeholder {
+  padding-bottom: 3px;
+  font-size: 14px;
+}
+
+.bpp-error-placeholder {
   padding-bottom: 3px;
   font-size: 14px;
 }

--- a/test/spec/provider/camunda/ErrorsProps.bpmn
+++ b/test/spec/provider/camunda/ErrorsProps.bpmn
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0tgjhvn" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:task id="Task_1" />
+    <bpmn:serviceTask id="ServiceTask_1" camunda:type="external" camunda:topic="topic" />
+    <bpmn:serviceTask id="ServiceTask_2" camunda:type="external" camunda:topic="topic">
+      <bpmn:extensionElements>
+        <camunda:errorEventDefinition id="ErrorEventDefinition_0q92m00" />
+        <camunda:errorEventDefinition id="ErrorEventDefinition_1fvy1ka" errorRef="Error_1" />
+        <camunda:errorEventDefinition id="ErrorEventDefinition_0o1ibsr" errorRef="Error_2" expression="${expression}" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_3" camunda:expression="expression" />
+  </bpmn:process>
+  <bpmn:error id="Error_1" name="Error_1" />
+  <bpmn:error id="Error_2" name="Error_2" errorCode="123" />
+  <bpmn:error id="Error_Without_A_Name" name="" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_0lzxzdg_di" bpmnElement="Task_1">
+        <dc:Bounds x="160" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0rlbkj7_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="310" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_04wa0x4_di" bpmnElement="ServiceTask_2">
+        <dc:Bounds x="470" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_085sx66_di" bpmnElement="ServiceTask_3">
+        <dc:Bounds x="630" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/camunda/ErrorsPropsSpec.js
+++ b/test/spec/provider/camunda/ErrorsPropsSpec.js
@@ -1,0 +1,686 @@
+'use strict';
+
+var TestHelper = require('../../../TestHelper');
+
+var TestContainer = require('mocha-test-container-support');
+
+/* global bootstrapModeler, inject */
+
+var propertiesPanelModule = require('lib'),
+    coreModule = require('bpmn-js/lib/core').default,
+    selectionModule = require('diagram-js/lib/features/selection').default,
+    modelingModule = require('bpmn-js/lib/features/modeling').default,
+    propertiesProviderModule = require('lib/provider/camunda'),
+    camundaModdlePackage = require('camunda-bpmn-moddle/resources/camunda');
+
+var domQuery = require('min-dom').query,
+    domClasses = require('min-dom').classes;
+
+var getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject,
+    getExtensionElements = require('../../../../lib/helper/ExtensionElementsHelper').getExtensionElements;
+
+
+describe('error-props', function() {
+
+  var diagramXML = require('./ErrorsProps.bpmn');
+
+  var testModules = [
+    coreModule, selectionModule, modelingModule,
+    propertiesPanelModule,
+    propertiesProviderModule
+  ];
+
+  var container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: testModules,
+    moddleExtensions: { camunda: camundaModdlePackage }
+  }));
+
+  beforeEach(inject(function(propertiesPanel) {
+    propertiesPanel.attachTo(container);
+    container = propertiesPanel._container;
+  }));
+
+
+  describe('error group in input/output tab', function() {
+
+    it('should not exist on task', inject(function(elementRegistry, selection) {
+
+      // given
+      var task = elementRegistry.get('Task_1');
+
+      // when
+      selection.select(task);
+
+      var errorGroup = getErrorsGroup(container);
+
+      // then
+      expect(domClasses(errorGroup).has('bpp-hidden')).to.be.true;
+    }));
+
+
+    it('should not exist on non-external service task', inject(function(elementRegistry, selection) {
+
+      // given
+      var serviceTask = elementRegistry.get('ServiceTask_3');
+
+      // when
+      selection.select(serviceTask);
+
+      var errorGroup = getErrorsGroup(container);
+
+      // then
+      expect(domClasses(errorGroup).has('bpp-hidden')).to.be.true;
+    }));
+
+
+    it('should exist on external service task', inject(function(elementRegistry, selection) {
+
+      // given
+      var serviceTask = elementRegistry.get('ServiceTask_1');
+
+      // when
+      selection.select(serviceTask);
+
+      var errorGroup = getErrorsGroup(container);
+
+      // then
+      expect(domClasses(errorGroup).has('bpp-hidden')).to.be.false;
+    }));
+
+  });
+
+
+  describe('error entries', function() {
+
+    it('should display placeholder if there are no errors declared', inject(function(elementRegistry, selection) {
+
+      // given
+      var serviceTask = elementRegistry.get('ServiceTask_1');
+      selection.select(serviceTask);
+
+      // when
+      var noErrorLabel = domQuery('[data-entry="error-placeholder"] span', container);
+
+      // then
+      expect(noErrorLabel).to.exist;
+      expect(noErrorLabel.textContent).to.eql('No errors defined.');
+    }));
+
+
+    describe('collapsible', function() {
+
+      it('should display no error title', inject(function(elementRegistry, selection) {
+
+        // given
+        var serviceTask = elementRegistry.get('ServiceTask_2');
+        selection.select(serviceTask);
+
+        // when
+        var collapsible = getCollapsibleContainer(container, 0);
+        var collapsibleTitle = getCollapsibleTitle(collapsible);
+
+        // then
+        expect(collapsibleTitle.textContent).to.eql('No Error referenced');
+      }));
+
+
+      it('should display error title', inject(function(elementRegistry, selection) {
+
+        // given
+        var serviceTask = elementRegistry.get('ServiceTask_2');
+        selection.select(serviceTask);
+
+        // when
+        var collapsible = getCollapsibleContainer(container, 1);
+        var collapsibleTitle = getCollapsibleTitle(collapsible);
+
+        // then
+        expect(collapsibleTitle.textContent).to.eql('Error_1');
+      }));
+
+
+      it('should display error code', inject(function(elementRegistry, selection) {
+
+        // given
+        var serviceTask = elementRegistry.get('ServiceTask_2');
+        selection.select(serviceTask);
+
+        // when
+        var collapsible = getCollapsibleContainer(container, 2);
+        var collapsibleTitle = getCollapsibleTitle(collapsible);
+
+        // then
+        expect(collapsibleTitle.textContent).to.contain('(code = 123)');
+      }));
+
+
+      it('should display throw expression', inject(function(elementRegistry, selection) {
+
+        // given
+        var serviceTask = elementRegistry.get('ServiceTask_2');
+        selection.select(serviceTask);
+
+        // when
+        var collapsible = getCollapsibleContainer(container, 2);
+        var collapsibleDescription = getCollapsibleDescription(collapsible);
+
+        // then
+        expect(collapsibleDescription.textContent).to.eql('${expression}');
+      }));
+
+    });
+
+
+    describe('create camunda:ErrorEventDefinition', function() {
+
+      var serviceTask;
+
+      beforeEach(inject(function(elementRegistry, selection) {
+
+        // given
+        serviceTask = elementRegistry.get('ServiceTask_1');
+        selection.select(serviceTask);
+
+        // assume
+        expect(getCollapsibleContainer(container, 0)).to.be.null;
+        expect(getErrorEventDefinitions(serviceTask).length).to.eql(0);
+
+        // when
+        clickButton('.bpp-error__add', container);
+      }));
+
+
+      describe('in the DOM', function() {
+
+        it('should do', function() {
+
+          // when
+          var collapsible = getCollapsibleContainer(container, 0);
+
+          // then
+          expect(collapsible).to.exist;
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          var collapsible = getCollapsibleContainer(container, 0);
+
+          // then
+          expect(collapsible).to.be.null;
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+          var collapsible = getCollapsibleContainer(container, 0);
+
+          // then
+          expect(collapsible).to.exist;
+        }));
+
+      });
+
+
+      describe('on the business object', function() {
+
+        it('should do', function() {
+
+          // then
+          expect(getErrorEventDefinitions(serviceTask).length).to.eql(1);
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+
+          // then
+          expect(getErrorEventDefinitions(serviceTask).length).to.eql(0);
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expect(getErrorEventDefinitions(serviceTask).length).to.eql(1);
+        }));
+
+      });
+
+    });
+
+
+    describe('remove camunda:ErrorEventDefinition', function() {
+
+      var serviceTask;
+      var collapsible;
+
+      beforeEach(inject(function(elementRegistry, selection) {
+
+        // given
+        serviceTask = elementRegistry.get('ServiceTask_2');
+        selection.select(serviceTask);
+        collapsible = getCollapsibleContainer(container, 2);
+
+        // assume
+        expect(collapsible).to.exist;
+        expect(getErrorEventDefinitions(serviceTask).length).to.eql(3);
+
+        // when
+        clickButton('.bpp-collapsible__remove', collapsible);
+      }));
+
+
+      describe('in the DOM', function() {
+
+        it('should do', function() {
+
+          // when
+          collapsible = getCollapsibleContainer(container, 2);
+
+          // then
+          expect(collapsible).to.be.null;
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          collapsible = getCollapsibleContainer(container, 2);
+
+          // then
+          expect(collapsible).to.exist;
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+          collapsible = getCollapsibleContainer(container, 2);
+
+          // then
+          expect(collapsible).to.be.null;
+        }));
+
+      });
+
+
+      describe('on the business object', function() {
+
+        it('should do', function() {
+
+          // then
+          expect(getErrorEventDefinitions(serviceTask).length).to.eql(2);
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+
+          // then
+          expect(getErrorEventDefinitions(serviceTask).length).to.eql(3);
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expect(getErrorEventDefinitions(serviceTask).length).to.eql(2);
+        }));
+
+      });
+
+    });
+
+
+    describe('referenced errors', function() {
+
+      var serviceTask;
+
+      beforeEach(inject(function(elementRegistry, selection) {
+        serviceTask = elementRegistry.get('ServiceTask_2');
+        selection.select(serviceTask);
+      }));
+
+
+      it('should display existing errors in selectbox', function() {
+
+        // given
+        var collapsible = getCollapsibleContainer(container, 0);
+        var errorReferenceContainer = getErrorReferenceContainer(container, 0);
+
+        // when
+        toggleCollapsible(collapsible);
+        var selectBox = getSelectBox(errorReferenceContainer);
+
+        // then
+        expect(selectBox.options.length).to.eql(4); // 3 errors and 1 empty option
+      });
+
+
+      it('should update collapsible title on selecting error', function() {
+
+        // given
+        var collapsible = getCollapsibleContainer(container, 0);
+        toggleCollapsible(collapsible);
+        var errorReferenceContainer = getErrorReferenceContainer(container, 0);
+        var selectBox = getSelectBox(errorReferenceContainer);
+        var collapsibleTitle = getCollapsibleTitle(collapsible).textContent;
+
+        // assume
+        expect(selectBox.value).to.eql('');
+        expect(collapsibleTitle).to.eql('No Error referenced');
+
+        // when
+        selectOptionByValue(selectBox, 'Error_1');
+        collapsibleTitle = getCollapsibleTitle(collapsible).textContent;
+
+        // then
+        expect(collapsibleTitle).to.eql('Error_1');
+      });
+
+
+      it('should update error name on selecting error', function() {
+
+        // given
+        var collapsible = getCollapsibleContainer(container, 0);
+        toggleCollapsible(collapsible);
+        var errorReferenceContainer = getErrorReferenceContainer(container, 0);
+        var selectBox = getSelectBox(errorReferenceContainer);
+        var errorName = getErrorNameInput(container, 0).value;
+
+        // assume
+        expect(selectBox.value).to.eql('');
+        expect(errorName).to.eql('');
+
+        // when
+        selectOptionByValue(selectBox, 'Error_1');
+        errorName = getErrorNameInput(container, 0).value;
+
+        // then
+        expect(errorName).to.eql('Error_1');
+      });
+
+
+      describe('create bpmn:Error', function() {
+
+        var collapsible;
+        var errorReferenceContainer;
+        var selectBox;
+
+        beforeEach(inject(function(elementRegistry) {
+          collapsible = getCollapsibleContainer(container, 0);
+          toggleCollapsible(collapsible);
+          errorReferenceContainer = getErrorReferenceContainer(container, 0);
+          selectBox = getSelectBox(errorReferenceContainer);
+
+          // assume
+          expect(getRootErrors(elementRegistry).length).to.eql(3);
+          expect(selectBox.options.length).to.eql(4);
+
+          // when
+          clickButton('button.action-button.add', errorReferenceContainer);
+        }));
+
+
+        describe('in the DOM', function() {
+
+          it('should do', inject(function(elementRegistry) {
+            selectBox = getSelectBox(errorReferenceContainer);
+
+            // then
+            expect(selectBox.options.length).to.eql(5);
+          }));
+
+
+          it('should undo', inject(function(elementRegistry, commandStack) {
+
+            // when
+            commandStack.undo();
+            selectBox = getSelectBox(errorReferenceContainer);
+
+            // then
+            expect(selectBox.options.length).to.eql(4);
+          }));
+
+
+          it('should redo', inject(function(elementRegistry, commandStack) {
+
+            // when
+            commandStack.undo();
+            commandStack.redo();
+            selectBox = getSelectBox(errorReferenceContainer);
+
+            // then
+            expect(selectBox.options.length).to.eql(5);
+          }));
+
+        });
+
+
+        describe('on the business object', function() {
+
+          it('should do', inject(function(elementRegistry) {
+
+            // when
+            var errors = getRootErrors(elementRegistry);
+
+            // then
+            expect(errors.length).to.eql(4);
+          }));
+
+
+          it('should undo', inject(function(elementRegistry, commandStack) {
+
+            // when
+            commandStack.undo();
+            var errors = getRootErrors(elementRegistry);
+
+            // then
+            expect(errors.length).to.eql(3);
+          }));
+
+
+          it('should redo', inject(function(elementRegistry, commandStack) {
+
+            // when
+            commandStack.undo();
+            commandStack.redo();
+            var errors = getRootErrors(elementRegistry);
+
+            // then
+            expect(errors.length).to.eql(4);
+          }));
+
+        });
+
+      });
+
+    });
+
+
+    describe('validation', function() {
+
+      var serviceTask;
+
+      beforeEach(inject(function(elementRegistry, selection) {
+        serviceTask = elementRegistry.get('ServiceTask_2');
+        selection.select(serviceTask);
+
+        var collapsible = getCollapsibleContainer(container, 0);
+        toggleCollapsible(collapsible);
+
+        var errorReferenceContainer = getErrorReferenceContainer(container, 0);
+        var selectBox = getSelectBox(errorReferenceContainer);
+        selectOptionByValue(selectBox, 'Error_Without_A_Name');
+      }));
+
+
+      it('should validate throw expression', function() {
+
+        // given
+        var throwExpressionInput = getThrowExpressionInput(container, 0);
+
+        // when
+        var inputClasses = domClasses(throwExpressionInput);
+
+        // then
+        expect(inputClasses.has('invalid')).to.be.true;
+      });
+
+
+      it('should validate error name', function() {
+
+        // given
+        var errorNameInput = getErrorNameInput(container, 0);
+
+        // when
+        var inputClasses = domClasses(errorNameInput);
+
+        // then
+        expect(inputClasses.has('invalid')).to.be.true;
+      });
+
+
+      it('should validate error code', function() {
+
+        // given
+        var errorCodeInput = getErrorCodeInput(container, 0);
+
+        // when
+        var inputClasses = domClasses(errorCodeInput);
+
+        // then
+        expect(inputClasses.has('invalid')).to.be.true;
+      });
+
+
+      it('should not validate error message', function() {
+
+        // given
+        var errorMessageInput = getErrorMessageInput(container, 0);
+
+        // when
+        var inputClasses = domClasses(errorMessageInput);
+
+        // then
+        expect(inputClasses.has('invalid')).to.be.false;
+      });
+
+    });
+
+  });
+
+});
+
+// HELPERS ///////////////////
+
+// Fetch Moddle Elements
+
+function getRootErrors(elementRegistry) {
+  var process = elementRegistry.get('Process_1');
+  var definition = process.businessObject.$parent;
+  var errors = definition.rootElements.filter(function(el) {
+    return el.$type === 'bpmn:Error';
+  });
+  return errors;
+}
+
+function getErrorEventDefinitions(task) {
+  var bo = getBusinessObject(task);
+
+  return getExtensionElements(bo, 'camunda:ErrorEventDefinition') || [];
+}
+
+
+// Fetch Input Elements
+
+function getCollapsibleTitle(collapsible) {
+  return domQuery('.bpp-collapsible__title', collapsible);
+}
+
+function getCollapsibleDescription(collapsible) {
+  return domQuery('.bpp-collapsible__description', collapsible);
+}
+
+function getSelectBox(errorReference) {
+  return domQuery('select#camunda-error', errorReference);
+}
+
+function getThrowExpressionInput(container, index) {
+  return domQuery('input#camunda-error-' + index + 'error-expression');
+}
+
+function getErrorNameInput(container, index) {
+  return domQuery('input#camunda-error-' + index + 'error-element-name', container);
+}
+
+function getErrorCodeInput(container, index) {
+  return domQuery('input#camunda-error-' + index + 'error-element-code', container);
+}
+
+function getErrorMessageInput(container, index) {
+  return domQuery('input#camunda-error-' + index + 'error-element-message', container);
+}
+
+// Fetch Containers
+
+function getCollapsibleContainer(container, index) {
+  return domQuery('.bpp-collapsible[data-entry="error-' + index + 'collapsible"]', container);
+}
+
+function getErrorReferenceContainer(container, index) {
+  return domQuery('[data-entry="error-' + index + 'error-reference"]', container);
+}
+
+function getErrorsGroup(container) {
+  return domQuery('[data-group*="errors"]', getInputOutputTab(container));
+}
+
+function getInputOutputTab(container) {
+  return domQuery('div[data-tab="input-output"]', container);
+}
+
+
+// Trigger DOM Events
+
+function selectOptionByValue(selectBox, value) {
+  TestHelper.selectedByOption(selectBox, value);
+  TestHelper.triggerEvent(selectBox, 'change');
+}
+
+function toggleCollapsible(collapsible) {
+  var toggle = domQuery('[data-action="toggle"]', collapsible);
+  TestHelper.triggerEvent(toggle, 'click');
+}
+
+function clickButton(selector, container) {
+  var button = domQuery(selector, container);
+  TestHelper.triggerEvent(button, 'click');
+}


### PR DESCRIPTION
Related to camunda/camunda-modeler#2070

This PR adds the UI component of the `camunda:ErrorEventDefinition` elements in the properties panel, in the input/output tab.

2 missing features to note :
-Copying and pasting a service task with a camunda:ErrorEventDefinition that references a bpmn:Error doesn't apply the reference on paste.
-Changing the type of a service task with camunda:ErrorEventDefninitions won't delete them, just hide the errors group in the input/output tab

Those features will be added at a later stage.

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js-properties-panel/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
