### PR TITLE
Element Templates Scopes v2

### DIFF
--- a/lib/provider/camunda/element-templates/CustomElementsPropertiesActivator.js
+++ b/lib/provider/camunda/element-templates/CustomElementsPropertiesActivator.js
@@ -6,6 +6,11 @@ var getTemplateId = require('./Helper').getTemplateId;
 
 var isBoolean = require('lodash/isBoolean');
 
+var find = require('min-dash').find,
+    isNumber = require('min-dash').isNumber;
+
+var handleLegacyScopes = require('./util/handleLegacyScopes');
+
 var PropertiesActivator = require('../../../PropertiesActivator');
 
 var HIGHER_PRIORITY = 1100;
@@ -98,23 +103,51 @@ function isEntryEditable(entry, template) {
 
 function getProperty(template, entry) {
 
-  var index;
-  var idx = entry.id.replace('custom-' + template.id + '-', '');
-  if (idx.indexOf('-') !== -1) {
-    var indexes = idx.split('-');
-    if (indexes.length == 2) {
-      var scopeName = indexes[0].replace(/_/g, ':');
-      index = parseInt(indexes[1], 10);
-      if (scopeName && !isNaN(index)) {
-        return template.scopes[scopeName].properties[index];
-      }
+  var idxAsNumber,
+      scope,
+      scopeName;
+
+  var throwError = function() {
+    throw new Error('cannot extract property index for entry <' + entry.id + '>');
+  };
+
+  // (0) retrieve raw property idx from entry
+  var idxOrScope = entry.id.replace('custom-' + template.id + '-', '');
+
+  // (1) handle custom props entries
+  // e.g. custom-com.example.template-{idx}
+  if (!idxOrScope.includes('-')) {
+    idxAsNumber = parseInt(idxOrScope, 10);
+
+    if (!isNumber(idxAsNumber)) {
+      throwError();
     }
-  } else {
-    index = parseInt(idx, 10);
-    if (!isNaN(index)) {
-      return template.properties[index];
-    }
+
+    return template.properties[idxAsNumber];
   }
 
-  throw new Error('cannot extract property index for entry <' + entry.id + '>');
+  // (2) handle scope entries
+  // e.g. custom-com.example.template-camunda_Connector-{idx}
+  var entryParts = idxOrScope.split('-');
+
+  if (entryParts.length == 2) {
+    scopeName = entryParts[0].replace(/_/g, ':');
+
+    idxAsNumber = parseInt(entryParts[1], 10);
+
+    if (scopeName && isNumber(idxAsNumber)) {
+      scope = findScopeForName(handleLegacyScopes(template.scopes), scopeName);
+
+      return scope.properties[idxAsNumber];
+    }
+
+  }
+
+  throwError();
+}
+
+function findScopeForName(scopes, scopeName) {
+  return find(scopes, function(scope) {
+    return scope.type === scopeName;
+  });
 }

--- a/lib/provider/camunda/element-templates/Validator.js
+++ b/lib/provider/camunda/element-templates/Validator.js
@@ -1,8 +1,12 @@
 'use strict';
 
-var isArray = require('lodash/isArray');
-var isObject = require('lodash/isObject');
+var isArray = require('min-dash').isArray,
+    isObject = require('min-dash').isObject,
+    keys = require('min-dash').keys;
+
 var semver = require('semver');
+
+var handleLegacyScopes = require('./util/handleLegacyScopes');
 
 var DROPDOWN_TYPE = 'Dropdown';
 
@@ -16,7 +20,8 @@ var PROPERTY_TYPE = 'property',
     CAMUNDA_OUT_TYPE = 'camunda:out',
     CAMUNDA_IN_BUSINESS_KEY_TYPE = 'camunda:in:businessKey',
     CAMUNDA_EXECUTION_LISTENER = 'camunda:executionListener',
-    CAMUNDA_FIELD = 'camunda:field';
+    CAMUNDA_FIELD = 'camunda:field',
+    CAMUNDA_CONNECTOR = 'camunda:Connector';
 
 var VALID_BINDING_TYPES = [
   PROPERTY_TYPE,
@@ -155,37 +160,53 @@ function Validator() {
    * Validate given scopes and return error (if any).
    *
    * @param {TemplateDescriptor} template
-   * @param {ScopesDescriptor} scopes
+   * @param {ScopesDescriptor|Array<TemplateDescriptor>} scopes
    *
    * @return {Error} validation error, if any
    */
   this._validateScopes = function(template, scopes) {
 
     var err,
-        scope,
-        scopeName;
+        scopeType;
 
-    if (!isObject(scopes) || isArray(scopes)) {
-      return this._logError('invalid scopes, should be scopes={}', template);
+    var self = this;
+
+    // handle legacy scope descriptor
+    if (!isArray(scopes)) {
+
+      if (!isObject(scopes)) {
+        return this._logError('invalid scopes, should be scopes={} or scopes=[]', template);
+      }
+
+      // only support <camunda:Connector> for legacy scopes
+      keys(scopes).forEach(function(scope) {
+        if (scope !== CAMUNDA_CONNECTOR) {
+          err = self._logError('invalid scope <' + scope + '>, object descriptor is only supported for <' + CAMUNDA_CONNECTOR + '>', template);
+        }
+      });
     }
 
-    for (scopeName in scopes) {
-      scope = scopes[scopeName];
+    handleLegacyScopes(scopes).forEach(function(scope) {
+      scopeType = scope.type;
 
       if (!isObject(scope) || isArray(scope)) {
-        err = this._logError('invalid scope, should be scope={}', template);
+        err = self._logError('invalid scope, should be scope={}', template);
+      }
+
+      if (!scopeType) {
+        err = self._logError('invalid scope, missing type', template);
       }
 
       if (!isArray(scope.properties)) {
-        err = this._logError(
-          'missing properties=[] in scope <' + scopeName + '>', template
+        err = self._logError(
+          'missing properties=[] in scope <' + scopeType + '>', template
         );
       } else {
-        if (!this._validateProperties(template, scope.properties)) {
-          err = new Error('invalid properties in scope <' + scopeName + '>');
+        if (!self._validateProperties(template, scope.properties)) {
+          err = new Error('invalid properties in scope <' + scopeType + '>');
         }
       }
-    }
+    });
 
     return err;
   };

--- a/lib/provider/camunda/element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/lib/provider/camunda/element-templates/cmd/ChangeElementTemplateHandler.js
@@ -3,6 +3,8 @@
 var findExtension = require('../Helper').findExtension,
     findExtensions = require('../Helper').findExtensions;
 
+var handleLegacyScopes = require('../util/handleLegacyScopes');
+
 var createCamundaExecutionListenerScript = require('../CreateHelper').createCamundaExecutionListenerScript,
     createCamundaFieldInjection = require('../CreateHelper').createCamundaFieldInjection,
     createCamundaIn = require('../CreateHelper').createCamundaIn,
@@ -91,8 +93,8 @@ ChangeElementTemplateHandler.prototype.preExecute = function(context) {
     this._updateCamundaPropertyProperties(element, oldTemplate, newTemplate);
 
     // Update properties for each scope
-    forEach(newTemplate.scopes, function(newScopeTemplate, scopeName) {
-      self._updateScopeProperties(element, scopeName, oldTemplate, newScopeTemplate);
+    forEach(handleLegacyScopes(newTemplate.scopes), function(newScopeTemplate) {
+      self._updateScopeProperties(element, oldTemplate, newScopeTemplate);
     });
 
   }
@@ -730,9 +732,11 @@ ChangeElementTemplateHandler.prototype._updateProperties = function(element, old
  * @param {string} scopeName
  * @param {Object} scopeTemplate
  */
-ChangeElementTemplateHandler.prototype._updateScopeProperties = function(element, scopeName, oldTemplate, newScopeTemplate) {
+ChangeElementTemplateHandler.prototype._updateScopeProperties = function(element, oldTemplate, newScopeTemplate) {
   var bpmnFactory = this._bpmnFactory,
       commandStack = this._commandStack;
+
+  var scopeName = newScopeTemplate.type;
 
   var scopeElement = findOldScopeElement(element, scopeName);
 
@@ -1002,9 +1006,11 @@ function findOldScopeElement(element, scopeName) {
 }
 
 function findOldScopeTemplate(scopeName, oldTemplate) {
-  var scopes = oldTemplate && oldTemplate.scopes;
+  var scopes = oldTemplate && handleLegacyScopes(oldTemplate.scopes);
 
-  return scopes && scopes[ scopeName ];
+  return scopes && find(scopes, function(scope) {
+    return scope.type === scopeName;
+  });
 }
 
 /**

--- a/lib/provider/camunda/element-templates/parts/CustomProps.js
+++ b/lib/provider/camunda/element-templates/parts/CustomProps.js
@@ -22,6 +22,8 @@ var createCamundaProperty = require('../CreateHelper').createCamundaProperty,
     createCamundaInWithBusinessKey = require('../CreateHelper').createCamundaInWithBusinessKey,
     createCamundaFieldInjection = require('../CreateHelper').createCamundaFieldInjection;
 
+var handleLegacyScopes = require('../util/handleLegacyScopes');
+
 var PROPERTY_TYPE = 'property',
     CAMUNDA_PROPERTY_TYPE = 'camunda:property',
     CAMUNDA_INPUT_PARAMETER_TYPE = 'camunda:inputParameter',
@@ -137,14 +139,16 @@ module.exports = function(element, elementTemplates, bpmnFactory, translate) {
   }
 
   if (template.scopes) {
-    for (var scopeName in template.scopes) {
 
-      var scope = template.scopes[scopeName];
-      var idScopeName = scopeName.replace(/:/g, '_');
+    handleLegacyScopes(template.scopes).forEach(function(scope) {
+
+      var scopeType = scope.type;
+
+      var idScopeName = scopeType.replace(/:/g, '_');
 
       var customScopeFieldsGroup = {
         id: 'customField-' + idScopeName,
-        label: translate('Custom Fields for scope: ') + scopeName,
+        label: translate('Custom Fields for scope: ') + scopeType,
         entries: []
       };
 
@@ -152,7 +156,7 @@ module.exports = function(element, elementTemplates, bpmnFactory, translate) {
 
         var propertyId = 'custom-' + template.id + '-' + idScopeName + '-' + idx;
 
-        var scopedProperty = propertyWithScope(p, scopeName);
+        var scopedProperty = propertyWithScope(p, scopeType);
 
         entry = renderCustomField(propertyId, scopedProperty, idx);
         if (entry) {
@@ -163,7 +167,7 @@ module.exports = function(element, elementTemplates, bpmnFactory, translate) {
       if (customScopeFieldsGroup.entries.length > 0) {
         groups.push(customScopeFieldsGroup);
       }
-    }
+    });
   }
 
   return groups;

--- a/lib/provider/camunda/element-templates/util/handleLegacyScopes.js
+++ b/lib/provider/camunda/element-templates/util/handleLegacyScopes.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var assign = require('min-dash').assign,
+    forEach = require('min-dash').forEach,
+    keys = require('min-dash').keys,
+    isObject = require('min-dash').isObject;
+
+/**
+ * Converts legacy scopes descriptor to newer supported array structure.
+ *
+ * For example, it transforms
+ *
+ * scopes: {
+ *   'camunda:Connector':
+ *     { properties: []
+ *   }
+ * }
+ *
+ * to
+ *
+ * scopes: [
+ *   {
+ *     type: 'camunda:Connector',
+ *     properties: []
+ *   }
+ * ]
+ *
+ * @param {ScopesDescriptor} scopes
+ *
+ * @returns {Array}
+ */
+module.exports = function handleLegacyScopes(scopes) {
+  var scopesAsArray = [];
+
+  if (!isObject(scopes)) {
+    return scopes;
+  }
+
+  forEach(keys(scopes), function(scopeName) {
+    scopesAsArray.push(assign({
+      type: scopeName
+    }, scopes[scopeName]));
+  });
+
+  return scopesAsArray;
+};

--- a/test/spec/provider/camunda/element-templates/ValidatorSpec.js
+++ b/test/spec/provider/camunda/element-templates/ValidatorSpec.js
@@ -462,99 +462,122 @@ describe('element-templates - Validator', function() {
     });
 
 
-    it('should reject invalid scopes type', function() {
+    describe('scopes', function() {
 
-      // given
-      var templates = new Validator();
+      it('should accept scopes as array', function() {
 
-      var templateDescriptors = require('./fixtures/error-scopes-invalid');
+        // given
+        var templates = new Validator();
 
-      // when
-      templates.addAll(templateDescriptors);
+        var templateDescriptors = require('./fixtures/scopes-array');
 
-      // then
-      expect(errors(templates)).to.contain('template(id: <foo>, name: <Invalid>): invalid scopes, should be scopes={}');
+        // when
+        templates.addAll(templateDescriptors);
 
-      expect(valid(templates)).to.be.empty;
-    });
+        // then
+        expect(errors(templates)).to.be.empty;
 
-
-    it('should reject invalid scopes content', function() {
-
-      // given
-      var templates = new Validator();
-
-      var templateDescriptors = require('./fixtures/error-scopes-invalid-scope');
-
-      // when
-      templates.addAll(templateDescriptors);
-
-      // then
-      expect(errors(templates)).to.contain('template(id: <foo>, name: <Invalid>): invalid scope, should be scope={}');
-
-      expect(valid(templates)).to.be.empty;
-    });
+        expect(valid(templates)).to.have.length(1);
+      });
 
 
-    it('should reject missing scope properties', function() {
+      it('should accept scopes as object descriptor (connectors)', function() {
 
-      // given
-      var templates = new Validator();
+        // given
+        var templates = new Validator();
 
-      var templateDescriptors = require('./fixtures/error-scopes-properties-missing');
+        var templateDescriptors = require('./fixtures/scopes-single-connector');
 
-      // when
-      templates.addAll(templateDescriptors);
+        // when
+        templates.addAll(templateDescriptors);
 
-      // then
-      expect(errors(templates)).to.contain(
-        'template(id: <foo>, name: <Invalid>): missing properties=[] in scope <camunda:Connector>'
-      );
+        // then
+        expect(errors(templates)).to.be.empty;
 
-      expect(valid(templates)).to.be.empty;
-    });
+        expect(valid(templates)).to.have.length(1);
+      });
 
 
-    it('should reject scope with invalid property', function() {
+      it('should reject invalid scopes content', function() {
 
-      // given
-      var templates = new Validator();
+        // given
+        var templates = new Validator();
 
-      var templateDescriptors = require('./fixtures/error-scopes-property-invalid');
+        var templateDescriptors = require('./fixtures/error-scopes-invalid-scope');
 
-      // when
-      templates.addAll(templateDescriptors);
+        // when
+        templates.addAll(templateDescriptors);
 
-      // then
-      expect(errors(templates)).to.eql([
-        'template(id: <foo>, name: <Invalid>): invalid property type <InvalidType>; must be any of { ' +
-        'String, Text, Boolean, Hidden, Dropdown ' +
-      '}',
-        'template(id: <foo>, name: <Invalid>): invalid property.binding type <alsoInvalid>; must be any of { ' +
-        'property, camunda:property, camunda:inputParameter, ' +
-        'camunda:outputParameter, camunda:in, camunda:out, ' +
-        'camunda:in:businessKey, camunda:executionListener, ' +
-        'camunda:field ' +
-      '}'
-      ]);
-      expect(valid(templates)).to.be.empty;
-    });
+        // then
+        expect(errors(templates)).to.contain('template(id: <foo>, name: <Invalid>): invalid scope <properties>, object descriptor is only supported for <camunda:Connector>');
+
+        expect(valid(templates)).to.be.empty;
+      });
 
 
-    it('should accept scopes example template', function() {
+      it('should reject missing scope properties', function() {
 
-      // given
-      var templates = new Validator();
+        // given
+        var templates = new Validator();
 
-      var templateDescriptors = require('./fixtures/scopes');
+        var templateDescriptors = require('./fixtures/error-scopes-properties-missing');
 
-      // when
-      templates.addAll(templateDescriptors);
+        // when
+        templates.addAll(templateDescriptors);
 
-      // then
-      expect(errors(templates)).to.be.empty;
+        // then
+        expect(errors(templates)).to.contain(
+          'template(id: <foo>, name: <Invalid>): missing properties=[] in scope <camunda:Connector>'
+        );
 
-      expect(valid(templates)).to.have.length(1);
+        expect(valid(templates)).to.be.empty;
+      });
+
+
+      it('should reject missing scope type', function() {
+
+        // given
+        var templates = new Validator();
+
+        var templateDescriptors = require('./fixtures/error-scopes-type-missing');
+
+        // when
+        templates.addAll(templateDescriptors);
+
+        // then
+        expect(errors(templates)).to.contain(
+          'template(id: <foo>, name: <Invalid>): invalid scope, missing type'
+        );
+
+        expect(valid(templates)).to.be.empty;
+      });
+
+
+      it('should reject scope with invalid property', function() {
+
+        // given
+        var templates = new Validator();
+
+        var templateDescriptors = require('./fixtures/error-scopes-property-invalid');
+
+        // when
+        templates.addAll(templateDescriptors);
+
+        // then
+        expect(errors(templates)).to.eql([
+          'template(id: <foo>, name: <Invalid>): invalid property type <InvalidType>; must be any of { ' +
+          'String, Text, Boolean, Hidden, Dropdown ' +
+        '}',
+          'template(id: <foo>, name: <Invalid>): invalid property.binding type <alsoInvalid>; must be any of { ' +
+          'property, camunda:property, camunda:inputParameter, ' +
+          'camunda:outputParameter, camunda:in, camunda:out, ' +
+          'camunda:in:businessKey, camunda:executionListener, ' +
+          'camunda:field ' +
+        '}'
+        ]);
+        expect(valid(templates)).to.be.empty;
+      });
+
     });
 
 

--- a/test/spec/provider/camunda/element-templates/cmd/service-task-connector-template-1.json
+++ b/test/spec/provider/camunda/element-templates/cmd/service-task-connector-template-1.json
@@ -1,0 +1,37 @@
+{
+  "name": "Service Task Template - Connector V1",
+  "id": "service-task-template-connector",
+  "version": 1,
+  "appliesTo": [
+    "bpmn:ServiceTask"
+  ],
+  "properties": [],
+  "scopes": [
+    {
+      "type": "camunda:Connector",
+      "properties": [
+        {
+          "value": "foo",
+          "binding": {
+            "type": "property",
+            "name": "connectorId"
+          }
+        },
+        {
+          "value": "input-1-value",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "input-1-name"
+          }
+        },
+        {
+          "value": "output-1-value",
+          "binding": {
+            "type": "camunda:outputParameter",
+            "source": "output-1-source"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/provider/camunda/element-templates/fixtures/error-scopes-properties-missing.json
+++ b/test/spec/provider/camunda/element-templates/fixtures/error-scopes-properties-missing.json
@@ -6,9 +6,10 @@
       "bpmn:UserTask"
     ],
     "properties": [],
-    "scopes": {
-      "camunda:Connector": {
+    "scopes": [
+      {
+        "type": "camunda:Connector"
       }
-    }
+    ]
   }
 ]

--- a/test/spec/provider/camunda/element-templates/fixtures/error-scopes-property-invalid.json
+++ b/test/spec/provider/camunda/element-templates/fixtures/error-scopes-property-invalid.json
@@ -6,8 +6,9 @@
       "bpmn:UserTask"
     ],
     "properties": [],
-    "scopes": {
-      "camunda:Connector": {
+    "scopes": [
+      {
+        "type": "camunda:Connector",
         "properties": [
           {
             "label": "Label",
@@ -20,6 +21,6 @@
           }
         ]
       }
-    }
+    ]
   }
 ]

--- a/test/spec/provider/camunda/element-templates/fixtures/error-scopes-type-missing.json
+++ b/test/spec/provider/camunda/element-templates/fixtures/error-scopes-type-missing.json
@@ -6,6 +6,10 @@
       "bpmn:UserTask"
     ],
     "properties": [],
-    "scopes": []
+    "scopes": [
+      {
+        "properties": []
+      }
+    ]
   }
 ]

--- a/test/spec/provider/camunda/element-templates/fixtures/scopes-array.json
+++ b/test/spec/provider/camunda/element-templates/fixtures/scopes-array.json
@@ -1,18 +1,19 @@
 [
   {
-    "name": "Invalid",
+    "name": "Connector - Array",
     "id": "foo",
     "appliesTo": [
       "bpmn:UserTask"
     ],
     "properties": [],
-    "scopes": {
-      "camunda:Connector": {
+    "scopes": [
+      {
+        "type": "camunda:Connector",
         "properties": [
           {
             "label": "ConnectorId",
             "type": "String",
-            "value": "HTTP Connector",
+            "value": "My Connector HTTP - GET",
             "binding": {
               "type": "property",
               "name": "connectorId"
@@ -20,6 +21,6 @@
           }
         ]
       }
-    }
+    ]
   }
 ]

--- a/test/spec/provider/camunda/element-templates/fixtures/scopes-single-connector.json
+++ b/test/spec/provider/camunda/element-templates/fixtures/scopes-single-connector.json
@@ -1,0 +1,25 @@
+[
+  {
+    "name": "Connector",
+    "id": "foo",
+    "appliesTo": [
+      "bpmn:UserTask"
+    ],
+    "properties": [],
+    "scopes": {
+      "camunda:Connector": {
+        "properties": [
+          {
+            "label": "ConnectorId",
+            "type": "String",
+            "value": "HTTP Connector",
+            "binding": {
+              "type": "property",
+              "name": "connectorId"
+            }
+          }
+        ]
+      }
+    }
+  }
+]

--- a/test/spec/provider/camunda/element-templates/parts/CustomProps.bpmn
+++ b/test/spec/provider/camunda/element-templates/parts/CustomProps.bpmn
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.4.0-dev">
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
   <bpmn:process id="Process_1" isExecutable="false">
-    <bpmn:ServiceTask id="ConnectorTask" name="Connector Task" camunda:modelerTemplate="my.connector.Task">
+    <bpmn:serviceTask id="ConnectorTask_legacy" name="Connector Task (Legacy)" camunda:modelerTemplate="my.connector.legacy.Task">
       <bpmn:extensionElements>
         <camunda:connector>
           <camunda:inputOutput>
             <camunda:inputParameter name="messageBody">
               <camunda:script scriptFormat="freemarker">Hello ${firstName}!</camunda:script>
             </camunda:inputParameter>
-            <camunda:inputParameter name="url"></camunda:inputParameter>
-            <camunda:inputParameter name="method"></camunda:inputParameter>
+            <camunda:inputParameter name="url" />
+            <camunda:inputParameter name="method" />
             <camunda:outputParameter name="${S(response)}">wsResponse</camunda:outputParameter>
           </camunda:inputOutput>
           <camunda:connectorId>My Connector HTTP</camunda:connectorId>
         </camunda:connector>
       </bpmn:extensionElements>
-    </bpmn:ServiceTask>
-    <bpmn:ServiceTask id="ConnectorTask_NoData" name="Connector Task NoData" camunda:modelerTemplate="my.connector.Task" />
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ConnectorTask_NoData" name="Connector Task NoData" camunda:modelerTemplate="my.connector.Task" />
     <bpmn:task id="MailTask" name="Mail Task" camunda:modelerTemplate="my.mail.Task">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -30,7 +30,7 @@
         </camunda:inputOutput>
       </bpmn:extensionElements>
     </bpmn:task>
-    <bpmn:task id="AsyncTask" name="AsyncTask" camunda:asyncBefore="true" camunda:modelerTemplate="my.awesome.Task" />
+    <bpmn:task id="AsyncTask" name="AsyncTask" camunda:modelerTemplate="my.awesome.Task" camunda:asyncBefore="true" />
     <bpmn:task id="WebserviceTask" name="Webservice Task" camunda:modelerTemplate="com.mycompany.WsCaller">
       <bpmn:extensionElements>
         <camunda:properties>
@@ -45,13 +45,13 @@
     <bpmn:exclusiveGateway id="ExclusiveGateway_04yuwdv">
       <bpmn:incoming>VipOrderPath</bpmn:incoming>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="VipOrderPath" name="YEY YEA!" sourceRef="Task_0owamzf" targetRef="ExclusiveGateway_04yuwdv" camunda:modelerTemplate="e.com.merce.FastPath">
+    <bpmn:sequenceFlow id="VipOrderPath" name="YEY YEA!" camunda:modelerTemplate="e.com.merce.FastPath" sourceRef="Task_0owamzf" targetRef="ExclusiveGateway_04yuwdv">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ customer.vip }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="DelegateTask" name="Delegate Task" camunda:delegateExpression="com.my.custom.Foo" camunda:modelerTemplate="my.custom.ServiceTask" />
+    <bpmn:serviceTask id="DelegateTask" name="Delegate Task" camunda:modelerTemplate="my.custom.ServiceTask" camunda:delegateExpression="com.my.custom.Foo" />
     <bpmn:task id="WebserviceTask_NoData" name="Webservice Task NoData" camunda:modelerTemplate="com.mycompany.WsCaller" />
     <bpmn:task id="ValidateTask" name="Validate Task" camunda:modelerTemplate="com.validated-inputs.Task" />
-    <bpmn:callActivity id="CallActivity" name="Call Activity" calledElement="calledProcess" camunda:modelerTemplate="my.Caller">
+    <bpmn:callActivity id="CallActivity" name="Call Activity" camunda:modelerTemplate="my.Caller" calledElement="calledProcess">
       <bpmn:extensionElements>
         <camunda:in source="var_local" target="var_called_source" />
         <camunda:out source="var_local_source" target="var_called" />
@@ -86,66 +86,88 @@
       </bpmn:extensionElements>
     </bpmn:serviceTask>
     <bpmn:serviceTask id="ServiceTask_FieldInjection_NoData" name="Field Injection Task No Data" camunda:modelerTemplate="com.camunda.example.CustomServiceTaskFieldInjection" />
+    <bpmn:serviceTask id="ConnectorTask" name="Connector Task" camunda:modelerTemplate="my.connector.Task">
+      <bpmn:extensionElements>
+        <camunda:connector>
+          <camunda:inputOutput>
+            <camunda:inputParameter name="messageBody">
+              <camunda:script scriptFormat="freemarker">Hello ${firstName}!</camunda:script>
+            </camunda:inputParameter>
+            <camunda:inputParameter name="url" />
+            <camunda:inputParameter name="method" />
+            <camunda:outputParameter name="${S(response)}">wsResponse</camunda:outputParameter>
+          </camunda:inputOutput>
+          <camunda:connectorId>My Connector HTTP</camunda:connectorId>
+        </camunda:connector>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ConnectorTask_NoData_legacy" name="Connector Task NoData" camunda:modelerTemplate="my.connector.legacy.Task" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
-      <bpmndi:BPMNShape id="Task_0zadlf1_di" bpmnElement="ConnectorTask">
-        <dc:Bounds x="574" y="53" width="100" height="80" />
+      <bpmndi:BPMNEdge id="SequenceFlow_13jfpgw_di" bpmnElement="VipOrderPath">
+        <di:waypoint x="259" y="247" />
+        <di:waypoint x="449" y="247" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="333" y="256" width="51" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Task_0zadlf1_di" bpmnElement="ConnectorTask_legacy">
+        <dc:Bounds x="690" y="53" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_0zadlf2_di" bpmnElement="ConnectorTask_NoData">
-        <dc:Bounds x="574" y="53" width="100" height="80" />
+        <dc:Bounds x="654" y="207" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_0zadlfo_di" bpmnElement="MailTask">
-        <dc:Bounds x="79" y="53" width="100" height="80" />
+        <dc:Bounds x="159" y="53" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_1nlqdin_di" bpmnElement="AsyncTask">
-        <dc:Bounds x="211" y="53" width="100" height="80" />
+        <dc:Bounds x="291" y="53" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_1vmddbe_di" bpmnElement="WebserviceTask">
-        <dc:Bounds x="344" y="53" width="100" height="80" />
+        <dc:Bounds x="424" y="53" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_0pfsj2a_di" bpmnElement="MailTask_NoData">
-        <dc:Bounds x="474" y="53" width="100" height="80" />
+        <dc:Bounds x="554" y="53" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_0owamzf_di" bpmnElement="Task_0owamzf">
-        <dc:Bounds x="79" y="207" width="100" height="80" />
+        <dc:Bounds x="159" y="207" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_04yuwdv_di" bpmnElement="ExclusiveGateway_04yuwdv" isMarkerVisible="true">
-        <dc:Bounds x="369" y="222" width="50" height="50" />
+        <dc:Bounds x="449" y="222" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="349" y="272" width="90" height="20" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_13jfpgw_di" bpmnElement="VipOrderPath">
-        <di:waypoint xsi:type="dc:Point" x="179" y="247" />
-        <di:waypoint xsi:type="dc:Point" x="369" y="247" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="233" y="256" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ServiceTask_1kj4b4i_di" bpmnElement="DelegateTask">
-        <dc:Bounds x="79" y="353" width="100" height="80" />
+        <dc:Bounds x="159" y="353" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_1p93nau_di" bpmnElement="WebserviceTask_NoData">
-        <dc:Bounds x="608" y="53" width="100" height="80" />
+        <dc:Bounds x="800" y="207" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_0pnk8c1_di" bpmnElement="ValidateTask">
-        <dc:Bounds x="211" y="353" width="100" height="80" />
+        <dc:Bounds x="291" y="353" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="CallActivity_16ib2yl_di" bpmnElement="CallActivity">
-        <dc:Bounds x="79" y="465" width="100" height="80" />
+        <dc:Bounds x="159" y="465" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="CallActivity_1nz6vft_di" bpmnElement="CallActivity_NoData">
-        <dc:Bounds x="211" y="465" width="100" height="80" />
+        <dc:Bounds x="291" y="465" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_1b49o1e_di" bpmnElement="ExecutionListenerTask">
-        <dc:Bounds x="741" y="53" width="100" height="80" />
+        <dc:Bounds x="821" y="53" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1yvdqua_di" bpmnElement="ServiceTask_FieldInjection">
-        <dc:Bounds x="875" y="53" width="100" height="80" />
+        <dc:Bounds x="955" y="53" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1p5xb8u_di" bpmnElement="ServiceTask_FieldInjection_NoData">
-        <dc:Bounds x="987" y="53" width="100" height="80" />
+        <dc:Bounds x="1067" y="53" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0m3yc93_di" bpmnElement="ConnectorTask">
+        <dc:Bounds x="654" y="310" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1yvd1h6_di" bpmnElement="ConnectorTask_NoData_legacy">
+        <dc:Bounds x="654" y="430" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/camunda/element-templates/parts/CustomProps.json
+++ b/test/spec/provider/camunda/element-templates/parts/CustomProps.json
@@ -6,6 +6,116 @@
       "bpmn:ServiceTask"
     ],
     "properties": [],
+    "scopes": [
+      {
+        "type": "camunda:Connector",
+        "properties": [
+          {
+            "label": "ConnectorId",
+            "type": "String",
+            "value": "My Connector HTTP",
+            "binding": {
+              "type": "property",
+              "name": "connectorId"
+            },
+            "constraints": {
+              "notEmpty": true
+            }
+          },
+          {
+            "label": "URL",
+            "type": "String",
+            "binding": {
+              "type": "camunda:inputParameter",
+              "name": "url"
+            },
+            "constraints": {
+              "notEmpty": true
+            }
+          },
+          {
+            "label": "Method",
+            "type": "Dropdown",
+            "choices": [
+              {
+                "value": "GET",
+                "name":"GET"
+              },
+              {
+                "value": "POST",
+                "name": "POST"
+              },
+              {
+                "value": "PUT",
+                "name": "PUT"
+              },
+              {
+                "value": "PATCH",
+                "name": "PATCH"
+              },
+              {
+                "value": "DELETE",
+                "name": "DELETE"
+              }
+            ],
+            "binding": {
+              "type": "camunda:inputParameter",
+              "name": "method"
+            },
+            "constraints": {
+              "notEmpty": true
+            }
+          },
+          {
+            "type": "Hidden",
+            "value": "Camunda",
+            "binding": {
+              "type": "camunda:inputParameter",
+              "name": "agent"
+            }
+          },
+          {
+            "label": "Template",
+            "type": "Text",
+            "description": "By the way, you can use freemarker templates ${...} here",
+            "value": "Hello ${firstName}!",
+            "binding": {
+              "type": "camunda:inputParameter",
+              "name": "messageBody",
+              "scriptFormat": "freemarker"
+            }
+          },
+          {
+            "label": "Response",
+            "type": "String",
+            "value": "${S(response)}",
+            "binding": {
+              "type": "camunda:outputParameter",
+              "name": "wsResponse",
+              "source": "wsResponse"
+            }
+          },
+        {
+          "label": "Result",
+          "type": "String",
+          "value": "httpResult",
+          "binding": {
+            "type": "camunda:outputParameter",
+            "source": "${httpResult}",
+            "scriptFormat": "freemarker"
+          }
+        }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ConnectorTask_legacy",
+    "id": "my.connector.legacy.Task",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [],
     "scopes": {
       "camunda:Connector": {
         "properties": [

--- a/test/spec/provider/camunda/element-templates/util/handleLegacyScopesSpec.js
+++ b/test/spec/provider/camunda/element-templates/util/handleLegacyScopesSpec.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var isArray = require('min-dash').isArray;
+
+var handleLegacyScopes = require('lib/provider/camunda/element-templates/util/handleLegacyScopes');
+
+
+describe('element-templates/util - handleLegacyScopes', function() {
+
+  it('should transform legacy scopes descriptor', function() {
+
+    // given
+    var templates = require('../fixtures/scopes-single-connector');
+
+    var scopesDescriptor = templates[0].scopes;
+
+    // when
+    var scopes = handleLegacyScopes(scopesDescriptor);
+
+    // then
+    expect(isArray(scopes)).to.be.true;
+
+    expect(scopes).to.have.length(1);
+
+    expect(scopes[0].type).to.eql('camunda:Connector');
+
+    expect(scopes[0].properties).to.eql(scopesDescriptor['camunda:Connector'].properties);
+  });
+
+
+  it('should keep scopes untouched', function() {
+
+    // given
+    var templates = require('../fixtures/scopes-array');
+
+    var scopesDescriptor = templates[0].scopes;
+
+    // when
+    var scopes = handleLegacyScopes(scopesDescriptor);
+
+    // then
+    expect(isArray(scopes)).to.be.true;
+
+    expect(scopes).to.eql(scopesDescriptor);
+  });
+
+});


### PR DESCRIPTION
This allows the new format for scopes inside element templates.

```js
{
  "name": "My Template",
  "id": "com.example.template",
  "version": 1,
  "appliesTo": [
    "bpmn:ServiceTask"
  ],
  "properties": [],
  "scopes": [
    {
      "type": "camunda:Connector",
      "properties": [ ]
  ]
}
```

It also ensures backward compatibility for old `camunda:Connector` scopes.

```js
{
  "name": "My Template",
  "id": "com.example.template",
  "version": 1,
  "appliesTo": [
    "bpmn:ServiceTask"
  ],
  "properties": [],
  "scopes": {
    "camunda:Connector": {
      "properties": [ ]
  }
}
```

Closes #423 