### PR TITLE
chore(CHANGELOG): update to v1.0.0-alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.0.0-alpha.0
+
+* `FEAT`: rewrite project to new, [@bpmn-io/properties-panel](https://github.com/bpmn-io/properties-panel)-based architecture
+* `FEAT`: replace tabs with flat structure where groups are basic building blocks
+* `FEAT`: add "dirty" markers to notify non-default value of entry/entries in group
+* `FEAT`: keep open/closed state of the groups between elements
+
+### Breaking Changes
+
+* `PropertiesProvider#getTabs` is no longer used. Migrate to the new `PropertiesProvider#getGroups` API instead.
+  Check out [the example migration](https://github.com/bpmn-io/bpmn-js-examples/pull/142) for guidance.
+* Previously exported entry factory functions are no longer available. Use components exported from
+  [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/properties-panel) instead.
+
 ## 0.46.0
 
 * `FEAT`: graceful handle incompatible properties providers ([#482](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/482))

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,8 @@ import resolve from '@rollup/plugin-node-resolve';
 
 import pkg from './package.json';
 
+const nonbundledDependencies = Object.keys({ ...pkg.dependencies, ...pkg.peerDependencies });
+
 export default [
   {
     input: 'src/index.js',
@@ -23,11 +25,7 @@ export default [
         file: pkg.module
       }
     ],
-    external: [
-      'array-move',
-      'min-dash',
-      /^@bpmn-io\/properties-panel'/
-    ],
+    external: id => nonbundledDependencies.find(dep => id.startsWith(dep)),
     plugins: [
       alias({
         entries: [


### PR DESCRIPTION
This is a concise update of the changelog which will prepare us for the first alpha. It will be followed by updated examples and the blog post which we should have ready before the first stable release.