### PR TITLE
fix(zeebePropProvider): rename target group to calledElement

### DIFF
--- a/src/provider/zeebe/ZeebePropertiesProvider.js
+++ b/src/provider/zeebe/ZeebePropertiesProvider.js
@@ -158,8 +158,8 @@ function FormGroup(element) {
 
 function TargetGroup(element) {
   const group = {
-    id: 'target',
-    label: 'Target',
+    id: 'calledElement',
+    label: 'Called element',
     entries: [
       ...TargetProps({ element })
     ],

--- a/test/spec/provider/zeebe/ZeebePropertiesProvider.spec.js
+++ b/test/spec/provider/zeebe/ZeebePropertiesProvider.spec.js
@@ -114,7 +114,7 @@ describe('<ZeebePropertiesProvider>', function() {
       });
 
       // when
-      const targetGroup = getGroup(container, 'target');
+      const targetGroup = getGroup(container, 'calledElement');
 
       // then
       expect(targetGroup).to.not.exist;
@@ -131,7 +131,7 @@ describe('<ZeebePropertiesProvider>', function() {
       });
 
       // when
-      const targetGroup = getGroup(container, 'target');
+      const targetGroup = getGroup(container, 'calledElement');
 
       // then
       expect(targetGroup).to.exist;


### PR DESCRIPTION
Required by camunda/camunda-modeler#2586

![Screenshot_20211202_204654](https://user-images.githubusercontent.com/42800119/144492299-59561f75-8d5f-4921-9e72-b7fc51c66ebc.png)