### PR TITLE
feat: update existing documentation entries

### DIFF
--- a/lib/provider/bpmn/parts/DocumentationProps.js
+++ b/lib/provider/bpmn/parts/DocumentationProps.js
@@ -7,13 +7,24 @@ var ModelUtil = require('bpmn-js/lib/util/ModelUtil'),
     is = ModelUtil.is,
     getBusinessObject = ModelUtil.getBusinessObject;
 
+var DOCUMENTATION_TEXT_FORMAT = 'text/plain';
+
 
 module.exports = function(group, element, bpmnFactory, translate) {
 
+  var findDocumentation = function(docs) {
+    return docs.find(function(d) {
+      return (d.textFormat || DOCUMENTATION_TEXT_FORMAT) === DOCUMENTATION_TEXT_FORMAT;
+    });
+  };
+
   var getValue = function(businessObject) {
     return function(element) {
-      var documentations = businessObject && businessObject.get('documentation'),
-          text = (documentations && documentations.length > 0) ? documentations[0].text : '';
+      var documentation = findDocumentation(
+        businessObject && businessObject.get('documentation')
+      );
+
+      var text = documentation && documentation.text || '';
 
       return { documentation: text };
     };
@@ -21,15 +32,33 @@ module.exports = function(group, element, bpmnFactory, translate) {
 
   var setValue = function(businessObject) {
     return function(element, values) {
-      var newObjectList = [];
+      var text = values.documentation;
 
-      if (typeof values.documentation !== 'undefined' && values.documentation !== '') {
-        newObjectList.push(bpmnFactory.create('bpmn:Documentation', {
-          text: values.documentation
-        }));
+      var documentation = findDocumentation(
+        businessObject && businessObject.get('documentation')
+      );
+
+      // update or removing existing documentation
+      if (documentation) {
+
+        if (text) {
+          return cmdHelper.updateBusinessObject(element, documentation, { text: values.documentation });
+        } else {
+          return cmdHelper.removeElementsFromList(element, businessObject, 'documentation', null, [ documentation ]);
+        }
       }
 
-      return cmdHelper.setList(element, businessObject, 'documentation', newObjectList);
+      if (text) {
+
+        // create new documentation entry
+        return cmdHelper.addElementsTolist(element, businessObject, 'documentation', [
+          bpmnFactory.create('bpmn:Documentation', {
+            text: values.documentation
+          })
+        ]);
+      }
+
+      // no text and nothing removed -> we are good
     };
   };
 

--- a/test/spec/provider/bpmn/Documentation.bpmn
+++ b/test/spec/provider/bpmn/Documentation.bpmn
@@ -1,51 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_3ENCQCCrEeWkp5kiupH8Fw" exporter="camunda modeler" exporterVersion="2.7.0" targetNamespace="http://activiti.org/bpmn">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="_3ENCQCCrEeWkp5kiupH8Fw" targetNamespace="http://camunda.org/schema/1.0/bpmn" exporter="Camunda Modeler" exporterVersion="4.5.0-rc.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
   <bpmn2:process id="Process_1" isExecutable="false">
-
-    <bpmn2:documentation><![CDATA[processlevel
-]]></bpmn2:documentation>
-
+    <bpmn2:documentation>processlevel</bpmn2:documentation>
     <bpmn2:startEvent id="StartEvent_1">
       <bpmn2:documentation>startevent</bpmn2:documentation>
-      <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
     </bpmn2:startEvent>
-
     <bpmn2:serviceTask id="ServiceTask_1">
       <bpmn2:documentation>Task</bpmn2:documentation>
-      <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
     </bpmn2:serviceTask>
-
     <bpmn2:complexGateway id="ComplexGateway_1">
       <bpmn2:documentation>gateway</bpmn2:documentation>
     </bpmn2:complexGateway>
-
     <bpmn2:endEvent id="EndEvent_1">
       <bpmn2:documentation>endevent</bpmn2:documentation>
     </bpmn2:endEvent>
-
-    <bpmn2:boundaryEvent id="BoundaryEvent_1" name="" attachedToRef="ServiceTask_1">
-    </bpmn2:boundaryEvent>
-
+    <bpmn2:boundaryEvent id="BoundaryEvent_1" name="" attachedToRef="ServiceTask_1" />
+    <bpmn2:task id="MULTIPLE_DOCS" name="MULTIPLE&#10;DOCS">
+      <bpmn2:documentation textFormat="application/x-other">VENDOR DOCS</bpmn2:documentation>
+      <bpmn2:documentation>MULTIPLE_DOCS</bpmn2:documentation>
+    </bpmn2:task>
+    <bpmn2:task id="TYPED_DOCS" name="TYPED DOCS">
+      <bpmn2:documentation textFormat="application/x-other">VENDOR DOCS</bpmn2:documentation>
+    </bpmn2:task>
+    <bpmn2:task id="TEXT_PLAIN" name="TEXT_PLAIN">
+      <bpmn2:documentation textFormat="application/x-other">VENDOR DOCS</bpmn2:documentation>
+      <bpmn2:documentation textFormat="text/plain">TEXT_PLAIN</bpmn2:documentation>
+    </bpmn2:task>
   </bpmn2:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_3" bpmnElement="StartEvent_1">
-        <dc:Bounds height="36.0" width="36.0" x="41.0" y="48.0"/>
+        <dc:Bounds x="161" y="108" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="0.0" width="0.0" x="59.0" y="89.0"/>
+          <dc:Bounds x="59" y="89" width="0" height="0" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_ServiceTask_4" bpmnElement="ServiceTask_1">
-        <dc:Bounds height="80.0" width="100.0" x="127.0" y="26.0"/>
+        <dc:Bounds x="247" y="86" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_ComplexGateway_2" bpmnElement="ComplexGateway_1">
-        <dc:Bounds height="50.0" width="50.0" x="277.0" y="41.0"/>
+        <dc:Bounds x="397" y="101" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_EndEvent_2" bpmnElement="EndEvent_1">
-        <dc:Bounds height="36.0" width="36.0" x="377.0" y="48.0"/>
+        <dc:Bounds x="497" y="108" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="MULTIPLE_DOCS_di" bpmnElement="MULTIPLE_DOCS">
+        <dc:Bounds x="247" y="230" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TYPED_DOCS_di" bpmnElement="TYPED_DOCS">
+        <dc:Bounds x="247" y="350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TEXT_PLAIN_di" bpmnElement="TEXT_PLAIN">
+        <dc:Bounds x="247" y="470" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_BoundaryEvent_3" bpmnElement="BoundaryEvent_1">
-        <dc:Bounds height="36.0" width="36.0" x="209.0" y="88.0"/>
+        <dc:Bounds x="329" y="148" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/bpmn/DocumentationSpec.js
+++ b/test/spec/provider/bpmn/DocumentationSpec.js
@@ -14,6 +14,7 @@ var propertiesPanelModule = require('lib'),
     propertiesProviderModule = require('lib/provider/bpmn'),
     getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
 
+
 describe('documentation-properties', function() {
 
   var diagramXML = require('./Documentation.bpmn');
@@ -50,54 +51,163 @@ describe('documentation-properties', function() {
   }));
 
 
-  it('should fetch the documentation for an element', inject(function(propertiesPanel, selection, elementRegistry) {
+  describe('should fetch documentation', function() {
 
-    var shape = elementRegistry.get('ServiceTask_1');
-    selection.select(shape);
-    var textField = domQuery('div[name=documentation]', propertiesPanel._container);
+    it('basic', inject(function(propertiesPanel, selection, elementRegistry) {
 
-    expect(textField.textContent).to.equal('Task');
-  }));
+      var shape = elementRegistry.get('ServiceTask_1');
+      selection.select(shape);
+      var textField = domQuery('div[name=documentation]', propertiesPanel._container);
 
-
-  it('should set the documentation for an element', inject(function(propertiesPanel, selection, elementRegistry) {
-
-    var shape = elementRegistry.get('BoundaryEvent_1');
-    selection.select(shape);
-    var textField = domQuery('div[name=documentation]', propertiesPanel._container),
-        businessObject = getBusinessObject(shape);
-
-    // given
-    expect(textField.textContent).to.be.empty;
-
-    // when
-    TestHelper.triggerValue(textField, 'foo', 'change');
-
-    var documentation = businessObject.get('documentation');
-
-    // then
-    expect(textField.textContent).to.equal('foo');
-    expect(documentation.length).to.be.at.least(0);
-    expect(documentation[0].text).to.equal('foo');
-    expect(documentation[0].$instanceOf('bpmn:Documentation')).to.be.true;
-  }));
+      expect(textField.textContent).to.equal('Task');
+    }));
 
 
-  it('should remove the documentation for an element', inject(function(propertiesPanel, selection, elementRegistry) {
+    it('documentation list', inject(function(propertiesPanel, selection, elementRegistry) {
 
-    var shape = elementRegistry.get('ServiceTask_1');
-    selection.select(shape);
-    var textField = domQuery('div[name=documentation]', propertiesPanel._container);
-    var businessObject = getBusinessObject(shape);
+      var shape = elementRegistry.get('MULTIPLE_DOCS');
+      selection.select(shape);
+      var textField = domQuery('div[name=documentation]', propertiesPanel._container);
 
-    // given
-    expect(textField.textContent).to.equal('Task');
+      expect(textField.textContent).to.equal('MULTIPLE_DOCS');
+    }));
 
-    // when
-    TestHelper.triggerValue(textField, '', 'change');
 
-    // then
-    expect(textField.textContent).to.equal('');
-    expect(businessObject.get('documentation').length).to.equal(0);
-  }));
+    it('ignoring typed documentation', inject(function(propertiesPanel, selection, elementRegistry) {
+
+      var shape = elementRegistry.get('TYPED_DOCS');
+      selection.select(shape);
+      var textField = domQuery('div[name=documentation]', propertiesPanel._container);
+
+      expect(textField.textContent).to.equal('');
+    }));
+
+
+    it('picking up textFormat=text/plain', inject(function(propertiesPanel, selection, elementRegistry) {
+
+      var shape = elementRegistry.get('TEXT_PLAIN');
+      selection.select(shape);
+      var textField = domQuery('div[name=documentation]', propertiesPanel._container);
+
+      expect(textField.textContent).to.equal('TEXT_PLAIN');
+    }));
+
+  });
+
+
+  describe('should set the documentation', function() {
+
+    it('basic', inject(function(propertiesPanel, selection, elementRegistry) {
+
+      var shape = elementRegistry.get('BoundaryEvent_1');
+      selection.select(shape);
+      var textField = domQuery('div[name=documentation]', propertiesPanel._container),
+          businessObject = getBusinessObject(shape);
+
+      // given
+      expect(textField.textContent).to.be.empty;
+
+      // when
+      TestHelper.triggerValue(textField, 'foo', 'change');
+
+      var documentation = businessObject.get('documentation');
+
+      // then
+      expect(textField.textContent).to.equal('foo');
+      expect(documentation.length).to.be.at.least(0);
+      expect(documentation[0].text).to.equal('foo');
+      expect(documentation[0].$instanceOf('bpmn:Documentation')).to.be.true;
+    }));
+
+
+    it('documentation list', inject(function(propertiesPanel, selection, elementRegistry) {
+
+      var shape = elementRegistry.get('MULTIPLE_DOCS');
+      selection.select(shape);
+      var textField = domQuery('div[name=documentation]', propertiesPanel._container),
+          businessObject = getBusinessObject(shape);
+
+      // given
+      expect(textField.textContent).to.eql('MULTIPLE_DOCS');
+
+      // when
+      TestHelper.triggerValue(textField, 'foo', 'change');
+
+      var documentation = businessObject.get('documentation');
+
+      // then
+      expect(textField.textContent).to.equal('foo');
+      expect(documentation.length).to.be.at.least(0);
+      expect(documentation[1].text).to.equal('foo');
+      expect(documentation[1].$instanceOf('bpmn:Documentation')).to.be.true;
+    }));
+
+
+    it('ignoring typed documentation', inject(function(propertiesPanel, selection, elementRegistry) {
+
+      var shape = elementRegistry.get('TYPED_DOCS');
+      selection.select(shape);
+      var textField = domQuery('div[name=documentation]', propertiesPanel._container),
+          businessObject = getBusinessObject(shape);
+
+      // given
+      expect(textField.textContent).to.be.empty;
+
+      // when
+      TestHelper.triggerValue(textField, 'foo', 'change');
+
+      var documentation = businessObject.get('documentation');
+
+      // then
+      expect(textField.textContent).to.equal('foo');
+      expect(documentation.length).to.be.at.least(0);
+      expect(documentation[1].text).to.equal('foo');
+      expect(documentation[1].$instanceOf('bpmn:Documentation')).to.be.true;
+    }));
+
+  });
+
+
+  describe('should remove the documentation', function() {
+
+    it('basic', inject(function(propertiesPanel, selection, elementRegistry) {
+
+      var shape = elementRegistry.get('ServiceTask_1');
+      selection.select(shape);
+      var textField = domQuery('div[name=documentation]', propertiesPanel._container);
+      var businessObject = getBusinessObject(shape);
+
+      // given
+      expect(textField.textContent).to.equal('Task');
+
+      // when
+      TestHelper.triggerValue(textField, '', 'change');
+
+      // then
+      expect(textField.textContent).to.equal('');
+      expect(businessObject.get('documentation')).to.have.length(0);
+    }));
+
+
+    it('documentation list', inject(function(propertiesPanel, selection, elementRegistry) {
+
+      var shape = elementRegistry.get('MULTIPLE_DOCS');
+      selection.select(shape);
+      var textField = domQuery('div[name=documentation]', propertiesPanel._container);
+      var businessObject = getBusinessObject(shape);
+
+      // given
+      expect(textField.textContent).to.equal('MULTIPLE_DOCS');
+
+      // when
+      TestHelper.triggerValue(textField, '', 'change');
+
+      // then
+      expect(textField.textContent).to.equal('');
+      expect(businessObject.get('documentation')).to.have.length(1);
+      expect(businessObject.get('documentation')[0].text).to.eql('VENDOR DOCS');
+    }));
+
+  });
+
 });


### PR DESCRIPTION
This PR changes our documentation behavior to more sensible defaults:

* we pick the first documentation element that has a
  textFormat=text/plain (or an empty text format)
* we update the documentation entry rather than resetting
  the whole list of entries

This ensures we play more nicely with others, that may use multiple
documentation entries for different use cases.

Related to https://github.com/camunda/camunda-modeler/issues/1682

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
