### PR TITLE
Error Templates (Part 1)

### DIFF
--- a/lib/provider/camunda/element-templates/CreateHelper.js
+++ b/lib/provider/camunda/element-templates/CreateHelper.js
@@ -203,8 +203,31 @@ function createCamundaFieldInjection(binding, value, bpmnFactory) {
 
   return bpmnFactory.create('camunda:Field', props);
 }
+
 module.exports.createCamundaFieldInjection = createCamundaFieldInjection;
 
+/**
+ * Create camunda:errorEventDefinition element containing expression and errorRef
+ * from given binding.
+ *
+ * @param {PropertyBinding} binding
+ * @param {String} value
+ * @param {ModdleElement} error
+ * @param {BpmnFactory} bpmnFactory
+ *
+ * @return {ModdleElement}
+ */
+function createCamundaErrorEventDefinition(binding, value, error, bpmnFactory) {
+  var errorRef = error,
+      expression = value;
+
+  return bpmnFactory.create('camunda:ErrorEventDefinition', {
+    expression: expression,
+    errorRef: errorRef
+  });
+}
+
+module.exports.createCamundaErrorEventDefinition = createCamundaErrorEventDefinition;
 
 // helpers ////////////////////////////
 

--- a/lib/provider/camunda/element-templates/Validator.js
+++ b/lib/provider/camunda/element-templates/Validator.js
@@ -21,7 +21,8 @@ var PROPERTY_TYPE = 'property',
     CAMUNDA_IN_BUSINESS_KEY_TYPE = 'camunda:in:businessKey',
     CAMUNDA_EXECUTION_LISTENER = 'camunda:executionListener',
     CAMUNDA_FIELD = 'camunda:field',
-    CAMUNDA_CONNECTOR = 'camunda:Connector';
+    CAMUNDA_CONNECTOR = 'camunda:Connector',
+    CAMUNDA_ERROR_EVENT_DEFINITION = 'camunda:errorEventDefinition';
 
 var VALID_BINDING_TYPES = [
   PROPERTY_TYPE,
@@ -32,7 +33,8 @@ var VALID_BINDING_TYPES = [
   CAMUNDA_OUT_TYPE,
   CAMUNDA_IN_BUSINESS_KEY_TYPE,
   CAMUNDA_EXECUTION_LISTENER,
-  CAMUNDA_FIELD
+  CAMUNDA_FIELD,
+  CAMUNDA_ERROR_EVENT_DEFINITION
 ];
 
 var SUPPORTED_SCHEMA_VERSION = require('@camunda/element-templates-json-schema/package.json').version;

--- a/lib/provider/camunda/element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/lib/provider/camunda/element-templates/cmd/ChangeElementTemplateHandler.js
@@ -12,9 +12,13 @@ var createCamundaExecutionListenerScript = require('../CreateHelper').createCamu
     createCamundaOut = require('../CreateHelper').createCamundaOut,
     createCamundaProperty = require('../CreateHelper').createCamundaProperty,
     createInputParameter = require('../CreateHelper').createInputParameter,
-    createOutputParameter = require('../CreateHelper').createOutputParameter;
+    createOutputParameter = require('../CreateHelper').createOutputParameter,
+    createCamundaErrorEventDefinition = require('../CreateHelper').createCamundaErrorEventDefinition;
 
 var EventDefinitionHelper = require('../../../../helper/EventDefinitionHelper');
+
+var getRoot = require('../../../../Utils').getRoot,
+    nextId = require('../../../../Utils').nextId;
 
 var getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
 
@@ -92,9 +96,12 @@ ChangeElementTemplateHandler.prototype.preExecute = function(context) {
     // Update camunda:Property properties
     this._updateCamundaPropertyProperties(element, oldTemplate, newTemplate);
 
+    // Update camunda:ErrorEventDefinition properties
+    this._updateCamundaErrorEventDefinitionProperties(element, oldTemplate, newTemplate);
+
     // Update properties for each scope
     forEach(handleLegacyScopes(newTemplate.scopes), function(newScopeTemplate) {
-      self._updateScopeProperties(element, oldTemplate, newScopeTemplate);
+      self._updateScopeProperties(element, oldTemplate, newScopeTemplate, newTemplate);
     });
 
   }
@@ -119,6 +126,102 @@ ChangeElementTemplateHandler.prototype._getOrCreateExtensionElements = function(
   }
 
   return extensionElements;
+};
+
+/**
+ * Update `camunda:ErrorEventDefinition` properties of specified business object. Event
+ * definitions can only exist in `bpmn:ExtensionElements`.
+ *
+ * Ensures an bpmn:Error exists for the event definition.
+ *
+ * @param {djs.model.Base} element
+ * @param {Object} oldTemplate
+ * @param {Object} newTemplate
+ */
+ChangeElementTemplateHandler.prototype._updateCamundaErrorEventDefinitionProperties = function(element, oldTemplate, newTemplate) {
+  var bpmnFactory = this._bpmnFactory,
+      commandStack = this._commandStack;
+
+  var newProperties = newTemplate.properties.filter(function(newProperty) {
+    var newBinding = newProperty.binding,
+        newBindingType = newBinding.type;
+
+    return newBindingType === 'camunda:errorEventDefinition';
+  });
+
+  // (1) Do not override if no updates
+  if (!newProperties.length) {
+    return;
+  }
+
+  var businessObject = this._getOrCreateExtensionElements(element);
+
+  var oldErrorEventDefinitions = findExtensions(element, [ 'camunda:ErrorEventDefinition' ]);
+
+  newProperties.forEach(function(newProperty) {
+    var oldProperty = findOldProperty(oldTemplate, newProperty),
+        oldEventDefinition = oldProperty && findOldBusinessObject(businessObject, oldProperty),
+        newBinding = newProperty.binding;
+
+    // (2) Update old event definitions
+    if (oldProperty && oldEventDefinition) {
+
+      if (!propertyChanged(oldEventDefinition, oldProperty)) {
+        commandStack.execute('properties-panel.update-businessobject', {
+          element: element,
+          businessObject: oldEventDefinition,
+          properties: {
+            expression: newProperty.value
+          }
+        });
+      }
+
+      remove(oldErrorEventDefinitions, oldEventDefinition);
+    }
+
+    // (3) Create new event definition + error
+    else {
+      var rootElement = getRoot(getBusinessObject(element)),
+          newError = bpmnFactory.create('bpmn:Error', {
+
+            // we need this to retrieve the business object later
+            id: nextId(newBinding.errorRef + '_')
+          });
+
+      newError.$parent = rootElement;
+
+      var newEventDefinition =
+            createCamundaErrorEventDefinition(newBinding, newProperty.value, newError, bpmnFactory);
+
+      commandStack.execute('properties-panel.update-businessobject-list', {
+        element: element,
+        currentObject: rootElement,
+        propertyName: 'rootElements',
+        objectsToAdd: [ newError ],
+        objectsToRemove: []
+      });
+
+      commandStack.execute('properties-panel.update-businessobject-list', {
+        element: element,
+        currentObject: businessObject,
+        propertyName: 'values',
+        objectsToAdd: [ newEventDefinition ],
+        objectsToRemove: []
+      });
+    }
+
+  });
+
+  // (4) Remove old event definitions
+  if (oldErrorEventDefinitions.length) {
+    commandStack.execute('properties-panel.update-businessobject-list', {
+      element: element,
+      currentObject: businessObject,
+      propertyName: 'values',
+      objectsToAdd: [],
+      objectsToRemove: oldErrorEventDefinitions
+    });
+  }
 };
 
 /**
@@ -691,12 +794,20 @@ ChangeElementTemplateHandler.prototype._updateProperties = function(element, old
         newBinding = newProperty.binding,
         newBindingName = newBinding.name,
         newPropertyValue = newProperty.value,
+        changedElement,
         properties;
 
     if (newBindingName === 'conditionExpression') {
       self._updateConditionExpression(element, oldProperty, newProperty);
     } else {
-      if (oldProperty && propertyChanged(element, oldProperty)) {
+
+      if (is(businessObject, 'bpmn:Error')) {
+        changedElement = businessObject;
+      } else {
+        changedElement = element;
+      }
+
+      if (oldProperty && propertyChanged(changedElement, oldProperty)) {
         return;
       }
 
@@ -729,22 +840,26 @@ ChangeElementTemplateHandler.prototype._updateProperties = function(element, old
  * Update properties for a specified scope.
  *
  * @param {djs.model.Base} element
- * @param {string} scopeName
- * @param {Object} scopeTemplate
+ * @param {Object} oldTemplate
+ * @param {Object} newScopeTemplate
+ * @param {Object} newTemplate
  */
-ChangeElementTemplateHandler.prototype._updateScopeProperties = function(element, oldTemplate, newScopeTemplate) {
+ChangeElementTemplateHandler.prototype._updateScopeProperties = function(element, oldTemplate, newScopeTemplate, newTemplate) {
   var bpmnFactory = this._bpmnFactory,
       commandStack = this._commandStack;
 
   var scopeName = newScopeTemplate.type;
 
-  var scopeElement = findOldScopeElement(element, scopeName);
+  var scopeElement;
+
+  scopeElement = findOldScopeElement(element, newScopeTemplate, newTemplate);
 
   if (!scopeElement) {
+
     scopeElement = bpmnFactory.create(scopeName);
   }
 
-  var oldScopeTemplate = findOldScopeTemplate(scopeName, oldTemplate);
+  var oldScopeTemplate = findOldScopeTemplate(newScopeTemplate, oldTemplate);
 
   // Update properties
   this._updateProperties(element, oldScopeTemplate, newScopeTemplate, scopeElement);
@@ -763,6 +878,12 @@ ChangeElementTemplateHandler.prototype._updateScopeProperties = function(element
 
   // Update camunda:Property properties
   this._updateCamundaPropertyProperties(element, oldScopeTemplate, newScopeTemplate, scopeElement);
+
+  // Assume: root elements were already been created in root by referenced event
+  // definition binding
+  if (isRootElementScope(scopeName)) {
+    return;
+  }
 
   var extensionElements = this._getOrCreateExtensionElements(element);
 
@@ -877,6 +998,19 @@ function findOldBusinessObject(element, oldProperty) {
 
     return find(businessObject.get('values'), function(oldBusinessObject) {
       return oldBusinessObject.get('camunda:name') === oldBinding.name;
+    });
+  }
+
+  if (oldBindingType === 'camunda:errorEventDefinition') {
+    var errorEventDefinitions = findExtensions(element, ['camunda:ErrorEventDefinition']);
+
+    if (!errorEventDefinitions.length) {
+      return;
+    }
+
+    // error id has to start with <${binding.errorRef}_>
+    return find(errorEventDefinitions, function(eventDefinition) {
+      return eventDefinition.errorRef.id.indexOf(oldBinding.errorRef) == 0;
     });
   }
 }
@@ -997,19 +1131,67 @@ function findOldProperty(oldTemplate, newProperty) {
       return oldBindingType === 'camunda:property' && oldBindingName === newBindingName;
     });
   }
-}
 
-function findOldScopeElement(element, scopeName) {
-  if (scopeName === 'camunda:Connector') {
-    return findExtension(element, 'camunda:Connector');
+  if (newBindingType === 'camunda:errorEventDefinition') {
+    return find(oldProperties, function(oldProperty) {
+      var newBindingRef = newBinding.errorRef,
+          oldBinding = oldProperty.binding,
+          oldBindingRef = oldBinding.errorRef,
+          oldBindingType = oldBinding.type;
+
+      return oldBindingType === 'camunda:errorEventDefinition'
+        && oldBindingRef === newBindingRef;
+    });
   }
 }
 
-function findOldScopeTemplate(scopeName, oldTemplate) {
-  var scopes = oldTemplate && handleLegacyScopes(oldTemplate.scopes);
+function findOldScopeElement(element, scopeTemplate, template) {
+  var scopeName = scopeTemplate.type,
+      id = scopeTemplate.id;
+
+  if (scopeName === 'camunda:Connector') {
+    return findExtension(element, 'camunda:Connector');
+  }
+
+  if (scopeName === 'bpmn:Error') {
+
+    // (1) find by error event definition binding
+    var errorEventDefinitionBinding = findErrorEventDefinitionBinding(template, id);
+
+    // (2) find error event definition
+    var errorEventDefinition = findOldBusinessObject(element, errorEventDefinitionBinding);
+
+    if (!errorEventDefinition) {
+      return;
+    }
+
+    // (3) retrieve referenced error
+    return errorEventDefinition.errorRef;
+  }
+}
+
+function isRootElementScope(scopeName) {
+  return [ 'bpmn:Error' ].includes(scopeName);
+}
+
+function findOldScopeTemplate(scopeTemplate, oldTemplate) {
+  var scopeName = scopeTemplate.type,
+      scopeId = scopeTemplate.id,
+      scopes = oldTemplate && handleLegacyScopes(oldTemplate.scopes);
 
   return scopes && find(scopes, function(scope) {
+
+    if (isRootElementScope(scopeName)) {
+      return scope.id === scopeId;
+    }
+
     return scope.type === scopeName;
+  });
+}
+
+function findErrorEventDefinitionBinding(template, templateErrorId) {
+  return find(template.properties, function(property) {
+    return property.binding.errorRef === templateErrorId;
   });
 }
 
@@ -1077,5 +1259,9 @@ function propertyChanged(element, oldProperty) {
 
   if (oldBindingType === 'camunda:property') {
     return businessObject.get('camunda:value') !== oldPropertyValue;
+  }
+
+  if (oldBindingType === 'camunda:errorEventDefinition') {
+    return businessObject.get('expression') !== oldPropertyValue;
   }
 }

--- a/test/spec/provider/camunda/element-templates/ValidatorSpec.js
+++ b/test/spec/provider/camunda/element-templates/ValidatorSpec.js
@@ -374,7 +374,7 @@ describe('element-templates - Validator', function() {
         'property, camunda:property, camunda:inputParameter, ' +
         'camunda:outputParameter, camunda:in, camunda:out, ' +
         'camunda:in:businessKey, camunda:executionListener, ' +
-        'camunda:field ' +
+        'camunda:field, camunda:errorEventDefinition ' +
       '}'
       ]);
 
@@ -572,7 +572,7 @@ describe('element-templates - Validator', function() {
           'property, camunda:property, camunda:inputParameter, ' +
           'camunda:outputParameter, camunda:in, camunda:out, ' +
           'camunda:in:businessKey, camunda:executionListener, ' +
-          'camunda:field ' +
+          'camunda:field, camunda:errorEventDefinition ' +
         '}'
         ]);
         expect(valid(templates)).to.be.empty;
@@ -596,6 +596,24 @@ describe('element-templates - Validator', function() {
 
       expect(valid(templates)).to.have.length(1);
     });
+
+
+    it('should accept errors example template', function() {
+
+      // given
+      var templates = new Validator();
+
+      var templateDescriptors = require('./fixtures/error-templates');
+
+      // when
+      templates.addAll(templateDescriptors);
+
+      // then
+      expect(errors(templates)).to.be.empty;
+
+      expect(valid(templates)).to.have.length(1);
+    });
+
 
   });
 });

--- a/test/spec/provider/camunda/element-templates/cmd/error-template-1.json
+++ b/test/spec/provider/camunda/element-templates/cmd/error-template-1.json
@@ -1,0 +1,46 @@
+{
+  "name": "Error template",
+  "version": 1,
+  "id": "error-template",
+  "appliesTo": [
+    "bpmn:ServiceTask"
+  ],
+  "properties": [
+    {
+      "value": "expression-value",
+      "binding": {
+        "type": "camunda:errorEventDefinition",
+        "errorRef": "Error_1"
+      }
+    }
+  ],
+  "scopes": [
+    {
+      "type": "bpmn:Error",
+      "id": "Error_1",
+      "properties": [
+        {
+          "value": "error-code",
+          "binding": {
+            "type": "property",
+            "name": "errorCode"
+          }
+        },
+        {
+          "value": "error-message",
+          "binding": {
+            "type": "property",
+            "name": "camunda:errorMessage"
+          }
+        },
+        {
+          "value": "error-name",
+          "binding": {
+            "type": "property",
+            "name": "name"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/provider/camunda/element-templates/cmd/service-task-error.bpmn
+++ b/test/spec/provider/camunda/element-templates/cmd/service-task-error.bpmn
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_13tyuxd" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="ServiceTask_1">
+      <bpmn:extensionElements>
+         <camunda:errorEventDefinition id="ErrorEventDefinition_1" errorRef="Error_1" expression="error-expression" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmn:error id="Error_1" name="error-name" errorCode="error-code" camunda:errorMessage="error-message" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="0" y="0" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/camunda/element-templates/fixtures/error-templates.json
+++ b/test/spec/provider/camunda/element-templates/fixtures/error-templates.json
@@ -1,0 +1,48 @@
+[
+  {
+    "name": "Error template",
+    "version": 1,
+    "id": "error-template",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "value": "expression-value",
+        "binding": {
+          "type": "camunda:errorEventDefinition",
+          "errorRef": "Error_1"
+        }
+      }
+    ],
+    "scopes": [
+      {
+        "type": "bpmn:Error",
+        "id": "Error_1",
+        "properties": [
+          {
+            "value": "error-code",
+            "binding": {
+              "type": "property",
+              "name": "errorCode"
+            }
+          },
+          {
+            "value": "error-message",
+            "binding": {
+              "type": "property",
+              "name": "camunda:errorMessage"
+            }
+          },
+          {
+            "value": "error-name",
+            "binding": {
+              "type": "property",
+              "name": "name"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This PR adds
* support for creating scoped `bpmn:Error` bindings
* support for applying `camunda:ErrorEventDefinition` bindings
* support for handling template `camunda:ErrorEventDefinition` --> `bpmn:Error` references

This adds **not**
* proper validation for `camunda:ErrorEventDefinition` (cf. missing binding.errorRef)
* display `camunda:ErrorEventDefinition` bindings in the Properties Panel custom props (get and set values)
* default components for  `camunda:ErrorEventDefinition` 
* docs updates

as this shall be part of https://github.com/bpmn-io/bpmn-js-properties-panel/issues/424.

-----

Related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/424
Closes https://github.com/bpmn-io/bpmn-js-properties-panel/issues/425
