### PR TITLE
Update ordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1171,6 +1171,11 @@
         "is-string": "^1.0.7"
       }
     },
+    "array-move": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/array-move/-/array-move-3.0.1.tgz",
+      "integrity": "sha512-H3Of6NIn2nNU1gsVDqDnYKY/LCdWvCMMOWifNGhKcVQgiZ6nOek39aESOvro6zmueP07exSl93YLvkN4fZOkSg=="
+    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@bpmn-io/element-templates-validator": "^0.3.0",
     "@bpmn-io/extract-process-variables": "^0.4.3",
     "@bpmn-io/properties-panel": "^0.8.1",
+    "array-move": "^3.0.1",
     "classnames": "^2.3.1",
     "ids": "^1.0.0",
     "min-dash": "^3.8.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,6 +24,7 @@ export default [
       }
     ],
     external: [
+      'array-move',
       'min-dash',
       'preact',
       'preact/jsx-runtime',

--- a/src/provider/camunda-platform/CamundaPlatformPropertiesProvider.js
+++ b/src/provider/camunda-platform/CamundaPlatformPropertiesProvider.js
@@ -3,6 +3,8 @@ import ListGroup from '@bpmn-io/properties-panel/lib/components/ListGroup';
 
 import { findIndex } from 'min-dash';
 
+import { mutate as arrayMove } from 'array-move';
+
 import {
   AsynchronousContinuationsProps,
   BusinessKeyProps,
@@ -119,6 +121,9 @@ export default class CamundaPlatformPropertiesProvider {
       updateEscalationGroup(groups, element);
       updateMultiInstanceGroup(groups, element);
 
+      // (3) move groups given specific priorities
+      moveImplementationGroup(groups);
+
       return groups;
     };
   }
@@ -132,6 +137,19 @@ export default class CamundaPlatformPropertiesProvider {
 }
 
 CamundaPlatformPropertiesProvider.$inject = [ 'propertiesPanel', 'injector' ];
+
+/**
+ * This ensures the <Implementation> group always locates after <Documentation>
+ */
+function moveImplementationGroup(groups) {
+  const documentationGroupIdx = findGroupIndex(groups, 'documentation');
+
+  if (documentationGroupIdx < 0) {
+    return;
+  }
+
+  return moveGroup(groups, 'CamundaPlatform__Implementation', documentationGroupIdx + 1);
+}
 
 function updateGeneralGroup(groups, element) {
 
@@ -660,4 +678,18 @@ function ExtensionPropertiesGroup(element, injector) {
 
 function findGroup(groups, id) {
   return groups.find(g => g.id === id);
+}
+
+function findGroupIndex(groups, id) {
+  return findIndex(groups, g => g.id === id);
+}
+
+function moveGroup(groups, id, position) {
+  const groupIndex = findGroupIndex(groups, id);
+
+  if (position < 0 || groupIndex < 0) {
+    return;
+  }
+
+  return arrayMove(groups, groupIndex, position);
 }

--- a/src/provider/camunda-platform/CamundaPlatformPropertiesProvider.js
+++ b/src/provider/camunda-platform/CamundaPlatformPropertiesProvider.js
@@ -43,14 +43,19 @@ import {
 const LOW_PRIORITY = 500;
 
 const CAMUNDA_PLATFORM_GROUPS = [
-  ProcessVariablesGroup,
   ImplementationGroup,
+  ProcessVariablesGroup,
   ErrorsGroup,
   UserAssignmentGroup,
+  FormGroup,
+  FormDataGroup,
+  TaskListenerGroup,
   StartInitiatorGroup,
   ScriptGroup,
-  AsynchronousContinuationsGroup,
+  ConditionGroup,
   CallActivityGroup,
+  AsynchronousContinuationsGroup,
+  JobExecutionGroup,
   InMappingPropagationGroup,
   InMappingGroup,
   InputGroup,
@@ -60,17 +65,12 @@ const CAMUNDA_PLATFORM_GROUPS = [
   OutputGroup,
   ConnectorOutputGroup,
   CandidateStarterGroup,
-  ConditionGroup,
+  ExecutionListenerGroup,
   ExtensionPropertiesGroup,
   ExternalTaskGroup,
   FieldInjectionGroup,
-  FormGroup,
-  FormDataGroup,
   BusinessKeyGroup,
   HistoryCleanupGroup,
-  JobExecutionGroup,
-  ExecutionListenerGroup,
-  TaskListenerGroup,
   TasklistGroup
 ];
 

--- a/src/provider/camunda-platform/properties/JobExecutionProps.js
+++ b/src/provider/camunda-platform/properties/JobExecutionProps.js
@@ -31,7 +31,18 @@ export function JobExecutionProps(props) {
 
   const entries = [];
 
-  // (1) add jobPriority field for camunda:jobPriorized with async enabled
+  // (1) add retryTimeCycle field for camunda:asyncCapable enabled Elements
+  // or TimerEvents
+  if ((is(element, 'camunda:AsyncCapable') && isAsync(businessObject)) ||
+      isTimerEvent(element)) {
+    entries.push({
+      id: 'retryTimeCycle',
+      component: <RetryTimeCycle element={ element } />,
+      isEdited: textFieldIsEdited
+    });
+  }
+
+  // (2) add jobPriority field for camunda:jobPriorized with async enabled
   //  or Processes
   //  or Processes referred to by participants
   //  or TimerEvents
@@ -42,17 +53,6 @@ export function JobExecutionProps(props) {
     entries.push({
       id: 'jobPriority',
       component: <JobPriority element={ element } />,
-      isEdited: textFieldIsEdited
-    });
-  }
-
-  // (2) add retryTimeCycle field for camunda:asyncCapable enabled Elements
-  // or TimerEvents
-  if ((is(element, 'camunda:AsyncCapable') && isAsync(businessObject)) ||
-      isTimerEvent(element)) {
-    entries.push({
-      id: 'retryTimeCycle',
-      component: <RetryTimeCycle element={ element } />,
       isEdited: textFieldIsEdited
     });
   }

--- a/src/provider/camunda-platform/properties/UserAssignmentProps.js
+++ b/src/provider/camunda-platform/properties/UserAssignmentProps.js
@@ -28,13 +28,13 @@ export function UserAssignmentProps(props) {
       isEdited: textFieldIsEdited
     },
     {
-      id: 'candidateUsers',
-      component: <CandidateUsers element={ element } />,
+      id: 'candidateGroups',
+      component: <CandidateGroups element={ element } />,
       isEdited: textFieldIsEdited
     },
     {
-      id: 'candidateGroups',
-      component: <CandidateGroups element={ element } />,
+      id: 'candidateUsers',
+      component: <CandidateUsers element={ element } />,
       isEdited: textFieldIsEdited
     },
     {

--- a/test/spec/provider/camunda-platform/CamundaPlatformPropertiesProvider.spec.js
+++ b/test/spec/provider/camunda-platform/CamundaPlatformPropertiesProvider.spec.js
@@ -1315,6 +1315,32 @@ describe('<CamundaPlatformPropertiesProvider>', function() {
         expect(elementVariableInput).to.exist;
       }));
 
+
+      it('should show implementation group at correct position',
+        inject(async function(elementRegistry, selection) {
+
+          // given
+          const element = elementRegistry.get('MessageIntermediateThrowEvent_1');
+
+          await act(() => {
+            selection.select(element);
+          });
+
+          // when
+          const implementationGroup = getGroup(container, 'CamundaPlatform__Implementation');
+
+          /**
+           * - General
+           * - Documentation
+           * - Implementation
+           */
+          const expectedGroup = getGroupAt(container, 2);
+
+          // then
+          expect(expectedGroup).to.eql(implementationGroup);
+        })
+      );
+
     });
 
   });
@@ -1325,6 +1351,11 @@ describe('<CamundaPlatformPropertiesProvider>', function() {
 
 function getGroup(container, id) {
   return domQuery(`[data-group-id="group-${id}"`, container);
+}
+
+function getGroupAt(container, position) {
+  const groups = domQueryAll('.bio-properties-panel-group', container);
+  return groups.item(position);
 }
 
 function getAllGroups(container, id) {


### PR DESCRIPTION
Related #515 

Based on feedback we got, this PR
* moves `Job execution` below `Asynchronous continuations`
* moved `Forms` and `Generated task form` below `User assignment`
* moved `Task listeners` below `Generated task form`
* switched `Priority` and `Retry time cycle` in `Job execution`
* switched `Candidate groups` and `Candidate users` in `User assignment`
* moved `Execution listeners` above `Extension properties`
* moved `Condition` above `Asynchronous continuations`
* moves `Implementation` below `Documentation`

-----

Command to try it out

```sh
npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel#update-ordering -c "npm run start:platform"
```

