### PR TITLE
chore: bump @bpmn-io/extract-process-variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -157,9 +157,9 @@
       }
     },
     "@bpmn-io/extract-process-variables": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.4.1.tgz",
-      "integrity": "sha512-qdeE257LarqHdtcfg974uiiFi9V6tFUB1BfVILENhHFN19hO0vq/jwRHRIEbKLrti0VqfHwWMvSbCFXTLnw6og==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.4.3.tgz",
+      "integrity": "sha512-CeCVAsrJS8/UXSUIsqjfZ3PQlqtxgomHtgZATXmTmoSWPGSHTyTLL9FvUbWHzOYomWfFbX2YBzHYTV1wYqM4uA==",
       "requires": {
         "min-dash": "^3.5.2"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "bpmn-js": "^8.2.2",
     "bpmn-moddle": "^7.0.4",
-    "camunda-bpmn-moddle": "5.0.0",
+    "camunda-bpmn-moddle": "^5.0.0",
     "chai": "^4.1.2",
     "diagram-js": "^7.2.0",
     "eslint": "^7.12.1",
@@ -53,7 +53,7 @@
     "webpack": "^5.24.2"
   },
   "dependencies": {
-    "@bpmn-io/extract-process-variables": "^0.4.1",
+    "@bpmn-io/extract-process-variables": "^0.4.3",
     "@camunda/element-templates-json-schema": "0.2.0",
     "ids": "^1.0.0",
     "inherits": "^2.0.1",


### PR DESCRIPTION
Fixes a peer dependency problem with `@bpmn-io/extract-process-variables` & `camunda-bpmn-moddle`