### PR TITLE
Error Template Props

### DIFF
--- a/lib/provider/camunda/CamundaPropertiesProvider.js
+++ b/lib/provider/camunda/CamundaPropertiesProvider.js
@@ -37,11 +37,13 @@ var listenerProps = require('./parts/ListenerProps'),
     listenerDetails = require('./parts/ListenerDetailProps'),
     listenerFields = require('./parts/ListenerFieldInjectionProps');
 
+// element template properties
 var elementTemplateDescriptionProps = require('./element-templates/parts/DescriptionProps'),
     elementTemplateChooserProps = require('./element-templates/parts/ChooserProps'),
     elementTemplateCustomProps = require('./element-templates/parts/CustomProps'),
     elementTemplateInputParametersProps = require('./element-templates/parts/InputParametersProps'),
     elementTemplateOutputParametersProps = require('./element-templates/parts/OutputParametersProps'),
+    elementTemplateErrorsProps = require('./element-templates/parts/ErrorsProps'),
     getTemplateId = require('./element-templates/Helper').getTemplateId;
 
 // Input/Output
@@ -203,12 +205,21 @@ function createElementTemplateGroups(
   };
   elementTemplateOutputParametersProps(elementTemplateOutputParametersGroup, element, elementTemplates, bpmnFactory, translate);
 
+
+  var elementTemplateErrorsGroup = {
+    id: 'template-errors',
+    label: translate('Errors'),
+    entries: []
+  };
+  elementTemplateErrorsProps(elementTemplateErrorsGroup, element, elementTemplates, bpmnFactory, translate);
+
   var customFieldsGroups = elementTemplateCustomProps(element, elementTemplates, bpmnFactory, translate);
 
   return [
     descriptionGroup,
     elementTemplateInputParametersGroup,
-    elementTemplateOutputParametersGroup
+    elementTemplateOutputParametersGroup,
+    elementTemplateErrorsGroup
   ].concat(customFieldsGroups);
 }
 

--- a/lib/provider/camunda/element-templates/CreateHelper.js
+++ b/lib/provider/camunda/element-templates/CreateHelper.js
@@ -215,18 +215,23 @@ module.exports.createCamundaFieldInjection = createCamundaFieldInjection;
  * @param {PropertyBinding} binding
  * @param {String} value
  * @param {ModdleElement} error
+ * @param {ModdleElement} parent
  * @param {BpmnFactory} bpmnFactory
  *
  * @return {ModdleElement}
  */
-function createCamundaErrorEventDefinition(binding, value, error, bpmnFactory) {
+function createCamundaErrorEventDefinition(binding, value, error, parent, bpmnFactory) {
   var errorRef = error,
       expression = value;
 
-  return bpmnFactory.create('camunda:ErrorEventDefinition', {
+  var newErrorEventDefinition = bpmnFactory.create('camunda:ErrorEventDefinition', {
     expression: expression,
     errorRef: errorRef
   });
+
+  newErrorEventDefinition.$parent = parent;
+
+  return newErrorEventDefinition;
 }
 
 module.exports.createCamundaErrorEventDefinition = createCamundaErrorEventDefinition;

--- a/lib/provider/camunda/element-templates/CreateHelper.js
+++ b/lib/provider/camunda/element-templates/CreateHelper.js
@@ -2,6 +2,8 @@
 
 var assign = require('lodash/assign');
 
+var nextId = require('../../../Utils').nextId;
+
 /**
  * Create an input parameter representing the given
  * binding and value.
@@ -228,6 +230,29 @@ function createCamundaErrorEventDefinition(binding, value, error, bpmnFactory) {
 }
 
 module.exports.createCamundaErrorEventDefinition = createCamundaErrorEventDefinition;
+
+/**
+ * Create bpmn:error element containing a specific error id given by a binding.
+ *
+ * @param {String} bindingErrorRef
+ * @param {ModdleElement} parent
+ * @param {BpmnFactory} bpmnFactory
+ *
+ * @return { ModdleElement }
+ */
+function createError(bindingErrorRef, parent, bpmnFactory) {
+  var error = bpmnFactory.create('bpmn:Error', {
+
+    // we need to later retrieve the error from a binding
+    id: nextId('Error_' + bindingErrorRef + '_')
+  });
+
+  error.$parent = parent;
+
+  return error;
+}
+
+module.exports.createError = createError;
 
 // helpers ////////////////////////////
 

--- a/lib/provider/camunda/element-templates/Helper.js
+++ b/lib/provider/camunda/element-templates/Helper.js
@@ -185,6 +185,23 @@ function findOutputParameter(inputOutput, binding) {
 module.exports.findOutputParameter = findOutputParameter;
 
 
+function findCamundaErrorEventDefinition(element, bindingErrorRef) {
+  var errorEventDefinitions = findExtensions(element, [ 'camunda:ErrorEventDefinition' ]),
+      error;
+
+  // error id has to start with <Error_${binding.errorRef}_>
+  return find(errorEventDefinitions, function(definition) {
+    error = definition.errorRef;
+
+    if (error) {
+      return error.id.indexOf('Error_' + bindingErrorRef) == 0;
+    }
+  });
+}
+
+module.exports.findCamundaErrorEventDefinition = findCamundaErrorEventDefinition;
+
+
 
 // helpers /////////////////////////////////
 

--- a/lib/provider/camunda/element-templates/Validator.js
+++ b/lib/provider/camunda/element-templates/Validator.js
@@ -337,6 +337,15 @@ function Validator() {
       }
     }
 
+    if (bindingType === CAMUNDA_ERROR_EVENT_DEFINITION) {
+      if (!binding.errorRef) {
+        err = this._logError(
+          'property.binding <' + bindingType + '> requires errorRef',
+          template
+        );
+      }
+    }
+
     return !err;
   };
 

--- a/lib/provider/camunda/element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/lib/provider/camunda/element-templates/cmd/ChangeElementTemplateHandler.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var findExtension = require('../Helper').findExtension,
-    findExtensions = require('../Helper').findExtensions;
+    findExtensions = require('../Helper').findExtensions,
+    findCamundaErrorEventDefinition = require('../Helper').findCamundaErrorEventDefinition;
 
 var handleLegacyScopes = require('../util/handleLegacyScopes');
 
@@ -13,12 +14,12 @@ var createCamundaExecutionListenerScript = require('../CreateHelper').createCamu
     createCamundaProperty = require('../CreateHelper').createCamundaProperty,
     createInputParameter = require('../CreateHelper').createInputParameter,
     createOutputParameter = require('../CreateHelper').createOutputParameter,
-    createCamundaErrorEventDefinition = require('../CreateHelper').createCamundaErrorEventDefinition;
+    createCamundaErrorEventDefinition = require('../CreateHelper').createCamundaErrorEventDefinition,
+    createError = require('../CreateHelper').createError;
 
 var EventDefinitionHelper = require('../../../../helper/EventDefinitionHelper');
 
-var getRoot = require('../../../../Utils').getRoot,
-    nextId = require('../../../../Utils').nextId;
+var getRoot = require('../../../../Utils').getRoot;
 
 var getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
 
@@ -182,15 +183,8 @@ ChangeElementTemplateHandler.prototype._updateCamundaErrorEventDefinitionPropert
     // (3) Create new event definition + error
     else {
       var rootElement = getRoot(getBusinessObject(element)),
-          newError = bpmnFactory.create('bpmn:Error', {
-
-            // we need this to retrieve the business object later
-            id: nextId(newBinding.errorRef + '_')
-          });
-
-      newError.$parent = rootElement;
-
-      var newEventDefinition =
+          newError = createError(newBinding.errorRef, rootElement, bpmnFactory),
+          newEventDefinition =
             createCamundaErrorEventDefinition(newBinding, newProperty.value, newError, bpmnFactory);
 
       commandStack.execute('properties-panel.update-businessobject-list', {
@@ -1002,16 +996,7 @@ function findOldBusinessObject(element, oldProperty) {
   }
 
   if (oldBindingType === 'camunda:errorEventDefinition') {
-    var errorEventDefinitions = findExtensions(element, ['camunda:ErrorEventDefinition']);
-
-    if (!errorEventDefinitions.length) {
-      return;
-    }
-
-    // error id has to start with <${binding.errorRef}_>
-    return find(errorEventDefinitions, function(eventDefinition) {
-      return eventDefinition.errorRef.id.indexOf(oldBinding.errorRef) == 0;
-    });
+    return findCamundaErrorEventDefinition(element, oldBinding.errorRef);
   }
 }
 
@@ -1157,6 +1142,10 @@ function findOldScopeElement(element, scopeTemplate, template) {
 
     // (1) find by error event definition binding
     var errorEventDefinitionBinding = findErrorEventDefinitionBinding(template, id);
+
+    if (!errorEventDefinitionBinding) {
+      return;
+    }
 
     // (2) find error event definition
     var errorEventDefinition = findOldBusinessObject(element, errorEventDefinitionBinding);

--- a/lib/provider/camunda/element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/lib/provider/camunda/element-templates/cmd/ChangeElementTemplateHandler.js
@@ -121,6 +121,8 @@ ChangeElementTemplateHandler.prototype._getOrCreateExtensionElements = function(
       values: []
     });
 
+    extensionElements.$parent = businessObject;
+
     modeling.updateProperties(element, {
       extensionElements: extensionElements
     });
@@ -185,7 +187,7 @@ ChangeElementTemplateHandler.prototype._updateCamundaErrorEventDefinitionPropert
       var rootElement = getRoot(getBusinessObject(element)),
           newError = createError(newBinding.errorRef, rootElement, bpmnFactory),
           newEventDefinition =
-            createCamundaErrorEventDefinition(newBinding, newProperty.value, newError, bpmnFactory);
+            createCamundaErrorEventDefinition(newBinding, newProperty.value, newError, businessObject, bpmnFactory);
 
       commandStack.execute('properties-panel.update-businessobject-list', {
         element: element,

--- a/lib/provider/camunda/element-templates/parts/CustomProps.js
+++ b/lib/provider/camunda/element-templates/parts/CustomProps.js
@@ -709,7 +709,7 @@ function setPropertyValue(element, property, value, bpmnFactory) {
 
       var newError = createError(binding.errorRef, rootElement, bpmnFactory),
           newEventDefinition =
-            createCamundaErrorEventDefinition(binding, value, newError, bpmnFactory);
+            createCamundaErrorEventDefinition(binding, value, newError, extensionElements, bpmnFactory);
 
       updates.push(cmdHelper.addAndRemoveElementsFromList(
         element,

--- a/lib/provider/camunda/element-templates/parts/CustomProps.js
+++ b/lib/provider/camunda/element-templates/parts/CustomProps.js
@@ -12,7 +12,8 @@ var findExtension = require('../Helper').findExtension,
     findInputParameter = require('../Helper').findInputParameter,
     findOutputParameter = require('../Helper').findOutputParameter,
     findCamundaProperty = require('../Helper').findCamundaProperty,
-    findCamundaInOut = require('../Helper').findCamundaInOut;
+    findCamundaInOut = require('../Helper').findCamundaInOut,
+    findCamundaErrorEventDefinition = require('../Helper').findCamundaErrorEventDefinition;
 
 var createCamundaProperty = require('../CreateHelper').createCamundaProperty,
     createInputParameter = require('../CreateHelper').createInputParameter,
@@ -20,9 +21,13 @@ var createCamundaProperty = require('../CreateHelper').createCamundaProperty,
     createCamundaIn = require('../CreateHelper').createCamundaIn,
     createCamundaOut = require('../CreateHelper').createCamundaOut,
     createCamundaInWithBusinessKey = require('../CreateHelper').createCamundaInWithBusinessKey,
-    createCamundaFieldInjection = require('../CreateHelper').createCamundaFieldInjection;
+    createCamundaFieldInjection = require('../CreateHelper').createCamundaFieldInjection,
+    createCamundaErrorEventDefinition = require('../CreateHelper').createCamundaErrorEventDefinition,
+    createError = require('../CreateHelper').createError;
 
 var handleLegacyScopes = require('../util/handleLegacyScopes');
+
+var getRoot = require('../../../../Utils').getRoot;
 
 var PROPERTY_TYPE = 'property',
     CAMUNDA_PROPERTY_TYPE = 'camunda:property',
@@ -32,7 +37,8 @@ var PROPERTY_TYPE = 'property',
     CAMUNDA_OUT_TYPE = 'camunda:out',
     CAMUNDA_IN_BUSINESS_KEY_TYPE = 'camunda:in:businessKey',
     CAMUNDA_EXECUTION_LISTENER_TYPE = 'camunda:executionListener',
-    CAMUNDA_FIELD = 'camunda:field';
+    CAMUNDA_FIELD = 'camunda:field',
+    CAMUNDA_ERROR_EVENT_DEFINITION = 'camunda:errorEventDefinition';
 
 var BASIC_MODDLE_TYPES = [
   'Boolean',
@@ -47,7 +53,8 @@ var EXTENSION_BINDING_TYPES = [
   CAMUNDA_IN_TYPE,
   CAMUNDA_OUT_TYPE,
   CAMUNDA_IN_BUSINESS_KEY_TYPE,
-  CAMUNDA_FIELD
+  CAMUNDA_FIELD,
+  CAMUNDA_ERROR_EVENT_DEFINITION
 ];
 
 var IO_BINDING_TYPES = [
@@ -156,7 +163,7 @@ module.exports = function(element, elementTemplates, bpmnFactory, translate) {
 
         var propertyId = 'custom-' + template.id + '-' + idScopeName + '-' + idx;
 
-        var scopedProperty = propertyWithScope(p, scopeType);
+        var scopedProperty = propertyWithScope(p, scope);
 
         entry = renderCustomField(propertyId, scopedProperty, idx);
         if (entry) {
@@ -263,7 +270,7 @@ function getPropertyValue(element, property) {
   var propertyValue = property.value || '';
 
   if (scope) {
-    bo = findExtension(bo, scope.name);
+    bo = findScopeElement(bo, scope);
     if (!bo) {
       return propertyValue;
     }
@@ -403,6 +410,17 @@ function getPropertyValue(element, property) {
     }
   }
 
+  var errorEventDefinition;
+  if (CAMUNDA_ERROR_EVENT_DEFINITION === bindingType) {
+    errorEventDefinition = findCamundaErrorEventDefinition(bo, binding.errorRef);
+
+    if (errorEventDefinition) {
+      return errorEventDefinition.expression;
+    } else {
+      return '';
+    }
+  }
+
   throw unknownPropertyBinding(property);
 }
 
@@ -432,6 +450,8 @@ function setPropertyValue(element, property, value, bpmnFactory) {
   var bindingType = binding.type,
       bindingName = binding.name;
 
+  var rootElement = getRoot(bo);
+
   var propertyValue;
 
   var updates = [];
@@ -452,13 +472,23 @@ function setPropertyValue(element, property, value, bpmnFactory) {
   }
 
   if (scope) {
-    bo = findExtension(bo, scope.name);
+    bo = findScopeElement(bo, scope);
     if (!bo) {
-      bo = elementHelper.createElement(scope.name, null, element, bpmnFactory);
 
-      updates.push(cmdHelper.addElementsTolist(
-        bo, extensionElements, 'values', [ bo ]
-      ));
+      // bpmn:Error
+      if (scope.name === 'bpmn:Error') {
+        bo = createError(scope.id, rootElement, bpmnFactory);
+
+        updates.push(cmdHelper.addElementsTolist(
+          bo, rootElement, 'rootElements', [ bo ]
+        ));
+      } else {
+        bo = elementHelper.createElement(scope.name, null, element, bpmnFactory);
+
+        updates.push(cmdHelper.addElementsTolist(
+          bo, extensionElements, 'values', [ bo ]
+        ));
+      }
     }
   }
 
@@ -667,6 +697,41 @@ function setPropertyValue(element, property, value, bpmnFactory) {
     ));
   }
 
+  // camunda:errorEventDefinition
+  if (bindingType === CAMUNDA_ERROR_EVENT_DEFINITION) {
+    var existingErrorEventDefinition = findCamundaErrorEventDefinition(bo, binding.errorRef);
+
+    if (existingErrorEventDefinition) {
+      updates.push(cmdHelper.updateBusinessObject(
+        element, existingErrorEventDefinition, { expression: value }
+      ));
+    } else {
+
+      var newError = createError(binding.errorRef, rootElement, bpmnFactory),
+          newEventDefinition =
+            createCamundaErrorEventDefinition(binding, value, newError, bpmnFactory);
+
+      updates.push(cmdHelper.addAndRemoveElementsFromList(
+        element,
+        rootElement,
+        'rootElements',
+        null,
+        [ newError ],
+        []
+      ));
+
+      updates.push(cmdHelper.addAndRemoveElementsFromList(
+        element,
+        extensionElements,
+        'values',
+        null,
+        [ newEventDefinition ],
+        []
+      ));
+    }
+
+  }
+
   if (updates.length) {
     return updates;
   }
@@ -721,14 +786,18 @@ function validateValue(value, property, translate) {
 
 // misc helpers ///////////////////////////////
 
-function propertyWithScope(property, scopeName) {
+function propertyWithScope(property, scope) {
+  var scopeName = scope.type,
+      scopeId = scope.id;
+
   if (!scopeName) {
     return property;
   }
 
   return assign({}, property, {
     scope: {
-      name: scopeName
+      name: scopeName,
+      id: scopeId
     }
   });
 }
@@ -797,4 +866,22 @@ function getDefaultType(property) {
   if (bindingType === CAMUNDA_EXECUTION_LISTENER_TYPE) {
     return 'Hidden';
   }
+}
+
+function findScopeElement(businessObject, scope) {
+
+  var scopeName = scope.name,
+      scopeId = scope.id;
+
+  if (scopeName === 'bpmn:Error') {
+
+    // retrieve error over referenced error event definition
+    var errorEventDefinition = findCamundaErrorEventDefinition(businessObject, scopeId);
+
+    if (errorEventDefinition) {
+      return errorEventDefinition.errorRef;
+    }
+  }
+
+  return findExtension(businessObject, scopeName);
 }

--- a/lib/provider/camunda/element-templates/parts/ErrorsProps.js
+++ b/lib/provider/camunda/element-templates/parts/ErrorsProps.js
@@ -1,0 +1,172 @@
+'use strict';
+
+var forEach = require('min-dash').forEach,
+    filter = require('min-dash').filter,
+    flatten = require('min-dash').flatten,
+    findIndex = require('min-dash').findIndex;
+
+var getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
+
+var findExtensions = require('../Helper').findExtensions,
+    findCamundaErrorEventDefinition = require('../Helper').findCamundaErrorEventDefinition;
+
+var ErrorEntries = require('../../parts/implementation/ErrorsEntries');
+
+var entryFactory = require('../../../../factory/EntryFactory');
+
+var domQuery = require('min-dom').query;
+
+var CAMUNDA_ERROR_EVENT_DEFINITION_TYPE = 'camunda:errorEventDefinition';
+
+var EMPTY_ERROR = {
+  get: function() {},
+  set: function() {},
+  errorRef: {}
+};
+
+/**
+ * Injects element template errors into the given group.
+ *
+ * @param {Object} group
+ * @param {djs.model.Base} element
+ * @param {ElementTemplates} elementTemplates
+ * @param {BpmnFactory} bpmnFactory
+ * @param {Function} translate
+ */
+module.exports = function(group, element, elementTemplates, bpmnFactory, translate) {
+  var template = elementTemplates.get(element);
+
+  if (!template) {
+    return [];
+  }
+
+  var errorEntries = [];
+
+  function onToggle(value, entryNode) {
+    if (!value) {
+      return;
+    }
+
+    var currentEntryId = entryNode.dataset.entry;
+
+    // collapse all other items
+    errorEntries.forEach(function(entries) {
+      var collapsible = entries[0];
+
+      if (collapsible.id === currentEntryId) {
+        return;
+      }
+
+      var entryNode = domQuery('[data-entry="' + collapsible.id + '"]');
+      collapsible.setOpen(false, entryNode);
+    });
+  }
+
+
+  function renderError(id, templateProperty) {
+    var binding = templateProperty.binding,
+        bindingErrorRef = binding.errorRef,
+        errorEntries = [],
+        collapsibleEntry;
+
+    // find error event definition first
+    var bo = getBusinessObject(element),
+        errorEventDefinitions = findExtensions(bo, [ 'camunda:ErrorEventDefinition' ]);
+
+    if (!errorEventDefinitions) {
+      return errorEntries;
+    }
+
+    var getError = function() {
+      var definition = findCamundaErrorEventDefinition(element, bindingErrorRef);
+
+      if (!definition) {
+        return EMPTY_ERROR;
+      }
+
+      return definition;
+    };
+
+    var error = getError();
+
+    var isOpen = function() {
+      return collapsibleEntry.isOpen();
+    };
+
+    var options = {
+      idPrefix: id + '-',
+      onToggle: onToggle,
+      getError: getError,
+      isOpen: function() {
+        return isOpen();
+      }
+    };
+
+    // (1) use errors implementation
+    var errorImplementation = ErrorEntries(error, bpmnFactory, element, options, translate);
+    errorEntries = errorImplementation.entries;
+
+    var errorReferenceIdx = findEntry(errorEntries, id + '-error-reference');
+
+    collapsibleEntry = errorEntries[findEntry(errorEntries, id + '-collapsible')];
+
+    // (2) replace validated expression entry by a simple, disabled entry
+    var expressionIdx = findEntry(errorEntries, id + '-error-expression');
+    removeEntry(errorEntries, expressionIdx);
+
+    var expressionEntry = entryFactory.textField(translate, {
+      id: id + '-error-expression',
+      label: translate('Throw Expression'),
+      modelProperty: 'expression',
+
+      get: function() {
+        return { expression: getError().expression };
+      },
+
+      buttonShow: {
+        method: function() {
+          return false;
+        }
+      },
+
+      hidden: function() {
+        return !isOpen();
+      },
+      disabled: function() {
+        return true;
+      }
+    });
+
+    errorEntries.splice(expressionIdx, 0, expressionEntry);
+
+    // (3) remove error selection
+    removeEntry(errorEntries, errorReferenceIdx);
+
+    return errorEntries;
+  }
+
+  // filter specific errors from template
+  var errors = filter(template.properties, function(p) {
+    return !p.type && p.binding.type === CAMUNDA_ERROR_EVENT_DEFINITION_TYPE;
+  });
+
+  forEach(errors, function(property, idx) {
+    var id = 'template-errors-' + template.id + '-' + idx;
+    errorEntries.push(renderError(id, property));
+  });
+
+  group.entries = group.entries.concat(flatten(errorEntries));
+};
+
+
+// helper //////////////////////////
+
+function findEntry(entries, id) {
+  return findIndex(entries, function(entry) {
+    return entry.id === id;
+  });
+}
+
+function removeEntry(entries, idx) {
+  entries.splice(idx, 1);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -165,9 +165,9 @@
       }
     },
     "@camunda/element-templates-json-schema": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.2.0.tgz",
-      "integrity": "sha512-U3+p9lmajdn3YT3woNASwBZAcgFrEeaQHKZOdsUyzFPI+bplNQpJGCEl1k4eHXUPowiAruhmsSUrOSEjqpcOBA=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.3.0.tgz",
+      "integrity": "sha512-m6n2XTZHjVEPd74RvHHya8aXSydmSFXBb5FyXomHbEIVryxNlgIs5UTm81HUbRAbeDHmSTv+6+6gkk7qqZK48g=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@bpmn-io/extract-process-variables": "^0.4.3",
-    "@camunda/element-templates-json-schema": "0.2.0",
+    "@camunda/element-templates-json-schema": "0.3.0",
     "ids": "^1.0.0",
     "inherits": "^2.0.1",
     "lodash": "^4.17.20",

--- a/test/spec/provider/camunda/element-templates/CreateHelperSpec.js
+++ b/test/spec/provider/camunda/element-templates/CreateHelperSpec.js
@@ -8,6 +8,10 @@ var coreModule = require('bpmn-js/lib/core').default,
     modelingModule = require('bpmn-js/lib/features/modeling').default,
     camundaModdlePackage = require('camunda-bpmn-moddle/resources/camunda');
 
+var getRoot = require('lib/Utils').getRoot;
+
+var getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
+
 var CreateHelper = require('lib/provider/camunda/element-templates/CreateHelper');
 
 var createInputParameter = CreateHelper.createInputParameter,
@@ -15,7 +19,8 @@ var createInputParameter = CreateHelper.createInputParameter,
     createCamundaIn = CreateHelper.createCamundaIn,
     createCamundaOut = CreateHelper.createCamundaOut,
     createCamundaInWithBusinessKey = CreateHelper.createCamundaInWithBusinessKey,
-    createCamundaExecutionListenerScript = CreateHelper.createCamundaExecutionListenerScript;
+    createCamundaExecutionListenerScript = CreateHelper.createCamundaExecutionListenerScript,
+    createError = CreateHelper.createError;
 
 
 var testModules = [
@@ -339,6 +344,31 @@ describe('element-templates - CreateHelper', function() {
       });
     }));
 
+  });
+
+
+  describe('createError', function() {
+
+    it('should create error', inject(function(bpmnFactory, elementRegistry) {
+
+      // given
+      var binding = {
+        type: 'camunda:errorEventDefinition',
+        errorRef: 'error-1'
+      };
+
+      var process = elementRegistry.get('Process_1');
+
+      var rootElement = getRoot(getBusinessObject(process));
+
+      // when
+      var error = createError(binding.errorRef, rootElement, bpmnFactory);
+
+      // then
+      expect(error).to.exist;
+      expect(error.$type).to.eql('bpmn:Error');
+      expect(error.id.indexOf('Error_' + binding.errorRef)).to.equal(0);
+    }));
   });
 
 });

--- a/test/spec/provider/camunda/element-templates/ValidatorSpec.js
+++ b/test/spec/provider/camunda/element-templates/ValidatorSpec.js
@@ -139,7 +139,7 @@ describe('element-templates - Validator', function() {
       // then
       expect(errors(templates)).to.have.length(6);
 
-      expect(errors(templates)[0]).to.eql('template(id: <foo>, name: <Foo>): unsupported element template schema version <99.99.99>. Your installation only supports up to version <0.2.0>. Please update your installation');
+      expect(errors(templates)[0]).to.eql('template(id: <foo>, name: <Foo>): unsupported element template schema version <99.99.99>. Your installation only supports up to version <'+ ElementTemplateSchemaVersion + '>. Please update your installation');
     });
 
   });

--- a/test/spec/provider/camunda/element-templates/ValidatorSpec.js
+++ b/test/spec/provider/camunda/element-templates/ValidatorSpec.js
@@ -399,7 +399,8 @@ describe('element-templates - Validator', function() {
         'template(id: <foo>, name: <Invalid>): property.binding <camunda:inputParameter> requires name',
         'template(id: <foo>, name: <Invalid>): property.binding <camunda:outputParameter> requires source',
         'template(id: <foo>, name: <Invalid>): property.binding <camunda:in> requires variables or target',
-        'template(id: <foo>, name: <Invalid>): property.binding <camunda:out> requires variables, sourceExpression or source'
+        'template(id: <foo>, name: <Invalid>): property.binding <camunda:out> requires variables, sourceExpression or source',
+        'template(id: <foo>, name: <Invalid>): property.binding <camunda:errorEventDefinition> requires errorRef'
       ]);
 
       expect(valid(templates)).to.be.empty;

--- a/test/spec/provider/camunda/element-templates/cmd/ChangeElementTemplateHandlerSpec.js
+++ b/test/spec/provider/camunda/element-templates/cmd/ChangeElementTemplateHandlerSpec.js
@@ -17,7 +17,8 @@ var getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject,
     is = require('bpmn-js/lib/util/ModelUtil').is;
 
 var findExtension = require('lib/provider/camunda/element-templates/Helper').findExtension,
-    findExtensions = require('lib/provider/camunda/element-templates/Helper').findExtensions;
+    findExtensions = require('lib/provider/camunda/element-templates/Helper').findExtensions,
+    findErrorEventDefinition = require('lib/provider/camunda/element-templates/Helper').findCamundaErrorEventDefinition;
 
 var findRootElementsByType = require('lib/Utils').findRootElementsByType;
 
@@ -1167,7 +1168,7 @@ describe('element-templates - ChangeElementTemplateHandler', function() {
           // then
           expectElementTemplate(task, 'task-template-no-properties');
 
-          var errorEventDefinition = findErrorEventDefinition(task, 'Error_1'),
+          var errorEventDefinition = findErrorEventDefinition(task, 'fooError'),
               error = errorEventDefinition.errorRef;
 
           expect(errorEventDefinition).to.exist;
@@ -1527,7 +1528,7 @@ describe('element-templates - ChangeElementTemplateHandler', function() {
             // then
             expectElementTemplate(serviceTask, 'service-task-template-no-properties');
 
-            var error = findErrorForEventDefinition(serviceTask, 'Error_1');
+            var error = findErrorForEventDefinition(serviceTask, 'fooError');
 
             expect(error).to.exist;
             expect(error.get('name')).to.equal('error-name');
@@ -3106,7 +3107,7 @@ describe('element-templates - ChangeElementTemplateHandler', function() {
         expect(errors).to.have.length(1);
 
         expect(error).to.exist;
-        expect(error.get('id').indexOf('error-1')).to.equal(0); // start with binding error ref
+        expect(error.get('id').indexOf('Error_error-1')).to.equal(0); // start with binding error ref
         expect(error.get('errorCode')).to.equal('error-code');
         expect(error.get('name')).to.equal('error-name');
         expect(error.get('errorMessage')).to.eql('error-message');
@@ -4380,12 +4381,4 @@ function findErrorForEventDefinition(element, bindingErrorRef) {
   if (eventDefinition) {
     return eventDefinition.errorRef;
   }
-}
-
-function findErrorEventDefinition(element, bindingErrorRef) {
-  var errorEventDefinitions = findExtensions(element, [ 'camunda:ErrorEventDefinition' ]);
-
-  return errorEventDefinitions.find(function(errorEventDefinition) {
-    return errorEventDefinition.errorRef.id.indexOf(bindingErrorRef) == 0;
-  });
 }

--- a/test/spec/provider/camunda/element-templates/cmd/ChangeElementTemplateHandlerSpec.js
+++ b/test/spec/provider/camunda/element-templates/cmd/ChangeElementTemplateHandlerSpec.js
@@ -4222,6 +4222,58 @@ describe('element-templates - ChangeElementTemplateHandler', function() {
 
   });
 
+
+  describe('_getOrCreateExtensionElements', function() {
+
+    beforeEach(bootstrap(require('./task.bpmn')));
+
+    var newTemplate = require('./task-template-1.json');
+
+    it('should work with existing extension elements', inject(function(elementRegistry) {
+
+      // given
+      var task = elementRegistry.get('Task_2'),
+          businessObject = getBusinessObject(task);
+
+      // when
+      changeTemplate(task, newTemplate);
+
+      // then
+      expectElementTemplate(task, 'task-template', 1);
+
+      var extensionElements = businessObject.get('extensionElements');
+
+      expect(extensionElements).to.exist;
+      expect(findExtensions(businessObject, [ 'camunda:ErrorEventDefinition' ]))
+        .to.have.length(1);
+    }));
+
+
+    it('should set parent to newly created extension elements', inject(function(elementRegistry) {
+
+      // given
+      var task = elementRegistry.get('Task_1'),
+          businessObject = getBusinessObject(task);
+
+      var extensionElements = businessObject.get('extensionElements');
+
+      // assume
+      expect(extensionElements).to.not.exist;
+
+      // when
+      changeTemplate(task, newTemplate);
+
+      // then
+      expectElementTemplate(task, 'task-template', 1);
+
+      extensionElements = businessObject.get('extensionElements');
+
+      expect(extensionElements).to.exist;
+      expect(extensionElements.$parent).to.eql(businessObject);
+    }));
+
+  });
+
 });
 
 

--- a/test/spec/provider/camunda/element-templates/cmd/service-task-error.bpmn
+++ b/test/spec/provider/camunda/element-templates/cmd/service-task-error.bpmn
@@ -3,11 +3,11 @@
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:serviceTask id="ServiceTask_1">
       <bpmn:extensionElements>
-         <camunda:errorEventDefinition id="ErrorEventDefinition_1" errorRef="Error_1" expression="error-expression" />
+         <camunda:errorEventDefinition id="ErrorEventDefinition_1" errorRef="Error_fooError" expression="error-expression" />
       </bpmn:extensionElements>
     </bpmn:serviceTask>
   </bpmn:process>
-  <bpmn:error id="Error_1" name="error-name" errorCode="error-code" camunda:errorMessage="error-message" />
+  <bpmn:error id="Error_fooError" name="error-name" errorCode="error-code" camunda:errorMessage="error-message" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">

--- a/test/spec/provider/camunda/element-templates/cmd/task.bpmn
+++ b/test/spec/provider/camunda/element-templates/cmd/task.bpmn
@@ -2,11 +2,19 @@
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_039bbyr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:task id="Task_1" />
+    <bpmn:task id="Task_2">
+      <bpmn:extensionElements>
+        <camunda:errorEventDefinition id="ErrorEventDefinition_1" expression="expression"></camunda:errorEventDefinition>
+      </bpmn:extensionElements>
+    </bpmn:task>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
         <dc:Bounds x="0" y="0" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
+        <dc:Bounds x="0" y="120" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/camunda/element-templates/fixtures/error-bindings-invalid.json
+++ b/test/spec/provider/camunda/element-templates/fixtures/error-bindings-invalid.json
@@ -47,6 +47,13 @@
         "binding": {
           "type": "camunda:out"
         }
+      },
+      {
+        "label": "Missing camunda:errorEventDefinition errorRef",
+        "type": "String",
+        "binding": {
+          "type": "camunda:errorEventDefinition"
+        }
       }
     ]
   }

--- a/test/spec/provider/camunda/element-templates/parts/CustomProps.bpmn
+++ b/test/spec/provider/camunda/element-templates/parts/CustomProps.bpmn
@@ -102,7 +102,15 @@
       </bpmn:extensionElements>
     </bpmn:serviceTask>
     <bpmn:serviceTask id="ConnectorTask_NoData_legacy" name="Connector Task NoData" camunda:modelerTemplate="my.connector.legacy.Task" />
+    <bpmn:serviceTask id="ExternalErrorTask" name="External Error Task" camunda:modelerTemplate="com.camunda.example.ExternalErrorTask" camunda:type="external">
+      <bpmn:extensionElements>
+        <camunda:errorEventDefinition id="ErrorEventDefinition_1bt7x0x" errorRef="Error_error-1_xyz" expression="error-expression" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ExternalErrorTask_NoData" name="External Error Task NoData" camunda:modelerTemplate="com.camunda.example.ExternalErrorTask" />
+    <bpmn:serviceTask id="ExternalErrorTask_NoError" name="External Error Task NoError" camunda:modelerTemplate="com.camunda.example.SimpleErrorScope" />
   </bpmn:process>
+  <bpmn:error id="Error_error-1_xyz" name="error-name" errorCode="my-code" camunda:errorMessage="foo" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNEdge id="SequenceFlow_13jfpgw_di" bpmnElement="VipOrderPath">
@@ -168,6 +176,15 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1yvd1h6_di" bpmnElement="ConnectorTask_NoData_legacy">
         <dc:Bounds x="654" y="430" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0epmlyl_di" bpmnElement="ExternalErrorTask">
+        <dc:Bounds x="800" y="310" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0kfraj6_di" bpmnElement="ExternalErrorTask_NoData">
+        <dc:Bounds x="800" y="430" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1cex61n_di" bpmnElement="ExternalErrorTask_NoError">
+        <dc:Bounds x="800" y="530" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/camunda/element-templates/parts/CustomProps.json
+++ b/test/spec/provider/camunda/element-templates/parts/CustomProps.json
@@ -618,5 +618,109 @@
         }
       }
     ]
+  },
+  {
+    "name": "ExternalErrorTask",
+    "id": "com.camunda.example.ExternalErrorTask",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "external",
+        "binding": {
+          "type": "property",
+          "name": "camunda:type"
+        }
+      },
+      {
+        "label": "Error Expression",
+        "value": "error-expression",
+        "type": "String",
+        "binding": {
+          "type": "camunda:errorEventDefinition",
+          "errorRef": "error-1"
+        }
+      }
+    ],
+    "scopes": [
+      {
+        "type": "bpmn:Error",
+        "id": "error-1",
+        "properties": [
+          {
+            "label": "Error Code",
+            "type": "String",
+            "value": "my-code",
+            "binding": {
+              "type": "property",
+              "name": "errorCode"
+            }
+          },
+          {
+            "label": "Error Message",
+            "type": "String",
+            "value": "error-message",
+            "binding": {
+              "type": "property",
+              "name": "camunda:errorMessage"
+            }
+          },
+          {
+            "label": "Error Name",
+            "type": "String",
+            "value": "error-name",
+            "binding": {
+              "type": "property",
+              "name": "name"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "SimpleErrorScope",
+    "id": "com.camunda.example.SimpleErrorScope",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [],
+    "scopes": [
+      {
+        "type": "bpmn:Error",
+        "id": "error-simple",
+        "properties": [
+          {
+            "label": "Error Code",
+            "type": "String",
+            "value": "my-code",
+            "binding": {
+              "type": "property",
+              "name": "errorCode"
+            }
+          },
+          {
+            "label": "Error Message",
+            "type": "String",
+            "value": "error-message",
+            "binding": {
+              "type": "property",
+              "name": "camunda:errorMessage"
+            }
+          },
+          {
+            "label": "Error Name",
+            "type": "String",
+            "value": "error-name",
+            "binding": {
+              "type": "property",
+              "name": "name"
+            }
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/test/spec/provider/camunda/element-templates/parts/ErrorsProps.bpmn
+++ b/test/spec/provider/camunda/element-templates/parts/ErrorsProps.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1jhfqto" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.14.0">
+  <bpmn:process id="Process_0jg7qce" isExecutable="true">
+    <bpmn:serviceTask id="ServiceTask_1" camunda:modelerTemplate="com.example.ExternalTaskWorker" camunda:type="external">
+      <bpmn:extensionElements>
+        <camunda:errorEventDefinition id="ErrorEventDefinition_1x790hf" errorRef="Error_error-1_19uan50" expression="${error.expression1}" />
+        <camunda:errorEventDefinition id="ErrorEventDefinition_1mfya2c" errorRef="Error_error-2_160l0k8" expression="${error.expression2}" />
+        <camunda:errorEventDefinition id="ErrorEventDefinition_0wrs1j5" errorRef="Error_error-3_05nhsr3" expression="${error.expression3}" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_empty" camunda:modelerTemplate="com.example.EmptyTemplate" />
+  </bpmn:process>
+  <bpmn:error id="Error_error-1_19uan50" name="error-name-1" errorCode="error-code-1" camunda:errorMessage="error-message-1" />
+  <bpmn:error id="Error_error-2_160l0k8" name="error-name-2" errorCode="error-code-2" camunda:errorMessage="error-message-2" />
+  <bpmn:error id="Error_error-3_05nhsr3" name="error-name-3" errorCode="error-code-3" camunda:errorMessage="error-message-3" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jg7qce">
+      <bpmndi:BPMNShape id="Activity_07xpg3x_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="200" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1qhu82r_di" bpmnElement="ServiceTask_empty">
+        <dc:Bounds x="200" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/camunda/element-templates/parts/ErrorsProps.json
+++ b/test/spec/provider/camunda/element-templates/parts/ErrorsProps.json
@@ -1,0 +1,152 @@
+[
+  {
+    "name": "External Task Worker",
+    "id": "com.example.ExternalTaskWorker",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "external",
+        "binding": {
+          "type": "property",
+          "name": "camunda:type"
+        }
+      },
+      {
+        "label": "error-name-1",
+        "value": "${error.expression1}",
+        "binding": {
+          "type": "camunda:errorEventDefinition",
+          "errorRef": "error-1"
+        }
+      },
+      {
+        "label": "error-name-2",
+        "value": "${error.expression2}",
+        "binding": {
+          "type": "camunda:errorEventDefinition",
+          "errorRef": "error-2"
+        }
+      },
+      {
+        "label": "error-name-3",
+        "value": "${error.expression3}",
+        "binding": {
+          "type": "camunda:errorEventDefinition",
+          "errorRef": "error-3"
+        }
+      }
+    ],
+    "scopes": [
+      {
+        "type": "bpmn:Error",
+        "id": "error-1",
+        "properties": [
+          {
+            "label": "Error Code",
+            "type": "Hidden",
+            "value": "error-code-1",
+            "binding": {
+              "type": "property",
+              "name": "errorCode"
+            }
+          },
+          {
+            "label": "Error Message",
+            "type": "Hidden",
+            "value": "error-message-1",
+            "binding": {
+              "type": "property",
+              "name": "camunda:errorMessage"
+            }
+          },
+          {
+            "label": "Error Name",
+            "type": "Hidden",
+            "value": "error-name-1",
+            "binding": {
+              "type": "property",
+              "name": "name"
+            }
+          }
+        ]
+      },
+      {
+        "type": "bpmn:Error",
+        "id": "error-2",
+        "properties": [
+          {
+            "label": "Error Code",
+            "type": "Hidden",
+            "value": "error-code-2",
+            "binding": {
+              "type": "property",
+              "name": "errorCode"
+            }
+          },
+          {
+            "label": "Error Message",
+            "type": "Hidden",
+            "value": "error-message-2",
+            "binding": {
+              "type": "property",
+              "name": "camunda:errorMessage"
+            }
+          },
+          {
+            "label": "Error Name",
+            "type": "Hidden",
+            "value": "error-name-2",
+            "binding": {
+              "type": "property",
+              "name": "name"
+            }
+          }
+        ]
+      },
+      {
+        "type": "bpmn:Error",
+        "id": "error-3",
+        "properties": [
+          {
+            "label": "Error Code",
+            "type": "Hidden",
+            "value": "error-code-3",
+            "binding": {
+              "type": "property",
+              "name": "errorCode"
+            }
+          },
+          {
+            "label": "Error Message",
+            "type": "Hidden",
+            "value": "error-message-3",
+            "binding": {
+              "type": "property",
+              "name": "camunda:errorMessage"
+            }
+          },
+          {
+            "label": "Error Name",
+            "type": "Hidden",
+            "value": "error-name-3",
+            "binding": {
+              "type": "property",
+              "name": "name"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Empty Template",
+    "id": "com.example.EmptyTemplate",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/camunda/element-templates/parts/ErrorsPropsSpec.js
+++ b/test/spec/provider/camunda/element-templates/parts/ErrorsPropsSpec.js
@@ -1,0 +1,373 @@
+'use strict';
+
+var TestHelper = require('../../../../../TestHelper');
+
+/* global inject */
+
+var findCamundaErrorEventDefinition = require('lib/provider/camunda/element-templates/Helper').findCamundaErrorEventDefinition;
+
+var entrySelect = require('./Helper').entrySelect,
+    selectAndGet = require('./Helper').selectAndGet,
+    bootstrap = require('./Helper').bootstrap;
+
+var domClasses = require('min-dom').classes,
+    domQuery = require('min-dom').query,
+    domQueryAll = require('min-dom').queryAll,
+    domAttr = require('min-dom').attr;
+
+describe('element-templates/parts - Collapsible Errors', function() {
+
+  var diagramXML = require('./ErrorsProps.bpmn'),
+      elementTemplates = require('./ErrorsProps.json');
+
+  beforeEach(bootstrap(diagramXML, elementTemplates));
+
+
+  describe('display', function() {
+
+    it('should display errors', inject(function(propertiesPanel) {
+
+      // given
+      var container = propertiesPanel._container;
+
+      selectAndGet('ServiceTask_1');
+
+      // when
+      var errorsGroup = getTemplateErrorsGroup(container);
+
+      // then
+      expect(isHidden(errorsGroup)).to.be.false;
+      expect(getTemplateErrors(container).length).to.equal(3);
+    }));
+
+
+    it('should NOT display errors - none defined', inject(function(propertiesPanel) {
+
+      // given
+      var container = propertiesPanel._container;
+
+      selectAndGet('ServiceTask_empty');
+
+      // when
+      var errorsGroup = getTemplateErrorsGroup(container);
+
+      // then
+      expect(isHidden(errorsGroup)).to.be.true;
+    }));
+
+
+    it('should display title', inject(function() {
+
+      // given
+      selectAndGet('ServiceTask_1');
+
+      // when
+      var collapsibleTitle = entrySelect(
+        'template-errors-com.example.ExternalTaskWorker-0-collapsible',
+        '.bpp-collapsible__title'
+      );
+
+      // then
+      expect(collapsibleTitle).to.exist;
+
+      // "${errorRef.name} (code = ${errorRef.errorCode})"
+      expect(collapsibleTitle.innerText).to.equal('error-name-1 (code = error-code-1)');
+    }));
+
+
+    it('should display error expression (disabled)', inject(function() {
+
+      // given
+      selectAndGet('ServiceTask_1');
+
+      // when
+      var expressionTextField = entrySelect(
+        'template-errors-com.example.ExternalTaskWorker-0-error-expression',
+        'input'
+      );
+
+      // then
+      expect(expressionTextField).to.exist;
+      expect(expressionTextField.value).to.equal('${error.expression1}');
+      expect(isDisabled(expressionTextField)).to.be.true;
+    }));
+
+
+    it('should NOT display error reference select', inject(function() {
+
+      // given
+      selectAndGet('ServiceTask_1');
+
+      // when
+      var selectField = entrySelect(
+        'template-errors-com.example.ExternalTaskWorker-0-error-reference',
+        'select'
+      );
+
+      // then
+      expect(selectField).not.to.exist;
+    }));
+
+
+    it('should display error name', inject(function() {
+
+      // given
+      selectAndGet('ServiceTask_1');
+
+      // when
+      var textField = entrySelect(
+        'template-errors-com.example.ExternalTaskWorker-0-error-element-name',
+        'input'
+      );
+
+      // then
+      expect(textField).to.exist;
+      expect(textField.value).to.equal('error-name-1');
+    }));
+
+
+    it('should display error code', inject(function() {
+
+      // given
+      selectAndGet('ServiceTask_1');
+
+      // when
+      var textField = entrySelect(
+        'template-errors-com.example.ExternalTaskWorker-0-error-element-code',
+        'input'
+      );
+
+      // then
+      expect(textField).to.exist;
+      expect(textField.value).to.equal('error-code-1');
+    }));
+
+
+    it('should display error message', inject(function() {
+
+      // given
+      selectAndGet('ServiceTask_1');
+
+      // when
+      var textField = entrySelect(
+        'template-errors-com.example.ExternalTaskWorker-0-error-element-message',
+        'input'
+      );
+
+      // then
+      expect(textField).to.exist;
+      expect(textField.value).to.equal('error-message-1');
+    }));
+
+  });
+
+
+  describe('should update error name', function() {
+
+    var task;
+
+    beforeEach(inject(function() {
+
+      // given
+      task = selectAndGet('ServiceTask_1');
+
+      var collapsibleTitle = entrySelect(
+            'template-errors-com.example.ExternalTaskWorker-0-collapsible',
+            '.bpp-collapsible__title'
+          ),
+          nameField = entrySelect(
+            'template-errors-com.example.ExternalTaskWorker-0-error-element-name',
+            'input'
+          );
+
+      // assure item is collapsed
+      TestHelper.triggerEvent(collapsibleTitle, 'click');
+
+      // when
+      TestHelper.triggerValue(nameField, 'foo', 'change');
+    }));
+
+    it('should execute', function() {
+
+      // then
+      var error = getError(task, 'error-1');
+
+      expect(error.name).to.equal('foo');
+    });
+
+
+    it('should undo', inject(function(commandStack) {
+
+      // when
+      commandStack.undo();
+
+      var error = getError(task, 'error-1');
+
+      // then
+      expect(error.name).to.equal('error-name-1');
+    }));
+
+
+    it('should redo', inject(function(commandStack) {
+
+      // when
+      commandStack.undo();
+      commandStack.redo();
+
+      var error = getError(task, 'error-1');
+
+      // then
+      expect(error.name).to.equal('foo');
+    }));
+
+  });
+
+
+  describe('should update error code', function() {
+
+    var task;
+
+    beforeEach(inject(function() {
+
+      // given
+      task = selectAndGet('ServiceTask_1');
+
+      var collapsibleTitle = entrySelect(
+            'template-errors-com.example.ExternalTaskWorker-0-collapsible',
+            '.bpp-collapsible__title'
+          ),
+          codeField = entrySelect(
+            'template-errors-com.example.ExternalTaskWorker-0-error-element-code',
+            'input'
+          );
+
+      // assure item is collapsed
+      TestHelper.triggerEvent(collapsibleTitle, 'click');
+
+      // when
+      TestHelper.triggerValue(codeField, 'foo', 'change');
+    }));
+
+    it('should execute', function() {
+
+      // then
+      var error = getError(task, 'error-1');
+
+      expect(error.errorCode).to.equal('foo');
+    });
+
+
+    it('should undo', inject(function(commandStack) {
+
+      // when
+      commandStack.undo();
+
+      var error = getError(task, 'error-1');
+
+      // then
+      expect(error.errorCode).to.equal('error-code-1');
+    }));
+
+
+    it('should redo', inject(function(commandStack) {
+
+      // when
+      commandStack.undo();
+      commandStack.redo();
+
+      var error = getError(task, 'error-1');
+
+      // then
+      expect(error.errorCode).to.equal('foo');
+    }));
+  });
+
+
+  describe('should update error message', function() {
+
+    var task;
+
+    beforeEach(inject(function() {
+
+      // given
+      task = selectAndGet('ServiceTask_1');
+
+      var collapsibleTitle = entrySelect(
+            'template-errors-com.example.ExternalTaskWorker-0-collapsible',
+            '.bpp-collapsible__title'
+          ),
+          messageField = entrySelect(
+            'template-errors-com.example.ExternalTaskWorker-0-error-element-message',
+            'input'
+          );
+
+      // assure item is collapsed
+      TestHelper.triggerEvent(collapsibleTitle, 'click');
+
+      // when
+      TestHelper.triggerValue(messageField, 'foo', 'change');
+    }));
+
+    it('should execute', function() {
+
+      // then
+      var error = getError(task, 'error-1');
+
+      expect(error.errorMessage).to.equal('foo');
+    });
+
+
+    it('should undo', inject(function(commandStack) {
+
+      // when
+      commandStack.undo();
+
+      var error = getError(task, 'error-1');
+
+      // then
+      expect(error.errorMessage).to.equal('error-message-1');
+    }));
+
+
+    it('should redo', inject(function(commandStack) {
+
+      // when
+      commandStack.undo();
+      commandStack.redo();
+
+      var error = getError(task, 'error-1');
+
+      // then
+      expect(error.errorMessage).to.equal('foo');
+    }));
+  });
+
+});
+
+
+// helpers ///////////////////////
+
+function getTemplateErrorsGroup(container) {
+  return domQuery('[data-group="template-errors"]', container);
+}
+
+function getTemplateErrors(container) {
+  var group = getTemplateErrorsGroup(container);
+  return domQueryAll('.bpp-collapsible-error', group);
+}
+
+function isHidden(entryNode) {
+  return domClasses(entryNode).has('bpp-hidden');
+}
+
+function isDisabled(node) {
+  return domAttr(node, 'disabled') !== null;
+}
+
+function getError(element, errorId) {
+  var errorEventDefinition = findCamundaErrorEventDefinition(element, errorId);
+
+  if (errorEventDefinition) {
+    return errorEventDefinition.errorRef;
+  }
+}


### PR DESCRIPTION
This adds
* support for `camunda:errorEventDefinition` & `bpmn:error` scope bindings in the Custom Fields
* the template errors default component
* bump the supported JSON Schema version to `v0.3.0`

Closes #424 
Related to https://github.com/camunda/camunda-modeler/issues/2083

-----

This can be tested with the following templates: [my-templates.json.txt](https://github.com/bpmn-io/bpmn-js-properties-panel/files/6162720/my-templates.json.txt)

I will send an artifact via Slack, because `build-on-demand` does not provide nested dependency as of now.


<img width="1149" alt="Bildschirmfoto 2021-03-18 um 10 20 14" src="https://user-images.githubusercontent.com/9433996/111603094-4972aa00-87d4-11eb-97a1-76d65c31ecd8.png">

<img width="1149" alt="Bildschirmfoto 2021-03-18 um 10 20 36" src="https://user-images.githubusercontent.com/9433996/111603105-4bd50400-87d4-11eb-8627-05d8a0590791.png">
