### PR TITLE
feat(element-templates): support specific local camunda:in|out

### DIFF
--- a/lib/provider/camunda/element-templates/CreateHelper.js
+++ b/lib/provider/camunda/element-templates/CreateHelper.js
@@ -272,31 +272,26 @@ function createCamundaInOutAttrs(binding, value) {
     if (binding.target && !binding.expression && !binding.variables) {
       properties.target = binding.target;
       properties.source = value;
-    }
 
-    if (binding.target && binding.expression === true && !binding.variables) {
+    } else if (binding.target && binding.expression === true && !binding.variables) {
       properties.target = binding.target;
       properties.sourceExpression = value;
-    }
 
-    if (binding.variables === 'local' && !binding.target && !binding.expression) {
+    } else if (binding.variables === 'local' && !binding.target && !binding.expression) {
       properties.local = true;
       properties.variables = 'all';
-    }
 
-    if (binding.variables === 'local' && binding.target && !binding.expression) {
+    } else if (binding.variables === 'local' && binding.target && !binding.expression) {
       properties.local = true;
       properties.source = value;
       properties.target = binding.target;
-    }
 
-    if (binding.variables === 'local' && binding.target && binding.expression) {
+    } else if (binding.variables === 'local' && binding.target && binding.expression) {
       properties.local = true;
       properties.sourceExpression = value;
       properties.target = binding.target;
-    }
 
-    if (binding.variables === 'all' && !binding.target && !binding.expression) {
+    } else if (binding.variables === 'all' && !binding.target && !binding.expression) {
       properties.variables = 'all';
     }
   }
@@ -305,30 +300,25 @@ function createCamundaInOutAttrs(binding, value) {
     if (binding.source && !binding.sourceExpression && !binding.variables) {
       properties.target = value;
       properties.source = binding.source;
-    }
 
-    if (binding.sourceExpression && !binding.source && !binding.variables) {
+    } else if (binding.sourceExpression && !binding.source && !binding.variables) {
       properties.target = value;
       properties.sourceExpression = binding.sourceExpression;
-    }
 
-    if (binding.variables === 'all' && !binding.sourceExpression && !binding.source) {
+    } else if (binding.variables === 'all' && !binding.sourceExpression && !binding.source) {
       properties.variables = 'all';
-    }
 
-    if (binding.variables === 'local' && binding.source && !binding.sourceExpression) {
+    } else if (binding.variables === 'local' && binding.source && !binding.sourceExpression) {
       properties.local = true;
       properties.source = binding.source;
       properties.target = value;
-    }
 
-    if (binding.variables === 'local' && binding.sourceExpression && !binding.source) {
+    } else if (binding.variables === 'local' && binding.sourceExpression && !binding.source) {
       properties.local = true;
       properties.sourceExpression = binding.sourceExpression;
       properties.target = value;
-    }
 
-    if (binding.variables === 'local' && !binding.sourceExpression && !binding.source) {
+    } else if (binding.variables === 'local' && !binding.sourceExpression && !binding.source) {
       properties.local = true;
       properties.variables = 'all';
     }

--- a/lib/provider/camunda/element-templates/CreateHelper.js
+++ b/lib/provider/camunda/element-templates/CreateHelper.js
@@ -268,36 +268,70 @@ function createCamundaInOutAttrs(binding, value) {
 
   var properties = {};
 
-  // camunda:in source(Expression) target
-  if (binding.target) {
-
-    properties.target = binding.target;
-
-    if (binding.expression) {
-      properties.sourceExpression = value;
-    } else {
+  if (binding.type === 'camunda:in') {
+    if (binding.target && !binding.expression && !binding.variables) {
+      properties.target = binding.target;
       properties.source = value;
     }
-  } else
 
-  // camunda:(in|out) variables local
-  if (binding.variables) {
-    properties.variables = 'all';
+    if (binding.target && binding.expression === true && !binding.variables) {
+      properties.target = binding.target;
+      properties.sourceExpression = value;
+    }
 
-    if (binding.variables === 'local') {
+    if (binding.variables === 'local' && !binding.target && !binding.expression) {
       properties.local = true;
+      properties.variables = 'all';
+    }
+
+    if (binding.variables === 'local' && binding.target && !binding.expression) {
+      properties.local = true;
+      properties.source = value;
+      properties.target = binding.target;
+    }
+
+    if (binding.variables === 'local' && binding.target && binding.expression) {
+      properties.local = true;
+      properties.sourceExpression = value;
+      properties.target = binding.target;
+    }
+
+    if (binding.variables === 'all' && !binding.target && !binding.expression) {
+      properties.variables = 'all';
     }
   }
 
-  // camunda:out source(Expression) target
-  else {
-    properties.target = value;
+  if (binding.type === 'camunda:out') {
+    if (binding.source && !binding.sourceExpression && !binding.variables) {
+      properties.target = value;
+      properties.source = binding.source;
+    }
 
-    [ 'source', 'sourceExpression' ].forEach(function(k) {
-      if (binding[k]) {
-        properties[k] = binding[k];
-      }
-    });
+    if (binding.sourceExpression && !binding.source && !binding.variables) {
+      properties.target = value;
+      properties.sourceExpression = binding.sourceExpression;
+    }
+
+    if (binding.variables === 'all' && !binding.sourceExpression && !binding.source) {
+      properties.variables = 'all';
+    }
+
+    if (binding.variables === 'local' && binding.source && !binding.sourceExpression) {
+      properties.local = true;
+      properties.source = binding.source;
+      properties.target = value;
+    }
+
+    if (binding.variables === 'local' && binding.sourceExpression && !binding.source) {
+      properties.local = true;
+      properties.sourceExpression = binding.sourceExpression;
+      properties.target = value;
+    }
+
+    if (binding.variables === 'local' && !binding.sourceExpression && !binding.source) {
+      properties.local = true;
+      properties.variables = 'all';
+    }
   }
 
   return properties;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2660,7 +2660,7 @@
     },
     "kew": {
       "version": "0.7.0",
-      "resolved": "http://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
       "dev": true
     },
@@ -2855,7 +2855,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -3398,7 +3398,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -155,11 +155,11 @@
       }
     },
     "@bpmn-io/element-templates-validator": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.1.0.tgz",
-      "integrity": "sha512-GK2IxWa//Zkck6wTwC6kmjNpL2W5zXLQdtPKdpe8UbAFtGxiltzUgIRiLPnvB0PKnKtyh1nq3on3GHxU9QlC0g==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.2.0.tgz",
+      "integrity": "sha512-/ogp0+6zUFdoiY09NYaHL5JtapB8zN1spG8hpML96qetXDCODRxnsqlHTvSwxtZHUDcgun+lxcK8b4wgtCP+6Q==",
       "requires": {
-        "@camunda/element-templates-json-schema": "^0.3.1",
+        "@camunda/element-templates-json-schema": "^0.4.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^3.7.0"
       }
@@ -173,9 +173,9 @@
       }
     },
     "@camunda/element-templates-json-schema": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.3.1.tgz",
-      "integrity": "sha512-tU1DGIInadVbO1YLd+k4S35lLQTu7fgSVyjwEGUt9wdmPk9xca4Pup1zVd9S0gLdXAddnox37jsL6dJhKlNUVQ=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.4.0.tgz",
+      "integrity": "sha512-M5xW61ba7z2maBxfoT4c1bjuLD8OIL7863et/hULiNG6+R/B9CZ4Qze1juuIfXv4zpF2fYSuUsTPkTtiZrcspQ=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.0",
@@ -1369,6 +1369,14 @@
         "debug": "~4.3.1",
         "engine.io-parser": "~4.0.0",
         "ws": "~7.4.2"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+          "dev": true
+        }
       }
     },
     "engine.io-parser": {
@@ -4867,9 +4875,9 @@
       "dev": true
     },
     "ws": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.2.tgz",
+      "integrity": "sha512-lkF7AWRicoB9mAgjeKbGqVUekLnSNO4VjKVnuPHpQeOxZOErX6BPXwJk70nFslRCEEA8EVW7ZjKwXaP9N+1sKQ==",
       "dev": true
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "webpack": "^5.24.2"
   },
   "dependencies": {
-    "@bpmn-io/element-templates-validator": "^0.1.0",
+    "@bpmn-io/element-templates-validator": "^0.2.0",
     "@bpmn-io/extract-process-variables": "^0.4.3",
     "ids": "^1.0.0",
     "inherits": "^2.0.1",

--- a/test/spec/provider/camunda/element-templates/CreateHelperSpec.js
+++ b/test/spec/provider/camunda/element-templates/CreateHelperSpec.js
@@ -148,6 +148,7 @@ describe('element-templates - CreateHelper', function() {
 
       // given
       var binding = {
+        type: 'camunda:in',
         target: 'var_called'
       };
 
@@ -167,6 +168,7 @@ describe('element-templates - CreateHelper', function() {
 
       // given
       var binding = {
+        type: 'camunda:in',
         target: 'var_called',
         expression: true
       };
@@ -187,6 +189,7 @@ describe('element-templates - CreateHelper', function() {
 
       // given
       var binding = {
+        type: 'camunda:in',
         variables: 'all'
       };
 
@@ -205,6 +208,7 @@ describe('element-templates - CreateHelper', function() {
 
       // given
       var binding = {
+        type: 'camunda:in',
         variables: 'local'
       };
 
@@ -214,8 +218,53 @@ describe('element-templates - CreateHelper', function() {
       // then
       expect(camundaIn).to.jsonEqual({
         $type: 'camunda:In',
-        variables: 'all',
-        local: true
+        local: true,
+        variables: 'all'
+      });
+    }));
+
+
+    it('should create variables="local" and target', inject(function(bpmnFactory) {
+
+      // given
+      var binding = {
+        type: 'camunda:in',
+        variables: 'local',
+        target: 'var_called'
+      };
+
+      // when
+      var camundaIn = createCamundaIn(binding, 'foobar', bpmnFactory);
+
+      // then
+      expect(camundaIn).to.jsonEqual({
+        $type: 'camunda:In',
+        local: true,
+        source: 'foobar',
+        target: 'var_called'
+      });
+    }));
+
+
+    it('should create variables="local", target and expression', inject(function(bpmnFactory) {
+
+      // given
+      var binding = {
+        type: 'camunda:in',
+        variables: 'local',
+        target: 'var_called',
+        expression: true
+      };
+
+      // when
+      var camundaIn = createCamundaIn(binding, 'foobar', bpmnFactory);
+
+      // then
+      expect(camundaIn).to.jsonEqual({
+        $type: 'camunda:In',
+        local: true,
+        sourceExpression: 'foobar',
+        target: 'var_called'
       });
     }));
 
@@ -244,7 +293,8 @@ describe('element-templates - CreateHelper', function() {
 
       // given
       var binding = {
-        target: 'var'
+        type: 'camunda:out',
+        source: 'var'
       };
 
       // when
@@ -263,17 +313,17 @@ describe('element-templates - CreateHelper', function() {
 
       // given
       var binding = {
-        target: 'var',
-        expression: true
+        type: 'camunda:out',
+        sourceExpression: '${ var }'
       };
 
       // when
-      var camundaOut = createCamundaOut(binding, '${ var }', bpmnFactory);
+      var camundaOut = createCamundaOut(binding, 'var_local_expr', bpmnFactory);
 
       // then
       expect(camundaOut).to.jsonEqual({
         $type: 'camunda:Out',
-        target: 'var',
+        target: 'var_local_expr',
         sourceExpression: '${ var }'
       });
     }));
@@ -283,6 +333,7 @@ describe('element-templates - CreateHelper', function() {
 
       // given
       var binding = {
+        type: 'camunda:out',
         variables: 'all'
       };
 
@@ -301,6 +352,7 @@ describe('element-templates - CreateHelper', function() {
 
       // given
       var binding = {
+        type: 'camunda:out',
         variables: 'local'
       };
 
@@ -310,8 +362,52 @@ describe('element-templates - CreateHelper', function() {
       // then
       expect(camundaOut).to.jsonEqual({
         $type: 'camunda:Out',
-        variables: 'all',
-        local: true
+        local: true,
+        variables: 'all'
+      });
+    }));
+
+
+    it('should create local="true" and source', inject(function(bpmnFactory) {
+
+      // given
+      var binding = {
+        type: 'camunda:out',
+        variables: 'local',
+        source: 'mySource'
+      };
+
+      // when
+      var camundaOut = createCamundaOut(binding, 'foobar', bpmnFactory);
+
+      // then
+      expect(camundaOut).to.jsonEqual({
+        $type: 'camunda:Out',
+        local: true,
+        source: 'mySource',
+        target: 'foobar'
+      });
+    }));
+
+
+    it('should create local="true" and sourceExpression', inject(function(bpmnFactory) {
+
+      // given
+      var binding = {
+        type: 'camunda:out',
+        variables: 'local',
+        sourceExpression: '${ mySource }'
+      };
+
+      // when
+      var camundaOut = createCamundaOut(binding, 'foobar', bpmnFactory);
+
+      // then
+      expect(camundaOut).to.jsonEqual({
+        $type: 'camunda:Out',
+        local: true,
+        sourceExpression: '${ mySource }',
+        target: 'foobar'
       });
     }));
 

--- a/test/spec/provider/camunda/element-templates/ValidatorSpec.js
+++ b/test/spec/provider/camunda/element-templates/ValidatorSpec.js
@@ -397,8 +397,8 @@ describe('element-templates - Validator', function() {
         'template(id: <foo>, name: <Invalid>): property.binding "camunda:property" requires name',
         'template(id: <foo>, name: <Invalid>): property.binding "camunda:inputParameter" requires name',
         'template(id: <foo>, name: <Invalid>): property.binding "camunda:outputParameter" requires source',
-        'template(id: <foo>, name: <Invalid>): property.binding "camunda:in" requires variables or target',
-        'template(id: <foo>, name: <Invalid>): property.binding "camunda:out" requires variables, sourceExpression or source',
+        'template(id: <foo>, name: <Invalid>): property.binding "camunda:in" requires variables, target, or both',
+        'template(id: <foo>, name: <Invalid>): property.binding "camunda:out" requires one of the following: variables, sourceExpression, source, (sourceExpression and variables), or (source and variables)',
         'template(id: <foo>, name: <Invalid>): property.binding "camunda:errorEventDefinition" requires errorRef'
       ]);
 

--- a/test/spec/provider/camunda/element-templates/cmd/ChangeElementTemplateHandlerSpec.js
+++ b/test/spec/provider/camunda/element-templates/cmd/ChangeElementTemplateHandlerSpec.js
@@ -604,7 +604,7 @@ describe('element-templates - ChangeElementTemplateHandler', function() {
 
           var insAndOuts = findExtensions(callActivity, [ 'camunda:In', 'camunda:Out' ]);
 
-          expect(insAndOuts).to.have.length(9);
+          expect(insAndOuts).to.have.length(13);
           expect(insAndOuts).to.jsonEqual([
             {
               $type: 'camunda:In',
@@ -628,6 +628,30 @@ describe('element-templates - ChangeElementTemplateHandler', function() {
             },
             {
               $type: 'camunda:In',
+              local: true,
+              source: '${in-3-value}',
+              target: 'in-3-target'
+            },
+            {
+              $type: 'camunda:In',
+              local: true,
+              sourceExpression: '${in-4-value}',
+              target: 'in-4-target'
+            },
+            {
+              $type: 'camunda:Out',
+              local: true,
+              source: 'out-3-source',
+              target: 'out-3-value'
+            },
+            {
+              $type: 'camunda:Out',
+              local: true,
+              sourceExpression: '${ out-4-source-expression }',
+              target: 'out-4-value'
+            },
+            {
+              $type: 'camunda:In',
               variables: 'all'
             },
             {
@@ -636,13 +660,13 @@ describe('element-templates - ChangeElementTemplateHandler', function() {
             },
             {
               $type: 'camunda:In',
-              variables: 'all',
-              local: true
+              local: true,
+              variables: 'all'
             },
             {
               $type: 'camunda:Out',
-              variables: 'all',
-              local: true
+              local: true,
+              variables: 'all'
             },
             {
               $type: 'camunda:In',
@@ -687,7 +711,7 @@ describe('element-templates - ChangeElementTemplateHandler', function() {
 
           var insAndOuts = findExtensions(callActivity, [ 'camunda:In', 'camunda:Out' ]);
 
-          expect(insAndOuts).to.have.length(9);
+          expect(insAndOuts).to.have.length(13);
           expect(insAndOuts).to.jsonEqual([
             {
               $type: 'camunda:In',
@@ -711,6 +735,30 @@ describe('element-templates - ChangeElementTemplateHandler', function() {
             },
             {
               $type: 'camunda:In',
+              local: true,
+              source: '${in-3-value}',
+              target: 'in-3-target'
+            },
+            {
+              $type: 'camunda:In',
+              local: true,
+              sourceExpression: '${in-4-value}',
+              target: 'in-4-target'
+            },
+            {
+              $type: 'camunda:Out',
+              local: true,
+              source: 'out-3-source',
+              target: 'out-3-value'
+            },
+            {
+              $type: 'camunda:Out',
+              local: true,
+              sourceExpression: '${ out-4-source-expression }',
+              target: 'out-4-value'
+            },
+            {
+              $type: 'camunda:In',
               variables: 'all'
             },
             {
@@ -719,13 +767,13 @@ describe('element-templates - ChangeElementTemplateHandler', function() {
             },
             {
               $type: 'camunda:In',
-              variables: 'all',
-              local: true
+              local: true,
+              variables: 'all'
             },
             {
               $type: 'camunda:Out',
-              variables: 'all',
-              local: true
+              local: true,
+              variables: 'all'
             },
             {
               $type: 'camunda:In',

--- a/test/spec/provider/camunda/element-templates/cmd/call-activity-template-1.json
+++ b/test/spec/provider/camunda/element-templates/cmd/call-activity-template-1.json
@@ -36,6 +36,39 @@
       }
     },
     {
+      "value": "${in-3-value}",
+      "binding": {
+        "type": "camunda:in",
+        "target": "in-3-target",
+        "variables": "local"
+      }
+    },
+    {
+      "value": "${in-4-value}",
+      "binding": {
+        "type": "camunda:in",
+        "target": "in-4-target",
+        "variables": "local",
+        "expression": true
+      }
+    },
+    {
+      "value": "out-3-value",
+      "binding": {
+        "type": "camunda:out",
+        "variables": "local",
+        "source": "out-3-source"
+      }
+    },
+    {
+      "value": "out-4-value",
+      "binding": {
+        "type": "camunda:out",
+        "variables": "local",
+        "sourceExpression": "${ out-4-source-expression }"
+      }
+    },
+    {
       "binding": {
         "type": "camunda:in",
         "variables": "all"


### PR DESCRIPTION
fixes upstream camunda/camunda-modeler#2334

requires camunda/element-templates-json-schema#30

(Note that prior to releasing this, we need to bump the
element-templates-json-schema version - otherwise respective schemas
will be marked as invalid and ignored)
