### PR TITLE
fix: preserve Windows newline characters

### DIFF
--- a/lib/PropertiesPanel.js
+++ b/lib/PropertiesPanel.js
@@ -640,6 +640,9 @@ PropertiesPanel.prototype._bindListeners = function(container) {
 
   function handlePaste(event) {
     var text = (event.clipboardData || window.clipboardData).getData('text');
+
+    text = normalizeEndOfLineSequences(text);
+
     document.execCommand('insertText', false, text);
 
     event.preventDefault();
@@ -1373,4 +1376,8 @@ function setContentEditableSelection(node, selection) {
 
 function isImplicitRoot(element) {
   return element.id === '__implicitroot';
+}
+
+function normalizeEndOfLineSequences(string) {
+  return string.replace(/\r\n|\r|\n/g, '\n');
 }


### PR DESCRIPTION
Fix verified through manual test since we [can't unit test it](https://github.com/bpmn-io/bpmn-js-properties-panel/blob/master/test/spec/PropertiesPanelSpec.js#L507).

Related to camunda/camunda-modeler#2280

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
