### PR TITLE
feat(element-templates): validate templates via JSON Schema

### DIFF
--- a/lib/provider/camunda/element-templates/Validator.js
+++ b/lib/provider/camunda/element-templates/Validator.js
@@ -1,43 +1,14 @@
 'use strict';
 
 var isArray = require('min-dash').isArray,
-    isObject = require('min-dash').isObject,
-    keys = require('min-dash').keys;
+    filter = require('min-dash').filter;
 
 var semver = require('semver');
 
-var handleLegacyScopes = require('./util/handleLegacyScopes');
+var SchemaValidator = require('@bpmn-io/json-schema-validator').Validator;
 
-var DROPDOWN_TYPE = 'Dropdown';
-
-var VALID_TYPES = [ 'String', 'Text', 'Boolean', 'Hidden', DROPDOWN_TYPE ];
-
-var PROPERTY_TYPE = 'property',
-    CAMUNDA_PROPERTY_TYPE = 'camunda:property',
-    CAMUNDA_INPUT_PARAMETER_TYPE = 'camunda:inputParameter',
-    CAMUNDA_OUTPUT_PARAMETER_TYPE = 'camunda:outputParameter',
-    CAMUNDA_IN_TYPE = 'camunda:in',
-    CAMUNDA_OUT_TYPE = 'camunda:out',
-    CAMUNDA_IN_BUSINESS_KEY_TYPE = 'camunda:in:businessKey',
-    CAMUNDA_EXECUTION_LISTENER = 'camunda:executionListener',
-    CAMUNDA_FIELD = 'camunda:field',
-    CAMUNDA_CONNECTOR = 'camunda:Connector',
-    CAMUNDA_ERROR_EVENT_DEFINITION = 'camunda:errorEventDefinition';
-
-var VALID_BINDING_TYPES = [
-  PROPERTY_TYPE,
-  CAMUNDA_PROPERTY_TYPE,
-  CAMUNDA_INPUT_PARAMETER_TYPE,
-  CAMUNDA_OUTPUT_PARAMETER_TYPE,
-  CAMUNDA_IN_TYPE,
-  CAMUNDA_OUT_TYPE,
-  CAMUNDA_IN_BUSINESS_KEY_TYPE,
-  CAMUNDA_EXECUTION_LISTENER,
-  CAMUNDA_FIELD,
-  CAMUNDA_ERROR_EVENT_DEFINITION
-];
-
-var SUPPORTED_SCHEMA_VERSION = require('@camunda/element-templates-json-schema/package.json').version;
+var SUPPORTED_SCHEMA_VERSION = require('@camunda/element-templates-json-schema/package.json').version,
+    schema = require('@camunda/element-templates-json-schema/resources/schema.json');
 
 
 /**
@@ -50,6 +21,9 @@ function Validator() {
   this._validTemplates = [];
   this._errors = [];
 
+  this._schemaValidator = new SchemaValidator({
+    schema: schema
+  });
 
   /**
    * Adds the templates.
@@ -110,27 +84,18 @@ function Validator() {
     var err,
         id = template.id,
         version = template.version || '_',
-        name = template.name,
-        appliesTo = template.appliesTo,
-        properties = template.properties,
-        scopes = template.scopes,
-        schemaVersion = template.$schema && getSchemaVersion(template.$schema);
+        schemaVersion = template.$schema && getSchemaVersion(template.$schema),
+        self = this;
 
-    if (!id) {
-      return this._logError('missing template id', template);
-    }
-
-    if (!name) {
-      return this._logError('missing template name', template);
-    }
-
+    // (1) Compatibility
     if (schemaVersion &&
        (semver.compare(SUPPORTED_SCHEMA_VERSION, schemaVersion) < 0)) {
       return this._logError('unsupported element template schema version <' + schemaVersion +
-         '>. Your installation only supports up to version <' + SUPPORTED_SCHEMA_VERSION +
-         '>. Please update your installation', template);
+        '>. Your installation only supports up to version <' + SUPPORTED_SCHEMA_VERSION +
+        '>. Please update your installation', template);
     }
 
+    // (2) Versioning
     if (this._templatesById[ id ] && this._templatesById[ id ][ version ]) {
       if (version === '_') {
         return this._logError('template id <' + id + '> already used', template);
@@ -139,214 +104,20 @@ function Validator() {
       }
     }
 
-    if (!isArray(appliesTo)) {
-      err = this._logError('missing appliesTo=[]', template);
-    }
+    // (3) JSON Schema compliant
+    var validationResult = this._schemaValidator.validate(template),
+        valid = validationResult.valid,
+        errors = validationResult.errors;
 
-    if (!isArray(properties)) {
-      err = this._logError('missing properties=[]', template);
-    } else {
-      if (!this._validateProperties(template, properties)) {
-        err = new Error('invalid properties');
-      }
-    }
+    if (!valid) {
+      err = new Error('invalid template');
 
-    if (scopes) {
-      err = this._validateScopes(template, scopes);
-    }
-
-    return err;
-  };
-
-  /**
-   * Validate given scopes and return error (if any).
-   *
-   * @param {TemplateDescriptor} template
-   * @param {ScopesDescriptor|Array<TemplateDescriptor>} scopes
-   *
-   * @return {Error} validation error, if any
-   */
-  this._validateScopes = function(template, scopes) {
-
-    var err,
-        scopeType;
-
-    var self = this;
-
-    // handle legacy scope descriptor
-    if (!isArray(scopes)) {
-
-      if (!isObject(scopes)) {
-        return this._logError('invalid scopes, should be scopes={} or scopes=[]', template);
-      }
-
-      // only support <camunda:Connector> for legacy scopes
-      keys(scopes).forEach(function(scope) {
-        if (scope !== CAMUNDA_CONNECTOR) {
-          err = self._logError('invalid scope <' + scope + '>, object descriptor is only supported for <' + CAMUNDA_CONNECTOR + '>', template);
-        }
+      filteredSchemaErrors(errors).forEach(function(error) {
+        self._logError(error.message, template);
       });
     }
 
-    handleLegacyScopes(scopes).forEach(function(scope) {
-      scopeType = scope.type;
-
-      if (!isObject(scope) || isArray(scope)) {
-        err = self._logError('invalid scope, should be scope={}', template);
-      }
-
-      if (!scopeType) {
-        err = self._logError('invalid scope, missing type', template);
-      }
-
-      if (!isArray(scope.properties)) {
-        err = self._logError(
-          'missing properties=[] in scope <' + scopeType + '>', template
-        );
-      } else {
-        if (!self._validateProperties(template, scope.properties)) {
-          err = new Error('invalid properties in scope <' + scopeType + '>');
-        }
-      }
-    });
-
     return err;
-  };
-
-  /**
-   * Validate properties and return false if any is invalid.
-   *
-   * @param {TemplateDescriptor} template
-   * @param {Array<PropertyDescriptor>} properties
-   *
-   * @return {Boolean} true if all properties are valid
-   */
-  this._validateProperties = function(template, properties) {
-    var validProperties = properties.filter(function(ele) { return this._validateProperty(template, ele); }, this);
-
-    return properties.length === validProperties.length;
-  };
-
-  /**
-   * Validate property and return false, if there was
-   * a validation error.
-   *
-   * @param {TemplateDescriptor} template
-   * @param {PropertyDescriptor} property
-   *
-   * @return {Boolean} true if property is valid
-   */
-  this._validateProperty = function(template, property) {
-
-    var type = property.type,
-        binding = property.binding;
-
-    var err;
-
-    var bindingType = binding.type;
-
-    if (type && VALID_TYPES.indexOf(type) === -1) {
-      err = this._logError(
-        'invalid property type <' + type + '>; ' +
-        'must be any of { ' + VALID_TYPES.join(', ') + ' }',
-        template
-      );
-    }
-
-    if (type === DROPDOWN_TYPE && bindingType !== CAMUNDA_EXECUTION_LISTENER) {
-      if (!isArray(property.choices)) {
-        err = this._logError(
-          'must provide choices=[] with ' + DROPDOWN_TYPE + ' type',
-          template
-        );
-      } else
-
-      if (!property.choices.every(isDropdownChoiceValid)) {
-        err = this._logError(
-          '{ name, value } must be specified for ' +
-          DROPDOWN_TYPE + ' choices',
-          template
-        );
-      }
-    }
-
-    if (!binding) {
-      return this._logError('property missing binding', template);
-    }
-
-    if (VALID_BINDING_TYPES.indexOf(bindingType) === -1) {
-      err = this._logError(
-        'invalid property.binding type <' + bindingType + '>; ' +
-        'must be any of { ' + VALID_BINDING_TYPES.join(', ') + ' }',
-        template
-      );
-    }
-
-    if (bindingType === PROPERTY_TYPE ||
-        bindingType === CAMUNDA_PROPERTY_TYPE ||
-        bindingType === CAMUNDA_INPUT_PARAMETER_TYPE ||
-        bindingType === CAMUNDA_FIELD) {
-
-      if (!binding.name) {
-        err = this._logError(
-          'property.binding <' + bindingType + '> requires name',
-          template
-        );
-      }
-    }
-
-    if (bindingType === CAMUNDA_OUTPUT_PARAMETER_TYPE) {
-      if (!binding.source) {
-        err = this._logError(
-          'property.binding <' + bindingType + '> requires source',
-          template
-        );
-      }
-    }
-
-    if (bindingType === CAMUNDA_IN_TYPE) {
-
-      if (!binding.variables && !binding.target) {
-        err = this._logError(
-          'property.binding <' + bindingType + '> requires ' +
-          'variables or target',
-          template
-        );
-      }
-    }
-
-    if (bindingType === CAMUNDA_OUT_TYPE) {
-
-      if (!binding.variables && !binding.source && !binding.sourceExpression) {
-        err = this._logError(
-          'property.binding <' + bindingType + '> requires ' +
-          'variables, sourceExpression or source',
-          template
-        );
-      }
-    }
-
-    if (bindingType === CAMUNDA_EXECUTION_LISTENER) {
-
-      if (type && type !== 'Hidden') {
-        err = this._logError(
-          'invalid property type <' + type + '> for ' + CAMUNDA_EXECUTION_LISTENER + '; ' +
-          'must be <Hidden>',
-          template
-        );
-      }
-    }
-
-    if (bindingType === CAMUNDA_ERROR_EVENT_DEFINITION) {
-      if (!binding.errorRef) {
-        err = this._logError(
-          'property.binding <' + bindingType + '> requires errorRef',
-          template
-        );
-      }
-    }
-
-    return !err;
   };
 
   /**
@@ -387,10 +158,6 @@ module.exports = Validator;
 
 // helpers ///////////////////////////////////
 
-function isDropdownChoiceValid(c) {
-  return 'name' in c && 'value' in c;
-}
-
 /**
  * Extract schema version from schema URI
  *
@@ -404,4 +171,36 @@ function getSchemaVersion(schemaUri) {
   var match = schemaUri.match(re);
 
   return match === null ? undefined : match[0];
+}
+
+/**
+ * Extract only relevant errors of the validation result.
+ *
+ * The JSON Schema we use under the hood produces more errors than we need for a
+ * detected schema violation (for example, unmatched sub-schemas, if-then-rules,
+ * `oneOf`-definitions ...).
+ *
+ * We call these errors "relevant" that have a custom error message defined by us OR
+ * are basic data type errors.
+ *
+ * @param {Array} schemaErrors
+ *
+ * @return {Array}
+ */
+function filteredSchemaErrors(schemaErrors) {
+  return filter(schemaErrors, function(err) {
+
+    // (1) regular errors are customized from the schema
+    if (err.keyword === 'errorMessage') {
+      return true;
+    }
+
+    // (2) data type errors are relevant, except for
+    // (scope) root level data type errors due to basic schema errors
+    if (err.keyword === 'type' && err.dataPath && err.dataPath !== '/scopes') {
+      return true;
+    }
+
+    return false;
+  });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -164,10 +164,27 @@
         "min-dash": "^3.5.2"
       }
     },
+    "@bpmn-io/json-schema-validator": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/json-schema-validator/-/json-schema-validator-0.2.1.tgz",
+      "integrity": "sha512-Ib9+c3achzfdUIhvxlhhpM1MpmxqGaYge3gAg+CLD/3SwQm2duvIJk3Cj4i4aXSBzCxNLKsXVP2W5RTeOg7tuQ==",
+      "requires": {
+        "ajv": "^6.12.6",
+        "ajv-errors": "^1.0.1",
+        "min-dash": "^3.7.0"
+      },
+      "dependencies": {
+        "min-dash": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.7.0.tgz",
+          "integrity": "sha512-IlEbbItQU7tipoa4aAWocSuhR76jKqQG/N2+/Mh7d+BLZ3UmQl57ppKhziPY/TXBGps9+M8BC1c7AzqcYLp5BA=="
+        }
+      }
+    },
     "@camunda/element-templates-json-schema": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.3.0.tgz",
-      "integrity": "sha512-m6n2XTZHjVEPd74RvHHya8aXSydmSFXBb5FyXomHbEIVryxNlgIs5UTm81HUbRAbeDHmSTv+6+6gkk7qqZK48g=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.3.1.tgz",
+      "integrity": "sha512-tU1DGIInadVbO1YLd+k4S35lLQTu7fgSVyjwEGUt9wdmPk9xca4Pup1zVd9S0gLdXAddnox37jsL6dJhKlNUVQ=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.0",
@@ -486,13 +503,17 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "ajv-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
     },
     "ajv-keywords": {
       "version": "3.5.2",
@@ -1750,14 +1771,12 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2438,8 +2457,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -3594,8 +3612,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "puppeteer": {
       "version": "8.0.0",
@@ -4542,7 +4559,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
   },
   "dependencies": {
     "@bpmn-io/extract-process-variables": "^0.4.3",
-    "@camunda/element-templates-json-schema": "0.3.0",
+    "@bpmn-io/json-schema-validator": "^0.2.1",
+    "@camunda/element-templates-json-schema": "0.3.1",
     "ids": "^1.0.0",
     "inherits": "^2.0.1",
     "lodash": "^4.17.20",

--- a/test/spec/provider/camunda/element-templates/ElementTemplatesLoaderSpec.js
+++ b/test/spec/provider/camunda/element-templates/ElementTemplatesLoaderSpec.js
@@ -179,7 +179,7 @@ describe('element-templates - ElementTemplatesLoader', function() {
         // given
         PROVIDER = function(done) {
           done(null, [
-            { name: 'Foo', id: 'foo', appliesTo: [ 'foo:Bar' ], properties: [ ] },
+            { name: 'Foo', id: 'foo', appliesTo: [ 'bpmn:Task' ], properties: [ ] },
             { name: 'Foo', id: 'foo' },
             { name: 'Foo', id: 'foo' }
           ]);

--- a/test/spec/provider/camunda/element-templates/ValidatorSpec.js
+++ b/test/spec/provider/camunda/element-templates/ValidatorSpec.js
@@ -329,7 +329,7 @@ describe('element-templates - Validator', function() {
 
       // then
       expect(errors(templates)).to.eql([
-        'template(id: <bar>, name: <Task>): must provide choices=[] with Dropdown type'
+        'template(id: <bar>, name: <Task>): must provide choices=[] with "Dropdown" type'
       ]);
 
       expect(valid(templates)).to.be.empty;
@@ -348,7 +348,7 @@ describe('element-templates - Validator', function() {
 
       // then
       expect(errors(templates)).to.eql([
-        'template(id: <bar>, name: <Task>): { name, value } must be specified for Dropdown choices'
+        'template(id: <bar>, name: <Task>): { name, value } must be specified for "Dropdown" choices'
       ]);
 
       expect(valid(templates)).to.be.empty;
@@ -367,10 +367,7 @@ describe('element-templates - Validator', function() {
 
       // then
       expect(errors(templates)).to.eql([
-        'template(id: <foo>, name: <Invalid>): invalid property type <InvalidType>; must be any of { ' +
-        'String, Text, Boolean, Hidden, Dropdown ' +
-      '}',
-        'template(id: <foo>, name: <Invalid>): invalid property.binding type <alsoInvalid>; must be any of { ' +
+        'template(id: <foo>, name: <Invalid>): invalid property.binding type "alsoInvalid"; must be any of { ' +
         'property, camunda:property, camunda:inputParameter, ' +
         'camunda:outputParameter, camunda:in, camunda:out, ' +
         'camunda:in:businessKey, camunda:executionListener, ' +
@@ -394,13 +391,13 @@ describe('element-templates - Validator', function() {
 
       // then
       expect(errors(templates)).to.eql([
-        'template(id: <foo>, name: <Invalid>): property.binding <property> requires name',
-        'template(id: <foo>, name: <Invalid>): property.binding <camunda:property> requires name',
-        'template(id: <foo>, name: <Invalid>): property.binding <camunda:inputParameter> requires name',
-        'template(id: <foo>, name: <Invalid>): property.binding <camunda:outputParameter> requires source',
-        'template(id: <foo>, name: <Invalid>): property.binding <camunda:in> requires variables or target',
-        'template(id: <foo>, name: <Invalid>): property.binding <camunda:out> requires variables, sourceExpression or source',
-        'template(id: <foo>, name: <Invalid>): property.binding <camunda:errorEventDefinition> requires errorRef'
+        'template(id: <foo>, name: <Invalid>): property.binding "property" requires name',
+        'template(id: <foo>, name: <Invalid>): property.binding "camunda:property" requires name',
+        'template(id: <foo>, name: <Invalid>): property.binding "camunda:inputParameter" requires name',
+        'template(id: <foo>, name: <Invalid>): property.binding "camunda:outputParameter" requires source',
+        'template(id: <foo>, name: <Invalid>): property.binding "camunda:in" requires variables or target',
+        'template(id: <foo>, name: <Invalid>): property.binding "camunda:out" requires variables, sourceExpression or source',
+        'template(id: <foo>, name: <Invalid>): property.binding "camunda:errorEventDefinition" requires errorRef'
       ]);
 
       expect(valid(templates)).to.be.empty;
@@ -453,10 +450,11 @@ describe('element-templates - Validator', function() {
 
       // then
       expect(errors(templates)).to.eql([
-        'template(id: <my.execution.listener.task>, name: <Execution Listener>): invalid property type <String> for camunda:executionListener; must be <Hidden>',
-        'template(id: <my.execution.listener.task>, name: <Execution Listener>): invalid property type <Text> for camunda:executionListener; must be <Hidden>',
-        'template(id: <my.execution.listener.task>, name: <Execution Listener>): invalid property type <Boolean> for camunda:executionListener; must be <Hidden>',
-        'template(id: <my.execution.listener.task>, name: <Execution Listener>): invalid property type <Dropdown> for camunda:executionListener; must be <Hidden>'
+        'template(id: <my.execution.listener.task>, name: <Execution Listener>): invalid property type "String" for binding type "camunda:executionListener"; must be "Hidden"',
+        'template(id: <my.execution.listener.task>, name: <Execution Listener>): invalid property type "Text" for binding type "camunda:executionListener"; must be "Hidden"',
+        'template(id: <my.execution.listener.task>, name: <Execution Listener>): invalid property type "Boolean" for binding type "camunda:executionListener"; must be "Hidden"',
+        'template(id: <my.execution.listener.task>, name: <Execution Listener>): must provide choices=[] with "Dropdown" type',
+        'template(id: <my.execution.listener.task>, name: <Execution Listener>): invalid property type "Dropdown" for binding type "camunda:executionListener"; must be "Hidden"',
       ]);
 
       expect(valid(templates)).to.have.length(0);
@@ -510,7 +508,7 @@ describe('element-templates - Validator', function() {
         templates.addAll(templateDescriptors);
 
         // then
-        expect(errors(templates)).to.contain('template(id: <foo>, name: <Invalid>): invalid scope <properties>, object descriptor is only supported for <camunda:Connector>');
+        expect(errors(templates)).to.contain('template(id: <foo>, name: <Invalid>): invalid scope "properties", object descriptor is only supported for "camunda:Connector"');
 
         expect(valid(templates)).to.be.empty;
       });
@@ -528,7 +526,7 @@ describe('element-templates - Validator', function() {
 
         // then
         expect(errors(templates)).to.contain(
-          'template(id: <foo>, name: <Invalid>): missing properties=[] in scope <camunda:Connector>'
+          'template(id: <foo>, name: <Invalid>): invalid scope "camunda:Connector", missing properties=[]'
         );
 
         expect(valid(templates)).to.be.empty;
@@ -566,10 +564,7 @@ describe('element-templates - Validator', function() {
 
         // then
         expect(errors(templates)).to.eql([
-          'template(id: <foo>, name: <Invalid>): invalid property type <InvalidType>; must be any of { ' +
-          'String, Text, Boolean, Hidden, Dropdown ' +
-        '}',
-          'template(id: <foo>, name: <Invalid>): invalid property.binding type <alsoInvalid>; must be any of { ' +
+          'template(id: <foo>, name: <Invalid>): invalid property.binding type "alsoInvalid"; must be any of { ' +
           'property, camunda:property, camunda:inputParameter, ' +
           'camunda:outputParameter, camunda:in, camunda:out, ' +
           'camunda:in:businessKey, camunda:executionListener, ' +

--- a/test/spec/provider/camunda/element-templates/parts/CustomProps.json
+++ b/test/spec/provider/camunda/element-templates/parts/CustomProps.json
@@ -591,7 +591,7 @@
       },
       {
         "value": "println end",
-        "type": "String",
+        "type": "Hidden",
         "binding": {
           "type": "camunda:executionListener",
           "event": "end",

--- a/test/spec/provider/camunda/element-templates/util/validateSpec.js
+++ b/test/spec/provider/camunda/element-templates/util/validateSpec.js
@@ -8,13 +8,13 @@ describe('element-templates/util - validate', function() {
   it('should return validation errors only', function() {
 
     // given
-    var templateDescriptors = require('../fixtures/error-property-invalid');
+    var templateDescriptors = require('../fixtures/error-bindings-invalid');
 
     // when
     var errors = validate(templateDescriptors);
 
     // then
-    expect(errors).to.have.length(2);
+    expect(errors).to.have.length(7);
 
     expect(errors[0] instanceof Error).to.be.true;
   });


### PR DESCRIPTION
This (partly) replaces the existing `PropertiesPanel#Validator` functionality with our `element-templates-json-schema`. This means that we now
* Validate `property.type` <-> `property.binding.type` combinations (Note that this needs an update of [our documentation](https://github.com/camunda/camunda-modeler/tree/develop/docs/element-templates#bindings), since beforehand, we did not strictly enforce those combinations, but informed possible errors)
* Keep the validation of versioning and schema compatibility inside the original Validator
* Move all other validation to the Schema itself

I decided to keep the existing test cases to have another verification, although most of them only test the existing JSON Schema.

<img width="1253" alt="Bildschirmfoto 2021-03-25 um 13 09 24" src="https://user-images.githubusercontent.com/9433996/112470782-5c085880-8d6b-11eb-9e42-e4d96df9af34.png">

----

Requires https://github.com/camunda/element-templates-json-schema/pull/27 to be merged + released + integrated
Closes #386
Related to https://github.com/camunda/camunda-modeler/issues/1939
Related to https://github.com/camunda/camunda-modeler/issues/2159 
