### PR TITLE
fix(element-templates): use pre-compiled schema validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FEAT`: support templating of `camunda:ErrorEventDefinition` and global `bpmn:Error` elements ([#424](https://github.com/bpmn-io/bpmn-js-properties-panel/issues/424), [#425](https://github.com/bpmn-io/bpmn-js-properties-panel/issues/425), [#441](https://github.com/bpmn-io/bpmn-js-properties-panel/issues/441))
 * `FEAT`: validate element templates via JSON Schema ([#455](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/455))
 * `FIX`: ensure necessary part of variable title is always displayed ([`452f4488`](https://github.com/bpmn-io/bpmn-js-properties-panel/commit/452f4488d2a65db858f6e67f4684e8c413af0ad5))
+* `FIX`: use pre-compiled element templates validator ([#462](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/462))
 * `CHORE`: make extension elements helper always return an array ([#447](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/447))
 
 ### Breaking Changes

--- a/lib/provider/camunda/element-templates/Validator.js
+++ b/lib/provider/camunda/element-templates/Validator.js
@@ -5,10 +5,10 @@ var isArray = require('min-dash').isArray,
 
 var semver = require('semver');
 
-var SchemaValidator = require('@bpmn-io/json-schema-validator').Validator;
+var validateAgainstSchema = require('@bpmn-io/element-templates-validator').validate,
+    getTemplateSchemaVersion = require('@bpmn-io/element-templates-validator').getSchemaVersion;
 
-var SUPPORTED_SCHEMA_VERSION = require('@camunda/element-templates-json-schema/package.json').version,
-    schema = require('@camunda/element-templates-json-schema/resources/schema.json');
+var SUPPORTED_SCHEMA_VERSION = getTemplateSchemaVersion();
 
 
 /**
@@ -20,10 +20,6 @@ function Validator() {
 
   this._validTemplates = [];
   this._errors = [];
-
-  this._schemaValidator = new SchemaValidator({
-    schema: schema
-  });
 
   /**
    * Adds the templates.
@@ -105,7 +101,7 @@ function Validator() {
     }
 
     // (3) JSON Schema compliant
-    var validationResult = this._schemaValidator.validate(template),
+    var validationResult = validateAgainstSchema(template),
         valid = validationResult.valid,
         errors = validationResult.errors;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -890,9 +890,9 @@
       "dev": true
     },
     "camunda-bpmn-moddle": {
-      "version": "5.1.0-0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-5.1.0-0.tgz",
-      "integrity": "sha512-iq1WGjucEerwyVtuh8Pr+LvT2ix1cjumHVlj8AHs66KU/TQq8fSRPtPa41gbQkbh6TgXQEo3+e1d/Wc/mcLXyQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-5.1.0.tgz",
+      "integrity": "sha512-JiEjTX7M8UcWmECK045E//YgkuHjvRJFur+o4t8fFG+BDXXC5dT5BYpuYMAjg0ocaD5n/b8KgNCdSjVZqEa8zQ==",
       "dev": true,
       "requires": {
         "min-dash": "^3.5.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,21 +156,13 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@bpmn-io/extract-process-variables": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.4.3.tgz",
-      "integrity": "sha512-CeCVAsrJS8/UXSUIsqjfZ3PQlqtxgomHtgZATXmTmoSWPGSHTyTLL9FvUbWHzOYomWfFbX2YBzHYTV1wYqM4uA==",
+    "@bpmn-io/element-templates-validator": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.1.0.tgz",
+      "integrity": "sha512-GK2IxWa//Zkck6wTwC6kmjNpL2W5zXLQdtPKdpe8UbAFtGxiltzUgIRiLPnvB0PKnKtyh1nq3on3GHxU9QlC0g==",
       "requires": {
-        "min-dash": "^3.5.2"
-      }
-    },
-    "@bpmn-io/json-schema-validator": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/json-schema-validator/-/json-schema-validator-0.2.1.tgz",
-      "integrity": "sha512-Ib9+c3achzfdUIhvxlhhpM1MpmxqGaYge3gAg+CLD/3SwQm2duvIJk3Cj4i4aXSBzCxNLKsXVP2W5RTeOg7tuQ==",
-      "requires": {
-        "ajv": "^6.12.6",
-        "ajv-errors": "^1.0.1",
+        "@camunda/element-templates-json-schema": "^0.3.1",
+        "json-source-map": "^0.6.1",
         "min-dash": "^3.7.0"
       },
       "dependencies": {
@@ -179,6 +171,14 @@
           "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.7.0.tgz",
           "integrity": "sha512-IlEbbItQU7tipoa4aAWocSuhR76jKqQG/N2+/Mh7d+BLZ3UmQl57ppKhziPY/TXBGps9+M8BC1c7AzqcYLp5BA=="
         }
+      }
+    },
+    "@bpmn-io/extract-process-variables": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.4.3.tgz",
+      "integrity": "sha512-CeCVAsrJS8/UXSUIsqjfZ3PQlqtxgomHtgZATXmTmoSWPGSHTyTLL9FvUbWHzOYomWfFbX2YBzHYTV1wYqM4uA==",
+      "requires": {
+        "min-dash": "^3.5.2"
       }
     },
     "@camunda/element-templates-json-schema": {
@@ -503,17 +503,13 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
-    },
-    "ajv-errors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
     },
     "ajv-keywords": {
       "version": "3.5.2",
@@ -1771,12 +1767,14 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2457,7 +2455,13 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
+      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -3612,7 +3616,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "puppeteer": {
       "version": "8.0.0",
@@ -4559,6 +4564,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -53,9 +53,8 @@
     "webpack": "^5.24.2"
   },
   "dependencies": {
+    "@bpmn-io/element-templates-validator": "^0.1.0",
     "@bpmn-io/extract-process-variables": "^0.4.3",
-    "@bpmn-io/json-schema-validator": "^0.2.1",
-    "@camunda/element-templates-json-schema": "0.3.1",
     "ids": "^1.0.0",
     "inherits": "^2.0.1",
     "lodash": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "bpmn-js": "^8.2.2",
     "bpmn-moddle": "^7.0.4",
-    "camunda-bpmn-moddle": "^5.1.0-0",
+    "camunda-bpmn-moddle": "^5.1.0",
     "chai": "^4.1.2",
     "diagram-js": "^7.2.0",
     "eslint": "^7.12.1",

--- a/test/spec/provider/camunda/element-templates/ValidatorSpec.js
+++ b/test/spec/provider/camunda/element-templates/ValidatorSpec.js
@@ -2,7 +2,9 @@
 
 var Validator = require('lib/provider/camunda/element-templates/Validator');
 
-var ElementTemplateSchemaVersion = require('@camunda/element-templates-json-schema/package.json').version;
+var getTemplateSchemaVersion = require('@bpmn-io/element-templates-validator').getSchemaVersion;
+
+var ElementTemplateSchemaVersion = getTemplateSchemaVersion();
 
 
 describe('element-templates - Validator', function() {


### PR DESCRIPTION
This uses the pre-compiled validator + schema: https://github.com/bpmn-io/element-templates-validator

* no more compiling on runtime, prevents CSP errors in the Modeler distro
* reduced bundle size
* the validator now defines with schema version we're using

Related to camunda/camunda-modeler#2181
