### PR TITLE
Remove error event definitions when changing service task implementation type

### DIFF
--- a/lib/provider/camunda/parts/implementation/ImplementationType.js
+++ b/lib/provider/camunda/parts/implementation/ImplementationType.js
@@ -139,6 +139,13 @@ module.exports = function(element, bpmnFactory, options, translate) {
       var commands = [];
       commands.push(cmdHelper.updateBusinessObject(element, bo, props));
 
+      if (oldType === 'external' && newType !== 'external') {
+        var errorEventDefinitions = extensionElementsHelper.getExtensionElements(bo, 'camunda:ErrorEventDefinition');
+        commands.push(map(errorEventDefinitions, function(errorEventDefinition) {
+          return extensionElementsHelper.removeEntry(bo, element, errorEventDefinition);
+        }));
+      }
+
       if (hasServiceTaskLikeSupport) {
         var connectors = extensionElementsHelper.getExtensionElements(bo, 'camunda:Connector');
         commands.push(map(connectors, function(connector) {

--- a/test/spec/provider/camunda/ImplementationType.bpmn
+++ b/test/spec/provider/camunda/ImplementationType.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
   <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:serviceTask id="CLASS" name="Class" camunda:class="foo" />
     <bpmn:serviceTask id="EXPRESSION" name="Expression" camunda:expression="foo" />
@@ -7,8 +7,9 @@
     <bpmn:serviceTask id="EXTERNAL" name="External" camunda:type="external" camunda:topic="foo" />
     <bpmn:serviceTask id="CONNECTOR" name="Connector">
       <bpmn:extensionElements>
-        <camunda:connector>        <camunda:connectorId>foo</camunda:connectorId>
-</camunda:connector>
+        <camunda:connector>
+          <camunda:connectorId>foo</camunda:connectorId>
+        </camunda:connector>
       </bpmn:extensionElements>
     </bpmn:serviceTask>
     <bpmn:businessRuleTask id="DMN" name="DMN" camunda:decisionRef="foo" />
@@ -17,15 +18,17 @@
     <bpmn:businessRuleTask id="BRT_DELEGATE_EXPRESSION" name="Delegate Expression" camunda:delegateExpression="foo" />
     <bpmn:businessRuleTask id="BRT_CONNECTOR" name="Connector">
       <bpmn:extensionElements>
-        <camunda:connector>        <camunda:connectorId>foo</camunda:connectorId>
-</camunda:connector>
+        <camunda:connector>
+          <camunda:connectorId>foo</camunda:connectorId>
+        </camunda:connector>
       </bpmn:extensionElements>
     </bpmn:businessRuleTask>
     <bpmn:serviceTask id="WITH_LISTENER_AND_CONNECTOR" name="With Listener and Connector">
       <bpmn:extensionElements>
         <camunda:executionListener class="foo" event="start" />
-        <camunda:connector>        <camunda:connectorId>foo</camunda:connectorId>
-</camunda:connector>
+        <camunda:connector>
+          <camunda:connectorId>foo</camunda:connectorId>
+        </camunda:connector>
       </bpmn:extensionElements>
     </bpmn:serviceTask>
     <bpmn:serviceTask id="WITH_LISTENER" name="With Listener">
@@ -33,44 +36,53 @@
         <camunda:executionListener class="foo" event="start" />
       </bpmn:extensionElements>
     </bpmn:serviceTask>
+    <bpmn:serviceTask id="WITH_ERROR_EVENT_DEFINITION" name="With ErrorEventDefinition" camunda:type="external" camunda:topic="foo">
+      <bpmn:extensionElements>
+        <camunda:errorEventDefinition id="ErrorEventDefinition_1gmr440" errorRef="Error_1vztv9i" expression="foo" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
   </bpmn:process>
+  <bpmn:error id="Error_1vztv9i" name="Error_3242bkf" errorCode="foo" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="ServiceTask_05myv93_di" bpmnElement="CLASS">
-        <dc:Bounds x="268" y="80" width="100" height="80" />
+        <dc:Bounds x="158" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1umdg9t_di" bpmnElement="EXPRESSION">
-        <dc:Bounds x="420" y="80" width="100" height="80" />
+        <dc:Bounds x="310" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0f5revy_di" bpmnElement="DELEGATE_EXPRESSION">
-        <dc:Bounds x="560" y="80" width="100" height="80" />
+        <dc:Bounds x="450" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_19csnox_di" bpmnElement="EXTERNAL">
-        <dc:Bounds x="700" y="80" width="100" height="80" />
+        <dc:Bounds x="590" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0bvt4w3_di" bpmnElement="CONNECTOR">
-        <dc:Bounds x="839" y="80" width="100" height="80" />
+        <dc:Bounds x="729" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BusinessRuleTask_139j051_di" bpmnElement="DMN">
-        <dc:Bounds x="975" y="209" width="100" height="80" />
+        <dc:Bounds x="865" y="209" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BusinessRuleTask_0jyqff8_di" bpmnElement="BRT_CLASS">
-        <dc:Bounds x="268" y="209" width="100" height="80" />
+        <dc:Bounds x="158" y="209" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BusinessRuleTask_1szdz9t_di" bpmnElement="BRT_EXPRESSION">
-        <dc:Bounds x="420" y="209" width="100" height="80" />
+        <dc:Bounds x="310" y="209" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BusinessRuleTask_0cqjf24_di" bpmnElement="BRT_DELEGATE_EXPRESSION">
-        <dc:Bounds x="560" y="209" width="100" height="80" />
+        <dc:Bounds x="450" y="209" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BusinessRuleTask_11woi3e_di" bpmnElement="BRT_CONNECTOR">
-        <dc:Bounds x="839" y="209" width="100" height="80" />
+        <dc:Bounds x="729" y="209" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0rsul8r_di" bpmnElement="WITH_LISTENER_AND_CONNECTOR">
-        <dc:Bounds x="268" y="329" width="100" height="80" />
+        <dc:Bounds x="158" y="329" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_178a7b4_di" bpmnElement="WITH_LISTENER">
-        <dc:Bounds x="420" y="329" width="100" height="80" />
+        <dc:Bounds x="310" y="329" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_06j6sv2_di" bpmnElement="WITH_ERROR_EVENT_DEFINITION">
+        <dc:Bounds x="450" y="329" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/camunda/ImplementationTypeSpec.js
+++ b/test/spec/provider/camunda/ImplementationTypeSpec.js
@@ -2744,6 +2744,62 @@ describe('implementation type', function() {
 
     }));
 
+
+    describe('error-related properties', function() {
+
+      var bo;
+
+      beforeEach(inject(function(elementRegistry, selection) {
+
+        // given
+        var shape = elementRegistry.get('WITH_ERROR_EVENT_DEFINITION');
+        selection.select(shape);
+        bo = getBusinessObject(shape);
+
+        // assume
+        expect(extensionElementsHelper.getExtensionElements(bo, 'camunda:ErrorEventDefinition').length).to.eql(1);
+
+        // when
+        selectImplementationType('class', container);
+
+      }));
+
+
+      it('should remove when changing from external to any other', inject(function() {
+
+        // then
+        expect(bo.extensionElements).not.to.exist;
+
+      }));
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(bo.extensionElements).to.exist;
+        expect(extensionElementsHelper.getExtensionElements(bo, 'camunda:ErrorEventDefinition').length).to.eql(1);
+
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // given
+        commandStack.undo();
+
+        // when
+        commandStack.redo();
+
+        // then
+        expect(bo.extensionElements).not.to.exist;
+
+      }));
+
+    });
+
   });
 
 });


### PR DESCRIPTION
This PR adds a condition that removes all `camunda:ErrorEventDefinition` extensions when changing the implementation type of a service task from external to any other.

Closes #441