### PR TITLE
Return an empty array instead of undefined when querying empty extension elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
-## BREAKING CHANGES
-* `ExtensionElementsHelper#getExtensionElements` now returns an empty array if no extension element of the requested type was found, instead of returning `undefined`.  
-This means the return value is now always _truthy_. ([#447](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/447))
+* `CHORE`: make extension elements helper always return an array ([#447](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/447))
 
 ...
+
+### Breaking Changes
+
+* `ExtensionElementsHelper#getExtensionElements` now returns an empty array if no extension element of the requested type was found, instead of returning `undefined`.  This means the return value is now always _truthy_. 
 
 ## 0.41.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+## BREAKING CHANGES
+* `ExtensionElementsHelper#getExtensionElements` now returns an empty array if no extension element of the requested type was found, instead of returning `undefined`.  
+This means the return value is now always _truthy_. ([#447](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/447))
+
 ...
 
 ## 0.41.0

--- a/lib/helper/AsyncCapableHelper.js
+++ b/lib/helper/AsyncCapableHelper.js
@@ -54,7 +54,7 @@ module.exports.isExclusive = isExclusive;
  * @return {Array<ModdleElement>} a list of 'camunda:FailedJobRetryTimeCycle'
  */
 function getFailedJobRetryTimeCycle(bo) {
-  return (extensionElementsHelper.getExtensionElements(bo, 'camunda:FailedJobRetryTimeCycle') || [])[0];
+  return extensionElementsHelper.getExtensionElements(bo, 'camunda:FailedJobRetryTimeCycle')[0];
 }
 
 module.exports.getFailedJobRetryTimeCycle = getFailedJobRetryTimeCycle;

--- a/lib/helper/ExtensionElementsHelper.js
+++ b/lib/helper/ExtensionElementsHelper.js
@@ -7,23 +7,20 @@ var is = require('bpmn-js/lib/util/ModelUtil').is;
 
 var ExtensionElementsHelper = {};
 
-var getExtensionElements = function(bo) {
-  return bo.get('extensionElements');
-};
-
 ExtensionElementsHelper.getExtensionElements = function(bo, type) {
-  var extensionElements = getExtensionElements(bo);
+  var elements = [];
+  var extensionElements = bo.get('extensionElements');
+
   if (typeof extensionElements !== 'undefined') {
     var extensionValues = extensionElements.get('values');
     if (typeof extensionValues !== 'undefined') {
-      var elements = extensionValues.filter(function(value) {
+      elements = extensionValues.filter(function(value) {
         return is(value, type);
       });
-      if (elements.length) {
-        return elements;
-      }
     }
   }
+
+  return elements;
 };
 
 ExtensionElementsHelper.addEntry = function(bo, element, entry, bpmnFactory) {

--- a/lib/helper/FormHelper.js
+++ b/lib/helper/FormHelper.js
@@ -19,9 +19,7 @@ FormHelper.getFormData = function(element) {
 
   var formData = getExtensionElements(bo, 'camunda:FormData');
 
-  if (typeof formData !== 'undefined') {
-    return formData[0];
-  }
+  return formData[0];
 };
 
 

--- a/lib/helper/ImplementationTypeHelper.js
+++ b/lib/helper/ImplementationTypeHelper.js
@@ -155,7 +155,7 @@ ImplementationTypeHelper.getImplementationType = function(element) {
 
   if (this.isServiceTaskLike(bo)) {
     var connectors = extensionsElementHelper.getExtensionElements(bo, 'camunda:Connector');
-    if (typeof connectors !== 'undefined') {
+    if (connectors.length) {
       return 'connector';
     }
   }

--- a/lib/helper/InputOutputHelper.js
+++ b/lib/helper/InputOutputHelper.js
@@ -12,7 +12,7 @@ var InputOutputHelper = {};
 module.exports = InputOutputHelper;
 
 function getElements(bo, type, prop) {
-  var elems = extensionElementsHelper.getExtensionElements(bo, type) || [];
+  var elems = extensionElementsHelper.getExtensionElements(bo, type);
   return !prop ? elems : (elems[0] || {})[prop] || [];
 }
 

--- a/lib/provider/camunda/parts/FormProps.js
+++ b/lib/provider/camunda/parts/FormProps.js
@@ -211,7 +211,7 @@ module.exports = function(group, element, bpmnFactory, translate) {
       var result = { businessKey: '' };
       var bo = getBusinessObject(element);
       var formDataExtension = getExtensionElements(bo, 'camunda:FormData');
-      if (formDataExtension) {
+      if (formDataExtension.length) {
         var formData = formDataExtension[0];
         var storedValue = formData.get('businessKey');
         result = { businessKey: storedValue };

--- a/lib/provider/camunda/parts/VariableMappingProps.js
+++ b/lib/provider/camunda/parts/VariableMappingProps.js
@@ -23,7 +23,7 @@ function getCamundaInOutMappings(element, type) {
 
   var signalEventDefinition = eventDefinitionHelper.getSignalEventDefinition(bo);
 
-  return extensionElementsHelper.getExtensionElements(signalEventDefinition || bo, type) || [];
+  return extensionElementsHelper.getExtensionElements(signalEventDefinition || bo, type);
 }
 
 /**

--- a/lib/provider/camunda/parts/implementation/Callable.js
+++ b/lib/provider/camunda/parts/implementation/Callable.js
@@ -73,13 +73,13 @@ function getCamundaInWithBusinessKey(element) {
       bo = getBusinessObject(element);
 
   var camundaInParams = extensionElementsHelper.getExtensionElements(bo, 'camunda:In');
-  if (camundaInParams) {
-    forEach(camundaInParams, function(param) {
-      if (param.businessKey !== undefined) {
-        camundaIn.push(param);
-      }
-    });
-  }
+
+  forEach(camundaInParams, function(param) {
+    if (param.businessKey !== undefined) {
+      camundaIn.push(param);
+    }
+  });
+
   return camundaIn;
 }
 

--- a/lib/provider/camunda/parts/implementation/FieldInjection.js
+++ b/lib/provider/camunda/parts/implementation/FieldInjection.js
@@ -56,7 +56,7 @@ module.exports = function(element, bpmnFactory, translate, options) {
       return (
         businessObject &&
         extensionElementsHelper.getExtensionElements(businessObject, CAMUNDA_FIELD_EXTENSION_ELEMENT)
-      ) || [];
+      );
     }
     return getCamundaListenerFields(element, node);
   }

--- a/test/spec/provider/camunda/FieldInjectionSpec.js
+++ b/test/spec/provider/camunda/FieldInjectionSpec.js
@@ -64,7 +64,7 @@ describe('fieldInjection-properties', function() {
       bo = bo.eventDefinitions[0];
     }
 
-    return extensionElementsHelper.getExtensionElements(bo, 'camunda:Field') || [];
+    return extensionElementsHelper.getExtensionElements(bo, 'camunda:Field');
   }
 
   function getInput(container, inputNode) {

--- a/test/spec/provider/camunda/ImplementationTypeSpec.js
+++ b/test/spec/provider/camunda/ImplementationTypeSpec.js
@@ -763,7 +763,7 @@ describe('implementation type', function() {
             // then
             expect(bo.get('camunda:class')).not.to.be.undefined;
             var connectors = extensionElementsHelper.getExtensionElements(bo, 'camunda:Connector');
-            expect(connectors).not.to.exist;
+            expect(connectors).to.be.empty;
           }));
 
 
@@ -1177,7 +1177,7 @@ describe('implementation type', function() {
             // then
             expect(bo.get('camunda:expression')).not.to.be.undefined;
             var connectors = extensionElementsHelper.getExtensionElements(bo, 'camunda:Connector');
-            expect(connectors).not.to.exist;
+            expect(connectors).to.be.empty;
           }));
 
 
@@ -1589,7 +1589,7 @@ describe('implementation type', function() {
             // then
             expect(bo.get('camunda:delegateExpression')).not.to.be.undefined;
             var connectors = extensionElementsHelper.getExtensionElements(bo, 'camunda:Connector');
-            expect(connectors).not.to.exist;
+            expect(connectors).to.be.empty;
           }));
 
 
@@ -2010,7 +2010,7 @@ describe('implementation type', function() {
             expect(bo.get('camunda:type')).not.to.be.undefined;
             expect(bo.get('camunda:topic')).not.to.be.undefined;
             var connectors = extensionElementsHelper.getExtensionElements(bo, 'camunda:Connector');
-            expect(connectors).not.to.exist;
+            expect(connectors).to.be.empty;
           }));
 
 
@@ -2093,7 +2093,7 @@ describe('implementation type', function() {
             // then
             expect(bo.get('camunda:class')).not.to.be.undefined;
             var connectors = extensionElementsHelper.getExtensionElements(bo, 'camunda:Connector');
-            expect(connectors).not.to.exist;
+            expect(connectors).to.be.empty;
           });
 
 
@@ -2118,7 +2118,7 @@ describe('implementation type', function() {
             // then
             expect(bo.get('camunda:class')).not.to.be.undefined;
             var connectors = extensionElementsHelper.getExtensionElements(bo, 'camunda:Connector');
-            expect(connectors).not.to.exist;
+            expect(connectors).to.be.empty;
           }));
 
         });
@@ -2172,7 +2172,7 @@ describe('implementation type', function() {
             // then
             expect(bo.get('camunda:expression')).not.to.be.undefined;
             var connectors = extensionElementsHelper.getExtensionElements(bo, 'camunda:Connector');
-            expect(connectors).not.to.exist;
+            expect(connectors).to.be.empty;
           });
 
 
@@ -2197,7 +2197,7 @@ describe('implementation type', function() {
             // then
             expect(bo.get('camunda:expression')).not.to.be.undefined;
             var connectors = extensionElementsHelper.getExtensionElements(bo, 'camunda:Connector');
-            expect(connectors).not.to.exist;
+            expect(connectors).to.be.empty;
           }));
 
         });
@@ -2251,7 +2251,7 @@ describe('implementation type', function() {
             // then
             expect(bo.get('camunda:delegateExpression')).not.to.be.undefined;
             var connectors = extensionElementsHelper.getExtensionElements(bo, 'camunda:Connector');
-            expect(connectors).not.to.exist;
+            expect(connectors).to.be.empty;
           });
 
 
@@ -2276,7 +2276,7 @@ describe('implementation type', function() {
             // then
             expect(bo.get('camunda:delegateExpression')).not.to.be.undefined;
             var connectors = extensionElementsHelper.getExtensionElements(bo, 'camunda:Connector');
-            expect(connectors).not.to.exist;
+            expect(connectors).to.be.empty;
           }));
 
         });
@@ -2335,7 +2335,7 @@ describe('implementation type', function() {
             expect(bo.get('camunda:type')).not.to.be.undefined;
             expect(bo.get('camunda:topic')).not.to.be.undefined;
             var connectors = extensionElementsHelper.getExtensionElements(bo, 'camunda:Connector');
-            expect(connectors).not.to.exist;
+            expect(connectors).to.be.empty;
 
           });
 
@@ -2363,7 +2363,7 @@ describe('implementation type', function() {
             expect(bo.get('camunda:type')).not.to.be.undefined;
             expect(bo.get('camunda:topic')).not.to.be.undefined;
             var connectors = extensionElementsHelper.getExtensionElements(bo, 'camunda:Connector');
-            expect(connectors).not.to.exist;
+            expect(connectors).to.be.empty;
           }));
 
         });
@@ -2422,7 +2422,7 @@ describe('implementation type', function() {
 
             // then
             var connectors = extensionElementsHelper.getExtensionElements(bo, 'camunda:Connector');
-            expect(connectors).not.to.exist;
+            expect(connectors).to.be.empty;
             expect(bo.get('camunda:decisionRef')).not.to.be.undefined;
           });
 
@@ -2447,7 +2447,7 @@ describe('implementation type', function() {
 
             // then
             var connectors = extensionElementsHelper.getExtensionElements(bo, 'camunda:Connector');
-            expect(connectors).not.to.exist;
+            expect(connectors).to.be.empty;
             expect(bo.get('camunda:decisionRef')).not.to.be.undefined;
           }));
 

--- a/test/spec/provider/camunda/InputOutputParameterListSpec.js
+++ b/test/spec/provider/camunda/InputOutputParameterListSpec.js
@@ -624,7 +624,7 @@ describe('input-output-parameterType-list', function() {
 // MODEL HELPER
 
 function getElements(bo, type, prop) {
-  var elems = extensionElementsHelper.getExtensionElements(bo, type) || [];
+  var elems = extensionElementsHelper.getExtensionElements(bo, type);
   return !prop ? elems : (elems[0] || {})[prop] || [];
 }
 

--- a/test/spec/provider/camunda/InputOutputParameterMapSpec.js
+++ b/test/spec/provider/camunda/InputOutputParameterMapSpec.js
@@ -731,7 +731,7 @@ describe('input-output-parameterType-map', function() {
 // MODEL HELPER
 
 function getElements(bo, type, prop) {
-  var elems = extensionElementsHelper.getExtensionElements(bo, type) || [];
+  var elems = extensionElementsHelper.getExtensionElements(bo, type);
   return !prop ? elems : (elems[0] || {})[prop] || [];
 }
 

--- a/test/spec/provider/camunda/InputOutputParameterScriptSpec.js
+++ b/test/spec/provider/camunda/InputOutputParameterScriptSpec.js
@@ -320,7 +320,7 @@ describe('input-output-parameterType-script', function() {
 // MODEL HELPER
 
 function getElements(bo, type, prop) {
-  var elems = extensionElementsHelper.getExtensionElements(bo, type) || [];
+  var elems = extensionElementsHelper.getExtensionElements(bo, type);
   return !prop ? elems : (elems[0] || {})[prop] || [];
 }
 

--- a/test/spec/provider/camunda/InputOutputParameterTextSpec.js
+++ b/test/spec/provider/camunda/InputOutputParameterTextSpec.js
@@ -776,7 +776,7 @@ describe('input-output-parameterType-text', function() {
 // MODEL HELPER
 
 function getElements(bo, type, prop) {
-  var elems = extensionElementsHelper.getExtensionElements(bo, type) || [];
+  var elems = extensionElementsHelper.getExtensionElements(bo, type);
   return !prop ? elems : (elems[0] || {})[prop] || [];
 }
 

--- a/test/spec/provider/camunda/InputParametersSpec.js
+++ b/test/spec/provider/camunda/InputParametersSpec.js
@@ -669,7 +669,7 @@ describe('input-parameters', function() {
 // MODEL HELPER
 
 function getElements(bo, type, prop) {
-  var elems = extensionElementsHelper.getExtensionElements(bo, type) || [];
+  var elems = extensionElementsHelper.getExtensionElements(bo, type);
   return !prop ? elems : (elems[0] || {})[prop] || [];
 }
 

--- a/test/spec/provider/camunda/ListenerFieldInjectionSpec.js
+++ b/test/spec/provider/camunda/ListenerFieldInjectionSpec.js
@@ -55,7 +55,7 @@ describe('listener-fieldInjection-properties', function() {
   }));
 
   function getExtensionElements(bo, type) {
-    return extensionElementsHelper.getExtensionElements(bo, type) || [];
+    return extensionElementsHelper.getExtensionElements(bo, type);
   }
 
   function getCamundaFields(bo, type, idx) {

--- a/test/spec/provider/camunda/OutputParametersSpec.js
+++ b/test/spec/provider/camunda/OutputParametersSpec.js
@@ -671,7 +671,7 @@ describe('output-parameters', function() {
 // MODEL HELPER
 
 function getElements(bo, type, prop) {
-  var elems = extensionElementsHelper.getExtensionElements(bo, type) || [];
+  var elems = extensionElementsHelper.getExtensionElements(bo, type);
   return !prop ? elems : (elems[0] || {})[prop] || [];
 }
 

--- a/test/spec/provider/camunda/PropertiesCollaborationSpec.js
+++ b/test/spec/provider/camunda/PropertiesCollaborationSpec.js
@@ -50,7 +50,7 @@ var getPropertyValues = function(element, isNoParticipant) {
   if (isNoParticipant) {
     bo = getBusinessObject(element);
   }
-  var properties = (getExtensionElements(bo, 'camunda:Properties') || [])[0];
+  var properties = getExtensionElements(bo, 'camunda:Properties')[0];
 
   if (properties) {
     return properties.values;

--- a/test/spec/provider/camunda/PropertiesSpec.js
+++ b/test/spec/provider/camunda/PropertiesSpec.js
@@ -45,7 +45,7 @@ function getPropertiesTable(container) {
 }
 
 var getPropertyValues = function(element) {
-  var properties = (getExtensionElements(getBusinessObject(element), 'camunda:Properties') || [])[0];
+  var properties = getExtensionElements(getBusinessObject(element), 'camunda:Properties')[0];
 
   if (properties) {
     return properties.values;

--- a/test/spec/provider/camunda/RetryTimeCycleSpec.js
+++ b/test/spec/provider/camunda/RetryTimeCycleSpec.js
@@ -165,7 +165,7 @@ describe('retryTimeCycle', function() {
 
         // then
         var timeCycles = extensionElementsHelper.getExtensionElements(bo, 'camunda:FailedJobRetryTimeCycle');
-        expect(timeCycles).not.to.ok;
+        expect(timeCycles).to.be.empty;
 
         var listeners = extensionElementsHelper.getExtensionElements(bo, 'camunda:ExecutionListener');
         expect(listeners).to.have.length(1);
@@ -425,7 +425,7 @@ describe('retryTimeCycle', function() {
 
         // then
         var timeCycles = extensionElementsHelper.getExtensionElements(bo, 'camunda:FailedJobRetryTimeCycle');
-        expect(timeCycles).not.to.ok;
+        expect(timeCycles).to.be.empty;
 
         var listeners = extensionElementsHelper.getExtensionElements(bo, 'camunda:ExecutionListener');
         expect(listeners).to.have.length(1);
@@ -455,7 +455,7 @@ describe('retryTimeCycle', function() {
 
         // then
         var timeCycles = extensionElementsHelper.getExtensionElements(bo, 'camunda:FailedJobRetryTimeCycle');
-        expect(timeCycles).not.to.ok;
+        expect(timeCycles).to.be.empty;
 
         var listeners = extensionElementsHelper.getExtensionElements(bo, 'camunda:ExecutionListener');
         expect(listeners).to.have.length(1);


### PR DESCRIPTION
This PR cleans up the `getExtensionElements` helper, making it return `[]` instead of `undefined` for empty extension elements, to avoid unnecessary checks, and updates every usage of it in the properties panel.

This will be a breaking change for next version, for anyone importing it, namely zeebe.