### PR TITLE
Reuse preact instance and adjust to new exports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,0 @@
-{
-  "plugins": [
-    [ "@babel/plugin-transform-react-jsx", {
-      "importSource": "preact",
-      "runtime": "automatic"
-    } ]
-  ]
-}

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib');

--- a/karma.config.js
+++ b/karma.config.js
@@ -70,7 +70,7 @@ module.exports = function(karma) {
               options: {
                 plugins: [
                   [ '@babel/plugin-transform-react-jsx', {
-                    'importSource': 'preact',
+                    'importSource': '@bpmn-io/properties-panel/preact',
                     'runtime': 'automatic'
                   } ]
                 ]
@@ -105,9 +105,9 @@ module.exports = function(karma) {
           function(resource) {
 
             const replMap = {
-              'preact/hooks': path.resolve('node_modules/preact/hooks/dist/hooks.module.js'),
-              'preact/jsx-runtime': path.resolve('node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js'),
-              'preact': path.resolve('node_modules/preact/dist/preact.module.js')
+              'preact/hooks': path.resolve('node_modules/@bpmn-io/properties-panel/preact/hooks/dist/hooks.module.js'),
+              'preact/jsx-runtime': path.resolve('node_modules/@bpmn-io/properties-panel/preact/jsx-runtime/dist/jsxRuntime.module.js'),
+              'preact': path.resolve('node_modules/@bpmn-io/properties-panel/preact/dist/preact.module.js')
             };
 
             const replacement = replMap[resource.request];
@@ -121,7 +121,7 @@ module.exports = function(karma) {
         ),
         new NormalModuleReplacementPlugin(
           /^preact\/hooks/,
-          path.resolve('node_modules/preact/hooks/dist/hooks.module.js')
+          path.resolve('node_modules/@bpmn-io/properties-panel/preact/hooks/dist/hooks.module.js')
         )
       ],
       resolve: {
@@ -131,8 +131,9 @@ module.exports = function(karma) {
           'main'
         ],
         alias: {
-          'react': 'preact/compat',
-          'react-dom': 'preact/compat'
+          'preact': '@bpmn-io/properties-panel/preact',
+          'react': '@bpmn-io/properties-panel/preact/compat',
+          'react-dom': '@bpmn-io/properties-panel/preact/compat'
         },
         modules: [
           'node_modules',

--- a/package-lock.json
+++ b/package-lock.json
@@ -5126,11 +5126,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "preact": {
-      "version": "10.6.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.3.tgz",
-      "integrity": "sha512-vwuM6VmFffw5t3RrLFn49QHPzoepD9hiNdkLa3Mt4UGSRdfQfIHtC1xqxhjVGoq70Sjtxrn4c9xwAnaS6z3anA=="
-    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -378,9 +378,10 @@
       }
     },
     "@bpmn-io/properties-panel": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.9.0.tgz",
-      "integrity": "sha512-vgo9PatqOjzSxjqYKVlUHZ9XZw7hoNhd5SeSg7LDmxmJsqBajqOFSAZ/gV9gHfoHjGarimVLu5F0NiUNN0uMwg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.10.0.tgz",
+      "integrity": "sha512-lYouhzJLor5BKWOSRikd/yGnkH50SnnmQGSVDOXOcs9zDjKKLB+LpFAnJ7MGsEd/MBSxgvAHzf4/o12Ht1nw1g==",
+      "dev": true,
       "requires": {
         "classnames": "^2.3.1",
         "min-dash": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "devDependencies": {
     "@babel/core": "^7.14.3",
     "@babel/plugin-transform-react-jsx": "^7.14.3",
+    "@bpmn-io/properties-panel": "^0.10.0",
     "@rollup/plugin-alias": "^3.1.2",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   "dependencies": {
     "@bpmn-io/element-templates-validator": "^0.3.0",
     "@bpmn-io/extract-process-variables": "^0.4.3",
-    "@bpmn-io/properties-panel": "^0.9.0",
     "array-move": "^3.0.1",
     "classnames": "^2.3.1",
     "ids": "^1.0.0",
@@ -105,6 +104,7 @@
   },
   "peerDependencies": {
     "bpmn-js": "8.x",
-    "diagram-js": "7.x"
+    "diagram-js": "7.x",
+    "@bpmn-io/properties-panel": "0.10.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "bpmn-js-properties-panel",
   "version": "0.46.0",
   "description": "A simple properties panel for bpmn-js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "all": "run-s lint test distro",
     "distro": "run-s build test:build",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "ids": "^1.0.0",
     "min-dash": "^3.8.0",
     "min-dom": "^3.1.3",
-    "preact": "^10.5.13",
     "semver": "^7.3.5"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,11 +23,11 @@ export default [
         file: pkg.module
       }
     ],
-    external: id => ([
+    external: [
       'array-move',
       'min-dash',
-      '@bpmn-io/properties-panel'
-    ].includes(id) || /^@bpmn-io\/properties-panel/.test(id)),
+      /^@bpmn-io\/properties-panel'/
+    ],
     plugins: [
       alias({
         entries: [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,20 +23,15 @@ export default [
         file: pkg.module
       }
     ],
-    external: [
+    external: id => ([
       'array-move',
       'min-dash',
-      'preact',
-      'preact/jsx-runtime',
-      'preact/hooks',
-      'preact/compat',
       '@bpmn-io/properties-panel'
-    ],
+    ].includes(id) || /^@bpmn-io\/properties-panel/.test(id)),
     plugins: [
       alias({
         entries: [
-          { find: 'react', replacement: 'preact/compat' },
-          { find: 'react-dom', replacement: 'preact/compat' }
+          { find: 'react', replacement: '@bpmn-io/properties-panel/preact/compat' }
         ]
       }),
       reactSvg(),
@@ -44,7 +39,7 @@ export default [
         babelHelpers: 'bundled',
         plugins: [
           [ '@babel/plugin-transform-react-jsx', {
-            'importSource': 'preact',
+            'importSource': '@bpmn-io/properties-panel/preact',
             'runtime': 'automatic'
           } ]
         ]

--- a/src/context/BpmnPropertiesPanelContext.js
+++ b/src/context/BpmnPropertiesPanelContext.js
@@ -1,6 +1,6 @@
 import {
   createContext
-} from 'preact';
+} from '@bpmn-io/properties-panel/preact';
 
 const BpmnPropertiesPanelContext = createContext({
   selectedElement: null,

--- a/src/entries/ReferenceSelect.js
+++ b/src/entries/ReferenceSelect.js
@@ -7,10 +7,9 @@ import {
 } from 'min-dom';
 
 import {
+  SelectEntry,
   usePrevious
-} from '@bpmn-io/properties-panel/lib/hooks';
-
-import SelectEntry from '@bpmn-io/properties-panel/lib/components/entries/Select';
+} from '@bpmn-io/properties-panel';
 
 
 export default function ReferenceSelectEntry(props) {

--- a/src/entries/ReferenceSelect.js
+++ b/src/entries/ReferenceSelect.js
@@ -1,6 +1,6 @@
 import {
   useEffect
-} from 'preact/hooks';
+} from '@bpmn-io/properties-panel/preact/hooks';
 
 import {
   query as domQuery

--- a/src/hooks/useService.js
+++ b/src/hooks/useService.js
@@ -1,6 +1,6 @@
 import {
   useContext
-} from 'preact/hooks';
+} from '@bpmn-io/properties-panel/preact/hooks';
 
 import { BpmnPropertiesPanelContext } from '../context';
 

--- a/src/provider/bpmn/BpmnPropertiesProvider.js
+++ b/src/provider/bpmn/BpmnPropertiesProvider.js
@@ -1,4 +1,4 @@
-import Group from '@bpmn-io/properties-panel/lib/components/Group';
+import { Group } from '@bpmn-io/properties-panel';
 
 import {
   CompensationProps,

--- a/src/provider/bpmn/properties/CompensationProps.js
+++ b/src/provider/bpmn/properties/CompensationProps.js
@@ -9,10 +9,10 @@ import {
 } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
-  isEdited as selectIsEdited
-} from '@bpmn-io/properties-panel/lib/components/entries/Select';
-
-import Checkbox from '@bpmn-io/properties-panel/lib/components/entries/Checkbox';
+  isSelectEntryEdited,
+  isCheckboxEntryEdited,
+  CheckboxEntry
+} from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -27,7 +27,7 @@ import {
 } from '../utils/EventDefinitionUtil';
 
 /**
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').EntryDefinition } Entry
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
 
 /**
@@ -42,20 +42,16 @@ export function CompensationProps(props) {
     return [];
   }
 
-  const isCheckboxEdited = (node) => {
-    return node && !node.checked;
-  };
-
   return [
     {
       id: 'waitForCompletion',
       component: <WaitForCompletion element={ element } />,
-      isEdited: isCheckboxEdited
+      isEdited: isCheckboxEntryEdited
     },
     {
       id: 'activityRef',
       component: <ActivityRef element={ element } />,
-      isEdited: selectIsEdited
+      isEdited: isSelectEntryEdited
     }
   ];
 }
@@ -82,7 +78,7 @@ function WaitForCompletion(props) {
     });
   };
 
-  return Checkbox({
+  return CheckboxEntry({
     element,
     id: 'waitForCompletion',
     label: translate('Wait for completion'),

--- a/src/provider/bpmn/properties/DocumentationProps.js
+++ b/src/provider/bpmn/properties/DocumentationProps.js
@@ -3,7 +3,10 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextArea, { isEdited as defaultIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextArea';
+import {
+  TextAreaEntry,
+  isTextAreaEntryEdited
+} from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -13,7 +16,7 @@ const DOCUMENTATION_TEXT_FORMAT = 'text/plain';
 
 
 /**
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').EntryDefinition } Entry
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
 
 /**
@@ -28,7 +31,7 @@ export function DocumentationProps(props) {
     {
       id: 'documentation',
       component: <ElementDocumentationProperty element={ element } />,
-      isEdited: defaultIsEdited
+      isEdited: isTextAreaEntryEdited
     }
   ];
 
@@ -36,7 +39,7 @@ export function DocumentationProps(props) {
     entries.push({
       id: 'processDocumentation',
       component: <ProcessDocumentationProperty element={ element } />,
-      isEdited: defaultIsEdited
+      isEdited: isTextAreaEntryEdited
     });
   }
 
@@ -58,7 +61,7 @@ function ElementDocumentationProperty(props) {
   const setValue =
     setDocumentation(element, getBusinessObject(element), bpmnFactory, commandStack);
 
-  return TextArea({
+  return TextAreaEntry({
     element,
     id: 'documentation',
     label: translate('Element documentation'),
@@ -85,7 +88,7 @@ function ProcessDocumentationProperty(props) {
   const setValue =
     setDocumentation(element, processRef, bpmnFactory, commandStack);
 
-  return TextArea({
+  return TextAreaEntry({
     element,
     id: 'processDocumentation',
     label: translate('Process documentation'),

--- a/src/provider/bpmn/properties/ErrorProps.js
+++ b/src/provider/bpmn/properties/ErrorProps.js
@@ -6,9 +6,12 @@ import {
   sortBy
 } from 'min-dash';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import {
+  TextFieldEntry,
+  isSelectEntryEdited,
+  isTextFieldEntryEdited
+} from '@bpmn-io/properties-panel';
 import ReferenceSelect from '../../../entries/ReferenceSelect';
-import { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
 
 import {
   useService
@@ -33,7 +36,7 @@ export const CREATE_NEW_OPTION = 'create-new';
 
 
 /**
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').EntryDefinition } Entry
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
 
 /**
@@ -54,7 +57,7 @@ export function ErrorProps(props) {
     {
       id: 'errorRef',
       component: <ErrorRef element={ element } />,
-      isEdited: selectIsEdited
+      isEdited: isSelectEntryEdited
     }
   ];
 
@@ -64,12 +67,12 @@ export function ErrorProps(props) {
       {
         id: 'errorName',
         component: <ErrorName element={ element } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       },
       {
         id: 'errorCode',
         component: <ErrorCode element={ element } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       }
     ];
   }
@@ -198,7 +201,7 @@ function ErrorName(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'errorName',
     label: translate('Name'),
@@ -234,7 +237,7 @@ function ErrorCode(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'errorCode',
     label: translate('Code'),

--- a/src/provider/bpmn/properties/EscalationProps.js
+++ b/src/provider/bpmn/properties/EscalationProps.js
@@ -6,9 +6,12 @@ import {
   sortBy
 } from 'min-dash';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import {
+  TextFieldEntry,
+  isTextFieldEntryEdited,
+  isSelectEntryEdited
+} from '@bpmn-io/properties-panel';
 import ReferenceSelect from '../../../entries/ReferenceSelect';
-import { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
 
 import {
   useService
@@ -32,7 +35,7 @@ const CREATE_NEW_OPTION = 'create-new';
 
 
 /**
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').EntryDefinition } Entry
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
 
 /**
@@ -53,7 +56,7 @@ export function EscalationProps(props) {
     {
       id: 'escalationRef',
       component: <EscalationRef element={ element } />,
-      isEdited: selectIsEdited
+      isEdited: isSelectEntryEdited
     }
   ];
 
@@ -63,12 +66,12 @@ export function EscalationProps(props) {
       {
         id: 'escalationName',
         component: <EscalationName element={ element } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       },
       {
         id: 'escalationCode',
         component: <EscalationCode element={ element } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       }
     ];
   }
@@ -195,7 +198,7 @@ function EscalationName(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'escalationName',
     label: translate('Name'),
@@ -231,7 +234,7 @@ function EscalationCode(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'escalationCode',
     label: translate('Code'),

--- a/src/provider/bpmn/properties/ExecutableProps.js
+++ b/src/provider/bpmn/properties/ExecutableProps.js
@@ -2,7 +2,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import Checkbox, { isEdited } from '@bpmn-io/properties-panel/lib/components/entries/Checkbox';
+import { CheckboxEntry, isCheckboxEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -10,7 +10,7 @@ import {
 
 
 /**
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').EntryDefinition } Entry
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
 
 /**
@@ -29,7 +29,7 @@ export function ExecutableProps(props) {
     {
       id: 'isExecutable',
       component: <Executable element={ element } />,
-      isEdited
+      isEdited: isCheckboxEntryEdited
     }
   ];
 }
@@ -79,7 +79,7 @@ function Executable(props) {
 
   }
 
-  return Checkbox({
+  return CheckboxEntry({
     element,
     id: 'isExecutable',
     label: translate('Executable'),

--- a/src/provider/bpmn/properties/IdProps.js
+++ b/src/provider/bpmn/properties/IdProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -15,7 +15,7 @@ import {
 
 
 /**
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').EntryDefinition } Entry
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
 
 /**
@@ -30,7 +30,7 @@ export function IdProps(props) {
     {
       id: 'id',
       component: <Id element={ element } />,
-      isEdited
+      isEdited: isTextFieldEntryEdited
     }
   ];
 }
@@ -60,7 +60,7 @@ function Id(props) {
     return isIdValid(businessObject, value, translate);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'id',
     label: translate(is(element, 'bpmn:Participant') ? 'Participant ID' : 'ID'),

--- a/src/provider/bpmn/properties/LinkProps.js
+++ b/src/provider/bpmn/properties/LinkProps.js
@@ -1,4 +1,4 @@
-import TextField, { isEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -10,7 +10,7 @@ import {
 } from '../utils/EventDefinitionUtil';
 
 /**
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').EntryDefinition } Entry
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
 
 /**
@@ -29,7 +29,7 @@ export function LinkProps(props) {
     {
       id: 'linkName',
       component: <LinkName element={ element } />,
-      isEdited
+      isEdited: isTextFieldEntryEdited
     },
   ];
 }
@@ -57,7 +57,7 @@ function LinkName(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'linkName',
     label: translate('Name'),

--- a/src/provider/bpmn/properties/MessageProps.js
+++ b/src/provider/bpmn/properties/MessageProps.js
@@ -6,9 +6,8 @@ import {
   sortBy
 } from 'min-dash';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited, isSelectEntryEdited } from '@bpmn-io/properties-panel';
 import ReferenceSelect from '../../../entries/ReferenceSelect';
-import { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
 
 import {
   useService
@@ -33,7 +32,7 @@ export const CREATE_NEW_OPTION = 'create-new';
 
 
 /**
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').EntryDefinition } Entry
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
 
 /**
@@ -54,7 +53,7 @@ export function MessageProps(props) {
     {
       id: 'messageRef',
       component: <MessageRef element={ element } />,
-      isEdited: selectIsEdited
+      isEdited: isSelectEntryEdited
     }
   ];
 
@@ -64,7 +63,7 @@ export function MessageProps(props) {
       {
         id: 'messageName',
         component: <MessageName element={ element } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       },
     ];
   }
@@ -195,7 +194,7 @@ function MessageName(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'messageName',
     label: translate('Name'),

--- a/src/provider/bpmn/properties/MultiInstanceProps.js
+++ b/src/provider/bpmn/properties/MultiInstanceProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -14,7 +14,7 @@ import {
 } from '../../../utils/ElementUtil';
 
 /**
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').EntryDefinition } Entry
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
 
 /**
@@ -33,12 +33,12 @@ export function MultiInstanceProps(props) {
     {
       id: 'loopCardinality',
       component: <LoopCardinality element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'completionCondition',
       component: <CompletionCondition element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     }
   ];
 
@@ -64,7 +64,7 @@ function LoopCardinality(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'loopCardinality',
     label: translate('Loop cardinality'),
@@ -93,7 +93,7 @@ function CompletionCondition(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'completionCondition',
     label: translate('Completion condition'),

--- a/src/provider/bpmn/properties/NameProps.js
+++ b/src/provider/bpmn/properties/NameProps.js
@@ -7,14 +7,14 @@ import {
   add as collectionAdd
 } from 'diagram-js/lib/util/Collections';
 
-import TextField, { isEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
 } from '../../../hooks';
 
 /**
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').EntryDefinition } Entry
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
 
 /**
@@ -33,7 +33,7 @@ export function NameProps(props) {
     {
       id: 'name',
       component: <Name element={ element } />,
-      isEdited
+      isEdited: isTextFieldEntryEdited
     }
   ];
 }
@@ -109,7 +109,7 @@ function Name(props) {
   }
 
 
-  return TextField(options);
+  return TextFieldEntry(options);
 }
 
 

--- a/src/provider/bpmn/properties/ProcessProps.js
+++ b/src/provider/bpmn/properties/ProcessProps.js
@@ -1,6 +1,6 @@
 import { is } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -11,7 +11,7 @@ import {
 } from '../utils/ValidationUtil';
 
 /**
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').EntryDefinition } Entry
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
 
 /**
@@ -30,12 +30,12 @@ export function ProcessProps(props) {
     {
       id: 'processId',
       component: <ProcessId element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'processName',
       component: <ProcessName element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     }
   ];
 }
@@ -65,7 +65,7 @@ function ProcessName(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'processName',
     label: translate('Process name'),
@@ -104,7 +104,7 @@ function ProcessId(props) {
     return isIdValid(process, value, translate);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'processId',
     label: translate('Process ID'),

--- a/src/provider/bpmn/properties/SignalProps.js
+++ b/src/provider/bpmn/properties/SignalProps.js
@@ -6,9 +6,8 @@ import {
   sortBy
 } from 'min-dash';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isSelectEntryEdited, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 import ReferenceSelect from '../../../entries/ReferenceSelect';
-import { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
 
 import {
   useService
@@ -33,7 +32,7 @@ export const CREATE_NEW_OPTION = 'create-new';
 
 
 /**
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').EntryDefinition } Entry
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
 
 /**
@@ -54,7 +53,7 @@ export function SignalProps(props) {
     {
       id: 'signalRef',
       component: <SignalRef element={ element } />,
-      isEdited: selectIsEdited
+      isEdited: isSelectEntryEdited
     }
   ];
 
@@ -64,7 +63,7 @@ export function SignalProps(props) {
       {
         id: 'signalName',
         component: <SignalName element={ element } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       },
     ];
   }
@@ -195,7 +194,7 @@ function SignalName(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'signalName',
     label: translate('Name'),

--- a/src/provider/bpmn/properties/TimerProps.js
+++ b/src/provider/bpmn/properties/TimerProps.js
@@ -13,12 +13,16 @@ import {
   getTimerDefinitionType
 } from '../utils/EventDefinitionUtil';
 
-import SelectEntry, { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import {
+  SelectEntry,
+  isSelectEntryEdited,
+  TextFieldEntry,
+  isTextFieldEntryEdited
+} from '@bpmn-io/properties-panel';
 
 
 /**
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').EntryDefinition } Entry
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
 
 /**
@@ -53,14 +57,14 @@ export function TimerProps(props) {
   entries.push({
     id: getId(idPrefix, 'timerEventDefinitionType'),
     component: <TimerEventDefinitionType element={ element } timerEventDefinition={ timerEventDefinition } timerEventDefinitionType={ timerEventDefinitionType } />,
-    isEdited: selectIsEdited
+    isEdited: isSelectEntryEdited
   });
 
   if (timerEventDefinitionType) {
     entries.push({
       id: getId(idPrefix, 'timerEventDefinitionValue'),
       component: <TimerEventDefinitionValue element={ element } timerEventDefinition={ timerEventDefinition } timerEventDefinitionType={ timerEventDefinitionType } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     });
   }
 
@@ -145,7 +149,7 @@ function TimerEventDefinitionType(props) {
  * together with timerEventDefinitionType.
  *
  * @param  {type} props
- * @return {TextField}
+ * @return {TextFieldEntry}
  */
 function TimerEventDefinitionValue(props) {
   const {
@@ -174,7 +178,7 @@ function TimerEventDefinitionValue(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'timerEventDefinitionValue',
     label: translate('Value'),

--- a/src/provider/camunda-platform/CamundaPlatformPropertiesProvider.js
+++ b/src/provider/camunda-platform/CamundaPlatformPropertiesProvider.js
@@ -1,5 +1,4 @@
-import Group from '@bpmn-io/properties-panel/lib/components/Group';
-import ListGroup from '@bpmn-io/properties-panel/lib/components/ListGroup';
+import { Group, ListGroup } from '@bpmn-io/properties-panel';
 
 import { findIndex } from 'min-dash';
 

--- a/src/provider/camunda-platform/properties/AsynchronousContinuationsProps.js
+++ b/src/provider/camunda-platform/properties/AsynchronousContinuationsProps.js
@@ -3,9 +3,10 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import Checkbox, {
-  isEdited as checkboxIsEdited
-} from '@bpmn-io/properties-panel/lib/components/entries/Checkbox';
+import {
+  CheckboxEntry,
+  isCheckboxEntryEdited
+} from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -30,12 +31,12 @@ export function AsynchronousContinuationsProps(props) {
       {
         id: 'asynchronousContinuationBefore',
         component: <AsynchronousContinuationBefore element={ element } />,
-        isEdited: checkboxIsEdited
+        isEdited: isCheckboxEntryEdited
       },
       {
         id: 'asynchronousContinuationAfter',
         component: <AsynchronousContinuationAfter element={ element } />,
-        isEdited: checkboxIsEdited
+        isEdited: isCheckboxEntryEdited
       }
     );
 
@@ -81,7 +82,7 @@ function AsynchronousContinuationBefore(props) {
 
   };
 
-  return Checkbox({
+  return CheckboxEntry({
     element,
     id: 'asynchronousContinuationBefore',
     label: translate('Before'),
@@ -112,7 +113,7 @@ function AsynchronousContinuationAfter(props) {
     });
   };
 
-  return Checkbox({
+  return CheckboxEntry({
     element,
     id: 'asynchronousContinuationAfter',
     label: translate('After'),
@@ -143,7 +144,7 @@ function Exclusive(props) {
     });
   };
 
-  return Checkbox({
+  return CheckboxEntry({
     element,
     id: 'exclusive',
     label: translate('Exclusive'),

--- a/src/provider/camunda-platform/properties/BusinessKeyProps.js
+++ b/src/provider/camunda-platform/properties/BusinessKeyProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import Select, { isEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
+import { SelectEntry, isSelectEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   getExtensionElementsList
@@ -29,7 +29,7 @@ export function BusinessKeyProps(props) {
     {
       id: 'businessKey',
       component: <BusinessKey element={ element } />,
-      isEdited
+      isEdited: isSelectEntryEdited
     },
   ];
 }
@@ -78,7 +78,7 @@ function BusinessKey(props) {
     return options;
   };
 
-  return Select({
+  return SelectEntry({
     element,
     id: 'businessKey',
     label: translate('Key'),

--- a/src/provider/camunda-platform/properties/CallActivityProps.js
+++ b/src/provider/camunda-platform/properties/CallActivityProps.js
@@ -15,9 +15,14 @@ import {
   useService
 } from '../../../hooks';
 
-import Checkbox, { isEdited as checkboxIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Checkbox';
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
-import Select, { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
+import {
+  TextFieldEntry,
+  isTextFieldEntryEdited,
+  CheckboxEntry,
+  isCheckboxEntryEdited,
+  SelectEntry,
+  isSelectEntryEdited
+} from '@bpmn-io/properties-panel';
 
 import { CalledBpmnProps } from './CalledBpmnProps';
 import { CalledCmmnProps } from './CalledCmmnProps';
@@ -39,7 +44,7 @@ export function CallActivityProps(props) {
   entries.push({
     id: 'calledElementType',
     component: <CalledElementType element={ element } />,
-    isEdited: selectIsEdited
+    isEdited: isSelectEntryEdited
   });
 
   const calledElementType = getCalledElementType(element);
@@ -107,7 +112,7 @@ function CalledElementType(props) {
     { value: 'cmmn', label: translate('CMMN') }
   ]);
 
-  return <Select
+  return <SelectEntry
     element={ element }
     id="calledElementType"
     label={ translate('Type') }
@@ -124,7 +129,7 @@ function BusinessKeyProps(props) {
     {
       id: 'calledElementBusinessKey',
       component: <BusinessKey element={ element } />,
-      isEdited: checkboxIsEdited
+      isEdited: isCheckboxEntryEdited
     }
   ];
 
@@ -132,7 +137,7 @@ function BusinessKeyProps(props) {
     entries.push({
       id: 'calledElementBusinessKeyExpression',
       component: <BusinessKeyExpression element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     });
   }
 
@@ -212,7 +217,7 @@ function BusinessKey(props) {
     });
   }
 
-  return <Checkbox
+  return <CheckboxEntry
     element={ element }
     id="calledElementBusinessKey"
     label={ translate('Business key') }
@@ -241,7 +246,7 @@ function BusinessKeyExpression(props) {
     });
   };
 
-  return <TextField
+  return <TextFieldEntry
     element={ element }
     id="calledElementBusinessKeyExpression"
     label={ translate('Business key expression') }

--- a/src/provider/camunda-platform/properties/CalledBpmnProps.js
+++ b/src/provider/camunda-platform/properties/CalledBpmnProps.js
@@ -6,8 +6,12 @@ import {
   useService
 } from '../../../hooks';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
-import Select, { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
+import {
+  TextFieldEntry,
+  isTextFieldEntryEdited,
+  SelectEntry,
+  isSelectEntryEdited
+} from '@bpmn-io/properties-panel';
 
 
 /**
@@ -21,17 +25,17 @@ export function CalledBpmnProps(props) {
     {
       id: 'calledElement',
       component: <CalledElement element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'calledElementBinding',
       component: <CalledElementBinding element={ element } />,
-      isEdited: selectIsEdited
+      isEdited: isSelectEntryEdited
     },
     {
       id: 'calledElementTenantId',
       component: <CalledElementTenantId element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     }
   ];
 
@@ -41,7 +45,7 @@ export function CalledBpmnProps(props) {
       {
         id: 'calledElementVersion',
         component: <CalledElementVersion element={ element } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       }
     );
   } else if (binding === 'versionTag') {
@@ -49,7 +53,7 @@ export function CalledBpmnProps(props) {
       {
         id: 'calledElementVersionTag',
         component: <CalledElementVersionTag element={ element } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       }
     );
   }
@@ -72,7 +76,7 @@ function CalledElement(props) {
     modeling.updateProperties(element, { calledElement: value || '' });
   };
 
-  return <TextField
+  return <TextFieldEntry
     element={ element }
     id="calledElement"
     label={ translate('Called element') }
@@ -110,7 +114,7 @@ function CalledElementBinding(props) {
   ]);
 
 
-  return <Select
+  return <SelectEntry
     element={ element }
     id="calledElementBinding"
     label={ translate('Binding') }
@@ -135,7 +139,7 @@ function CalledElementVersion(props) {
     modeling.updateProperties(element, { calledElementVersion: value });
   };
 
-  return <TextField
+  return <TextFieldEntry
     element={ element }
     id="calledElementVersion"
     label={ translate('Version') }
@@ -160,7 +164,7 @@ function CalledElementVersionTag(props) {
     modeling.updateProperties(element, { calledElementVersionTag: value });
   };
 
-  return <TextField
+  return <TextFieldEntry
     element={ element }
     id="calledElementVersionTag"
     label={ translate('Version tag') }
@@ -185,7 +189,7 @@ function CalledElementTenantId(props) {
     modeling.updateProperties(element, { calledElementTenantId: value });
   };
 
-  return <TextField
+  return <TextFieldEntry
     element={ element }
     id="calledElementTenantId"
     label={ translate('Tenant ID') }

--- a/src/provider/camunda-platform/properties/CalledCmmnProps.js
+++ b/src/provider/camunda-platform/properties/CalledCmmnProps.js
@@ -6,8 +6,12 @@ import {
   useService
 } from '../../../hooks';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
-import Select, { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
+import {
+  TextFieldEntry,
+  isTextFieldEntryEdited,
+  SelectEntry,
+  isSelectEntryEdited
+} from '@bpmn-io/properties-panel';
 
 /**
  * Defines entries for calling a CMMN diagram.
@@ -20,17 +24,17 @@ export function CalledCmmnProps(props) {
     {
       id: 'calledElementCaseRef',
       component: <CaseRef element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'calledElementCaseBinding',
       component: <CaseBinding element={ element } />,
-      isEdited: selectIsEdited
+      isEdited: isSelectEntryEdited
     },
     {
       id: 'calledElementCaseTenantId',
       component: <CaseTenantId element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     }
   ];
 
@@ -39,7 +43,7 @@ export function CalledCmmnProps(props) {
       {
         id: 'calledElementCaseVersion',
         component: <CaseVersion element={ element } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       }
     );
   }
@@ -62,7 +66,7 @@ function CaseRef(props) {
     modeling.updateProperties(element, { caseRef: value || '' });
   };
 
-  return <TextField
+  return <TextFieldEntry
     element={ element }
     id="calledElementCaseRef"
     label={ translate('Case ref') }
@@ -98,7 +102,7 @@ function CaseBinding(props) {
   ]);
 
 
-  return <Select
+  return <SelectEntry
     element={ element }
     id="calledElementCaseBinding"
     label={ translate('Binding') }
@@ -123,7 +127,7 @@ function CaseVersion(props) {
     modeling.updateProperties(element, { caseVersion: value });
   };
 
-  return <TextField
+  return <TextFieldEntry
     element={ element }
     id="calledElementCaseVersion"
     label={ translate('Version') }
@@ -148,7 +152,7 @@ function CaseTenantId(props) {
     modeling.updateProperties(element, { caseTenantId: value });
   };
 
-  return <TextField
+  return <TextFieldEntry
     element={ element }
     id="calledElementCaseTenantId"
     label={ translate('Tenant ID') }

--- a/src/provider/camunda-platform/properties/CandidateStarterProps.js
+++ b/src/provider/camunda-platform/properties/CandidateStarterProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -26,12 +26,12 @@ export function CandidateStarterProps(props) {
     {
       id: 'candidateStarterGroups',
       component: <CandidateStarterGroups element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'candidateStarterUsers',
       component: <CandidateStarterUsers element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     }
   ];
 }
@@ -59,7 +59,7 @@ function CandidateStarterGroups(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'candidateStarterGroups',
     label: translate('Candidate starter groups'),
@@ -93,7 +93,7 @@ function CandidateStarterUsers(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'candidateStarterUsers',
     label: translate('Candidate starter users'),

--- a/src/provider/camunda-platform/properties/ConditionProps.js
+++ b/src/provider/camunda-platform/properties/ConditionProps.js
@@ -17,9 +17,14 @@ import {
   useService
 } from '../../../hooks';
 
-import TextArea, { isEdited as textAreaIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextArea';
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
-import Select, { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
+import {
+  TextFieldEntry,
+  isTextFieldEntryEdited,
+  SelectEntry,
+  isSelectEntryEdited,
+  TextAreaEntry,
+  isTextAreaEntryEdited
+} from '@bpmn-io/properties-panel';
 
 /**
  * Defines condition properties for conditional sequence flow.
@@ -40,7 +45,7 @@ export function ConditionProps(props) {
   entries.push({
     id: 'conditionType',
     component: <ConditionType element={ element } />,
-    isEdited: selectIsEdited
+    isEdited: isSelectEntryEdited
   });
 
   const conditionType = getConditionType(element);
@@ -53,7 +58,7 @@ export function ConditionProps(props) {
     entries.push({
       id: 'conditionExpression',
       component: <ConditionExpression element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     });
   }
 
@@ -98,7 +103,7 @@ function ConditionType(props) {
     { value: 'expression', label: translate('Expression') }
   ]);
 
-  return <Select
+  return <SelectEntry
     element={ element }
     id="conditionType"
     label={ translate('Type') }
@@ -135,7 +140,7 @@ function ConditionExpression(props) {
     updateCondition(element, commandStack, conditionExpression);
   };
 
-  return <TextField
+  return <TextFieldEntry
     element={ element }
     id="conditionExpression"
     label={ translate('Condition Expression') }
@@ -155,14 +160,14 @@ function ConditionScriptProps(props) {
   entries.push({
     id: 'conditionScriptLanguage',
     component: <Language element={ element } />,
-    isEdited: textFieldIsEdited
+    isEdited: isTextFieldEntryEdited
   });
 
   // (2) type
   entries.push({
     id: 'conditionScriptType',
     component: <ScriptType element={ element } />,
-    isEdited: selectIsEdited
+    isEdited: isSelectEntryEdited
   });
 
   // (3) script
@@ -170,7 +175,7 @@ function ConditionScriptProps(props) {
     entries.push({
       id: 'conditionScriptValue',
       component: <Script element={ element } />,
-      isEdited: textAreaIsEdited
+      isEdited: isTextAreaEntryEdited
     });
   } else if (scriptType === 'resource') {
 
@@ -178,7 +183,7 @@ function ConditionScriptProps(props) {
     entries.push({
       id: 'conditionScriptResource',
       component: <Resource element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     });
   }
 
@@ -208,7 +213,7 @@ function Language(props) {
     });
   };
 
-  return <TextField
+  return <TextFieldEntry
     element={ element }
     id="conditionScriptLanguage"
     label={ translate('Format') }
@@ -255,7 +260,7 @@ function ScriptType(props) {
     return options;
   };
 
-  return Select({
+  return SelectEntry({
     element,
     id: 'conditionScriptType',
     label: translate('Script type'),
@@ -286,7 +291,7 @@ function Script(props) {
     });
   };
 
-  return <TextArea
+  return <TextAreaEntry
     element={ element }
     id="conditionScriptValue"
     label={ translate('Script') }
@@ -318,7 +323,7 @@ function Resource(props) {
     });
   };
 
-  return <TextField
+  return <TextFieldEntry
     element
     id="conditionScriptResource"
     label={ translate('Resource') }

--- a/src/provider/camunda-platform/properties/DelegateVariableMappingProps.js
+++ b/src/provider/camunda-platform/properties/DelegateVariableMappingProps.js
@@ -1,5 +1,9 @@
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
-import Select, { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
+import {
+  TextFieldEntry,
+  isTextFieldEntryEdited,
+  SelectEntry,
+  isSelectEntryEdited
+} from '@bpmn-io/properties-panel';
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
@@ -14,7 +18,7 @@ export function DelegateVariableMappingProps(props) {
     {
       id: 'calledElementDelegateVariableMappingType',
       component: <DelegateVariableMappingType element={ element } />,
-      isEdited: selectIsEdited
+      isEdited: isSelectEntryEdited
     }
   ];
 
@@ -23,13 +27,13 @@ export function DelegateVariableMappingProps(props) {
     entries.push({
       id: 'calledElementVariableMappingClass',
       component: <VariableMappingClass element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     });
   } else if (type === 'delegateExpression') {
     entries.push({
       id: 'calledElementVariableMappingDelegateExpression',
       component: <VariableMappingDelegateExpression element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     });
   }
 
@@ -71,7 +75,7 @@ function DelegateVariableMappingType(props) {
     { value: 'delegateExpression', label: translate('Delegate expression') }
   ]);
 
-  return <Select
+  return <SelectEntry
     element={ element }
     id="calledElementDelegateVariableMappingType"
     label={ translate('Delegate Variable Mapping') }
@@ -99,7 +103,7 @@ function VariableMappingDelegateExpression(props) {
     });
   };
 
-  return <TextField
+  return <TextFieldEntry
     element={ element }
     id="calledElementVariableMappingDelegateExpression"
     label={ translate('Delegate Expression') }
@@ -127,7 +131,7 @@ function VariableMappingClass(props) {
     });
   };
 
-  return <TextField
+  return <TextFieldEntry
     element={ element }
     id="calledElementVariableMappingClass"
     label={ translate('Delegate Class') }

--- a/src/provider/camunda-platform/properties/DmnImplementationProps.js
+++ b/src/provider/camunda-platform/properties/DmnImplementationProps.js
@@ -2,8 +2,12 @@ import {
   getBusinessObject
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
-import Select, { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
+import {
+  TextFieldEntry,
+  isTextFieldEntryEdited,
+  SelectEntry,
+  isSelectEntryEdited
+} from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -31,7 +35,7 @@ export function DmnImplementationProps(props) {
   entries.push({
     id: 'decisionRef',
     component: <DecisionRef element={ element } />,
-    isEdited: textFieldIsEdited
+    isEdited: isTextFieldEntryEdited
   });
 
 
@@ -39,7 +43,7 @@ export function DmnImplementationProps(props) {
   entries.push({
     id: 'decisionRefBinding',
     component: <Binding element={ element } />,
-    isEdited: selectIsEdited
+    isEdited: isSelectEntryEdited
   });
 
   // (3) version
@@ -47,7 +51,7 @@ export function DmnImplementationProps(props) {
     entries.push({
       id: 'decisionRefVersion',
       component: <Version element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     });
   }
 
@@ -56,7 +60,7 @@ export function DmnImplementationProps(props) {
     entries.push({
       id: 'decisionRefVersionTag',
       component: <VersionTag element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     });
   }
 
@@ -64,14 +68,14 @@ export function DmnImplementationProps(props) {
   entries.push({
     id: 'decisionRefTenantId',
     component: <TenantId element={ element } />,
-    isEdited: textFieldIsEdited
+    isEdited: isTextFieldEntryEdited
   });
 
   // (6) resultVariable
   entries.push({
     id: 'decisionRefResultVariable',
     component: <ResultVariable element={ element } />,
-    isEdited: textFieldIsEdited
+    isEdited: isTextFieldEntryEdited
   });
 
   // (7) mapDecisionResult
@@ -79,7 +83,7 @@ export function DmnImplementationProps(props) {
     entries.push({
       id: 'mapDecisionResult',
       component: <MapDecisionResult element={ element } />,
-      isEdited: selectIsEdited
+      isEdited: isSelectEntryEdited
     });
   }
 
@@ -109,7 +113,7 @@ function DecisionRef(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'decisionRef',
     label: translate('Decision reference'),
@@ -160,7 +164,7 @@ function Binding(props) {
     return options;
   };
 
-  return Select({
+  return SelectEntry({
     element,
     id: 'decisionRefBinding',
     label: translate('Binding'),
@@ -193,7 +197,7 @@ function Version(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'decisionRefVersion',
     label: translate('Version'),
@@ -226,7 +230,7 @@ function VersionTag(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'decisionRefVersionTag',
     label: translate('Version tag'),
@@ -259,7 +263,7 @@ function TenantId(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'decisionRefTenantId',
     label: translate('Tenant ID'),
@@ -294,7 +298,7 @@ function ResultVariable(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'decisionRefResultVariable',
     label: translate('Result variable'),
@@ -339,7 +343,7 @@ function MapDecisionResult(props) {
     return options;
   };
 
-  return Select({
+  return SelectEntry({
     element,
     id: 'mapDecisionResult',
     label: translate('Map decision result'),

--- a/src/provider/camunda-platform/properties/Error.js
+++ b/src/provider/camunda-platform/properties/Error.js
@@ -1,5 +1,4 @@
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
-import { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
+import { TextFieldEntry, isTextFieldEntryEdited, isSelectEntryEdited } from '@bpmn-io/properties-panel';
 
 import ReferenceSelect from '../../../entries/ReferenceSelect';
 
@@ -36,7 +35,7 @@ export default function Error(props) {
   let entries = [{
     id: idPrefix + '-errorRef',
     component: <ErrorRef element={ element } errorEventDefinition={ errorEventDefinition } idPrefix={ idPrefix } />,
-    isEdited: selectIsEdited
+    isEdited: isSelectEntryEdited
   }];
 
   const error = errorEventDefinition.get('errorRef');
@@ -47,17 +46,17 @@ export default function Error(props) {
       {
         id: idPrefix + '-errorName',
         component: <ErrorName element={ element } error={ error } idPrefix={ idPrefix } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       },
       {
         id: idPrefix + '-errorCode',
         component: <ErrorCode element={ element } error={ error } idPrefix={ idPrefix } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       },
       {
         id: idPrefix + '-errorMessage',
         component: <ErrorMessage element={ element } error={ error } idPrefix={ idPrefix } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       }
     ];
   }
@@ -197,7 +196,7 @@ function ErrorName(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: idPrefix + '-errorName',
     label: translate('Name'),
@@ -235,7 +234,7 @@ function ErrorCode(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: idPrefix + '-errorCode',
     label: translate('Code'),
@@ -273,7 +272,7 @@ function ErrorMessage(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: idPrefix + '-errorMessage',
     label: translate('Message'),
@@ -308,7 +307,7 @@ function Expression(props) {
     return errorEventDefinition.get('camunda:expression');
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: errorEventDefinition,
     id: idPrefix + '-expression',
     label: translate('Throw expression'),

--- a/src/provider/camunda-platform/properties/ErrorProps.js
+++ b/src/provider/camunda-platform/properties/ErrorProps.js
@@ -6,7 +6,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -39,7 +39,7 @@ export function ErrorProps(props) {
     entries.splice(idx, 0, {
       id: 'errorMessage',
       component: <ErrorMessage element={ element } />,
-      isEdited
+      isEdited: isTextFieldEntryEdited
     });
   }
 
@@ -53,12 +53,12 @@ export function ErrorProps(props) {
     {
       id: 'errorCodeVariable',
       component: <ErrorCodeVariable element={ element } />,
-      isEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'errorMessageVariable',
       component: <ErrorMessageVariable element={ element } />,
-      isEdited
+      isEdited: isTextFieldEntryEdited
     }
   );
 
@@ -91,7 +91,7 @@ function ErrorMessage(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'errorMessage',
     label: translate('Message'),
@@ -127,7 +127,7 @@ function ErrorCodeVariable(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'errorCodeVariable',
     label: translate('Code variable'),
@@ -164,7 +164,7 @@ function ErrorMessageVariable(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'errorMessageVariable',
     label: translate('Message variable'),

--- a/src/provider/camunda-platform/properties/EscalationProps.js
+++ b/src/provider/camunda-platform/properties/EscalationProps.js
@@ -2,7 +2,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -14,7 +14,7 @@ import {
 } from '../../bpmn/utils/EventDefinitionUtil';
 
 /**
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').EntryDefinition } Entry
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
 
 /**
@@ -34,7 +34,7 @@ export function EscalationProps(props) {
     {
       id: 'escalationCodeVariable',
       component: <EscalationCodeVariable element={ element } />,
-      isEdited
+      isEdited: isTextFieldEntryEdited
     }
   );
 
@@ -67,7 +67,7 @@ function EscalationCodeVariable(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'escalationCodeVariable',
     label: translate('Code variable'),

--- a/src/provider/camunda-platform/properties/ExtensionProperty.js
+++ b/src/provider/camunda-platform/properties/ExtensionProperty.js
@@ -1,4 +1,4 @@
-import TextField from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -49,7 +49,7 @@ function NameProperty(props) {
     return property.name;
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: property,
     id: idPrefix + '-name',
     label: translate('Name'),
@@ -84,7 +84,7 @@ function ValueProperty(props) {
     return property.value;
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: property,
     id: idPrefix + '-value',
     label: translate('Value'),

--- a/src/provider/camunda-platform/properties/ExternalTaskPriorityProps.js
+++ b/src/provider/camunda-platform/properties/ExternalTaskPriorityProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -31,7 +31,7 @@ export function ExternalTaskPriorityProps(props) {
     {
       id: 'externalTaskPriority',
       component: <ExternalTaskPriority element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
   ];
 }
@@ -67,7 +67,7 @@ function ExternalTaskPriority(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'externalTaskPriority',
     label: translate('Priority'),

--- a/src/provider/camunda-platform/properties/FieldInjection.js
+++ b/src/provider/camunda-platform/properties/FieldInjection.js
@@ -1,5 +1,4 @@
-import TextField from '@bpmn-io/properties-panel/lib/components/entries/TextField';
-import SelectEntry from '@bpmn-io/properties-panel/lib/components/entries/Select';
+import { TextFieldEntry, SelectEntry } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -59,7 +58,7 @@ function NameProperty(props) {
     return field.name;
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: field,
     id: idPrefix + '-name',
     label: translate('Name'),
@@ -147,7 +146,7 @@ function ValueProperty(props) {
     return field.string || field.stringValue || field.expression;
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: field,
     id: idPrefix + '-value',
     label: translate('Value'),

--- a/src/provider/camunda-platform/properties/FormField.js
+++ b/src/provider/camunda-platform/properties/FormField.js
@@ -1,7 +1,4 @@
-import CollapsibleEntry from '@bpmn-io/properties-panel/lib/components/entries/Collapsible';
-import ListEntry from '@bpmn-io/properties-panel/lib/components/entries/List';
-import SelectEntry from '@bpmn-io/properties-panel/lib/components/entries/Select';
-import TextField from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { CollapsibleEntry, ListEntry, TextFieldEntry, SelectEntry } from '@bpmn-io/properties-panel';
 
 import FormFieldConstraint from './FormFieldConstraint';
 import FormFieldProperty from './FormFieldProperty';
@@ -95,7 +92,7 @@ function Id(props) {
     return formField.get('id');
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: formField,
     id: idPrefix + '-formFieldID',
     label: translate('ID'),
@@ -131,7 +128,7 @@ function Label(props) {
     return formField.get('label');
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: formField,
     id: idPrefix + '-formFieldLabel',
     label: translate('Label'),
@@ -224,7 +221,7 @@ function CustomType(props) {
     return formField.get('type');
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: formField,
     id: idPrefix + '-formFieldCustomType',
     label: translate('Custom type'),
@@ -259,7 +256,7 @@ function DefaultValue(props) {
     return formField.get('defaultValue');
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: formField,
     id: idPrefix + '-formFieldDefaultValue',
     label: translate('Default value'),

--- a/src/provider/camunda-platform/properties/FormFieldConstraint.js
+++ b/src/provider/camunda-platform/properties/FormFieldConstraint.js
@@ -1,4 +1,4 @@
-import TextField from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -51,7 +51,7 @@ function Name(props) {
     return constraint.name;
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: constraint,
     id: idPrefix + '-name',
     label: translate('Name'),
@@ -86,7 +86,7 @@ function Config(props) {
     return constraint.config;
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: constraint,
     id: idPrefix + '-config',
     label: translate('Config'),

--- a/src/provider/camunda-platform/properties/FormFieldProperty.js
+++ b/src/provider/camunda-platform/properties/FormFieldProperty.js
@@ -1,4 +1,4 @@
-import TextField from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -51,7 +51,7 @@ function Id(props) {
     return property.id;
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: property,
     id: idPrefix + '-id',
     label: translate('ID'),
@@ -86,7 +86,7 @@ function Value(props) {
     return property.value;
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: property,
     id: idPrefix + '-value',
     label: translate('Value'),

--- a/src/provider/camunda-platform/properties/FormFieldValue.js
+++ b/src/provider/camunda-platform/properties/FormFieldValue.js
@@ -1,4 +1,4 @@
-import TextField from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -51,7 +51,7 @@ function Id(props) {
     return value.id;
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: value,
     id: idPrefix + '-id',
     label: translate('ID'),
@@ -86,7 +86,7 @@ function Name(props) {
     return value.name;
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: value,
     id: idPrefix + '-name',
     label: translate('Name'),

--- a/src/provider/camunda-platform/properties/FormProps.js
+++ b/src/provider/camunda-platform/properties/FormProps.js
@@ -1,7 +1,6 @@
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
-import Select, { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited, SelectEntry, isSelectEntryEdited } from '@bpmn-io/properties-panel';
 
 import { FormTypeProps } from './FormTypeProps';
 
@@ -38,24 +37,24 @@ export function FormProps(props) {
     entries.push({
       id: 'formKey',
       component: <FormKey element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     });
   } else if (formType === 'formRef') {
     entries.push({
       id: 'formRef',
       component: <FormRef element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     }, {
       id: 'formRefBinding',
       component: <Binding element={ element } />,
-      isEdited: selectIsEdited
+      isEdited: isSelectEntryEdited
     });
 
     if (bindingType === 'version') {
       entries.push({
         id: 'formRefVersion',
         component: <Version element={ element } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       });
     }
   }
@@ -82,7 +81,7 @@ function FormKey(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'formKey',
     label: translate('Form key'),
@@ -111,7 +110,7 @@ function FormRef(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'formRef',
     label: translate('Form reference'),
@@ -150,7 +149,7 @@ function Binding(props) {
     return options;
   };
 
-  return Select({
+  return SelectEntry({
     element,
     id: 'formRefBinding',
     label: translate('Binding'),
@@ -179,7 +178,7 @@ function Version(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'formRefVersion',
     label: translate('Version'),

--- a/src/provider/camunda-platform/properties/FormTypeProps.js
+++ b/src/provider/camunda-platform/properties/FormTypeProps.js
@@ -2,7 +2,7 @@ import { isDefined } from 'min-dash';
 
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
-import Select, { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
+import { SelectEntry, isSelectEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -27,7 +27,7 @@ export function FormTypeProps(props) {
     {
       id: 'formType',
       component: <FormType element={ element } />,
-      isEdited: selectIsEdited
+      isEdited: isSelectEntryEdited
     }
   ];
 }
@@ -75,7 +75,7 @@ function FormType(props) {
     ];
   };
 
-  return Select({
+  return SelectEntry({
     element,
     id: 'formType',
     label: translate('Type'),

--- a/src/provider/camunda-platform/properties/HistoryCleanupProps.js
+++ b/src/provider/camunda-platform/properties/HistoryCleanupProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -26,7 +26,7 @@ export function HistoryCleanupProps(props) {
     {
       id: 'historyTimeToLive',
       component: <HistoryTimeToLive element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
   ];
 }
@@ -54,7 +54,7 @@ function HistoryTimeToLive(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'historyTimeToLive',
     label: translate('Time to live'),

--- a/src/provider/camunda-platform/properties/ImplementationProps.js
+++ b/src/provider/camunda-platform/properties/ImplementationProps.js
@@ -2,7 +2,7 @@ import {
   getBusinessObject
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import { DmnImplementationProps } from './DmnImplementationProps';
 import { ImplementationTypeProps } from './ImplementationTypeProps';
@@ -42,19 +42,19 @@ export function ImplementationProps(props) {
     entries.push({
       id: 'javaClass',
       component: <JavaClass element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     });
   } else if (implementationType === 'expression') {
     entries.push(
       {
         id: 'expression',
         component: <Expression element={ element } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       },
       {
         id: 'expressionResultVariable',
         component: <ResultVariable element={ element } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       }
     );
   } else if (implementationType === 'delegateExpression') {
@@ -62,7 +62,7 @@ export function ImplementationProps(props) {
       {
         id: 'delegateExpression',
         component: <DelegateExpression element={ element } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       }
     );
   } else if (implementationType === 'dmn') {
@@ -72,7 +72,7 @@ export function ImplementationProps(props) {
       {
         id: 'externalTopic',
         component: <Topic element={ element } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       }
     );
   } else if (implementationType === 'connector') {
@@ -80,7 +80,7 @@ export function ImplementationProps(props) {
       {
         id: 'connectorId',
         component: <ConnectorId element={ element } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       }
     );
   }
@@ -113,7 +113,7 @@ export function JavaClass(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id,
     label: translate('Java class'),
@@ -148,7 +148,7 @@ export function Expression(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id,
     label: translate('Expression'),
@@ -181,7 +181,7 @@ function ResultVariable(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'expressionResultVariable',
     label: translate('Result variable'),
@@ -216,7 +216,7 @@ export function DelegateExpression(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id,
     label: translate('Delegate expression'),
@@ -249,7 +249,7 @@ function Topic(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'externalTopic',
     label: translate('Topic'),
@@ -282,7 +282,7 @@ function ConnectorId(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'connectorId',
     label: translate('Connector ID'),

--- a/src/provider/camunda-platform/properties/ImplementationTypeProps.js
+++ b/src/provider/camunda-platform/properties/ImplementationTypeProps.js
@@ -2,7 +2,7 @@ import {
   sortBy
 } from 'min-dash';
 
-import Select, { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
+import { SelectEntry, isSelectEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -54,7 +54,7 @@ export function ImplementationTypeProps(props) {
     {
       id: 'implementationType',
       component: <ImplementationType element={ element } />,
-      isEdited: selectIsEdited
+      isEdited: isSelectEntryEdited
     },
   ];
 }
@@ -191,7 +191,7 @@ function ImplementationType(props) {
     return sortByName(options);
   };
 
-  return Select({
+  return SelectEntry({
     element,
     id: 'implementationType',
     label: translate('Type'),

--- a/src/provider/camunda-platform/properties/InMappingPropagationProps.js
+++ b/src/provider/camunda-platform/properties/InMappingPropagationProps.js
@@ -1,4 +1,4 @@
-import Checkbox, { isEdited as checkboxIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Checkbox';
+import { CheckboxEntry, isCheckboxEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   isAny
@@ -46,7 +46,7 @@ export function InMappingPropagationProps(props) {
     {
       id: 'inMapping-propagation',
       component: <PropagateAll element={ element } />,
-      isEdited: checkboxIsEdited
+      isEdited: isCheckboxEntryEdited
     }
   ];
 
@@ -54,7 +54,7 @@ export function InMappingPropagationProps(props) {
     entries.push({
       id: 'inMapping-propagation-local',
       component: <Local element={ element } />,
-      isEdited: checkboxIsEdited
+      isEdited: isCheckboxEntryEdited
     });
   }
 
@@ -145,7 +145,7 @@ function PropagateAll(props) {
     });
   }
 
-  return Checkbox({
+  return CheckboxEntry({
     id: 'inMapping-propagation',
     label: translate('Propagate all variables'),
     getValue,
@@ -177,7 +177,7 @@ function Local(props) {
     });
   };
 
-  return Checkbox({
+  return CheckboxEntry({
     element,
     id: 'inMapping-propagation-local',
     label: translate('Local'),

--- a/src/provider/camunda-platform/properties/InOutMapping.js
+++ b/src/provider/camunda-platform/properties/InOutMapping.js
@@ -1,6 +1,4 @@
-import Checkbox from '@bpmn-io/properties-panel/lib/components/entries/Checkbox';
-import Select from '@bpmn-io/properties-panel/lib/components/entries/Select';
-import TextField from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { CheckboxEntry, SelectEntry, TextFieldEntry } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -102,7 +100,7 @@ function Type(props) {
     return options;
   };
 
-  return Select({
+  return SelectEntry({
     element: mapping,
     id: idPrefix + '-type',
     label: translate('Type'),
@@ -137,7 +135,7 @@ function Source(props) {
     return mapping.get('camunda:source');
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: mapping,
     id: idPrefix + '-source',
     label: translate('Source'),
@@ -172,7 +170,7 @@ function SourceExpression(props) {
     return mapping.get('camunda:sourceExpression');
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: mapping,
     id: idPrefix + '-sourceExpression',
     label: translate('Source expression'),
@@ -207,7 +205,7 @@ function Target(props) {
     return mapping.get('camunda:target');
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: mapping,
     id: idPrefix + '-target',
     label: translate('Target'),
@@ -241,7 +239,7 @@ function Local(props) {
     });
   };
 
-  return Checkbox({
+  return CheckboxEntry({
     element,
     id: idPrefix + '-local',
     label: translate('Local'),

--- a/src/provider/camunda-platform/properties/InitiatorProps.js
+++ b/src/provider/camunda-platform/properties/InitiatorProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -23,7 +23,7 @@ export function InitiatorProps(props) {
     {
       id: 'initiator',
       component: <Initiator element={ element } />,
-      isEdited
+      isEdited: isTextFieldEntryEdited
     },
   ];
 }
@@ -51,7 +51,7 @@ function Initiator(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'initiator',
     label: translate('Initiator'),

--- a/src/provider/camunda-platform/properties/InputOutputParameter.js
+++ b/src/provider/camunda-platform/properties/InputOutputParameter.js
@@ -2,9 +2,14 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextArea, { isEdited as textAreaIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextArea';
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
-import Select, { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
+import {
+  SelectEntry,
+  isSelectEntryEdited,
+  TextFieldEntry,
+  isTextFieldEntryEdited,
+  TextAreaEntry,
+  isTextAreaEntryEdited
+} from '@bpmn-io/properties-panel';
 
 import {
   ScriptProps
@@ -49,12 +54,12 @@ export default function InputOutputParameter(props) {
     {
       id: idPrefix + '-name',
       component: <Name idPrefix={ idPrefix } element={ element } parameter={ parameter } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: idPrefix + '-type',
       component: <Type idPrefix={ idPrefix } element={ element } parameter={ parameter } />,
-      isEdited: selectIsEdited
+      isEdited: isSelectEntryEdited
     }
   ];
 
@@ -64,7 +69,7 @@ export default function InputOutputParameter(props) {
     entries.push({
       id: idPrefix + '-stringOrExpression',
       component: <StringOrExpression idPrefix={ idPrefix } element={ element } parameter={ parameter } />,
-      isEdited: textAreaIsEdited
+      isEdited: isTextAreaEntryEdited
     });
 
   // (2) Script
@@ -119,7 +124,7 @@ function Name(props) {
     return parameter.get('name');
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: parameter,
     id: idPrefix + '-name',
     label: translate(isInput(parameter) ? 'Local variable name' : 'Process variable name'),
@@ -181,7 +186,7 @@ function Type(props) {
     return options;
   };
 
-  return Select({
+  return SelectEntry({
     element: parameter,
     id: idPrefix + '-type',
     label: translate('Assignment type'),
@@ -216,7 +221,7 @@ function StringOrExpression(props) {
     return parameter.get('value');
   };
 
-  return TextArea({
+  return TextAreaEntry({
     element: parameter,
     id: idPrefix + '-stringOrExpression',
     label: translate('Value'),

--- a/src/provider/camunda-platform/properties/JobExecutionProps.js
+++ b/src/provider/camunda-platform/properties/JobExecutionProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -38,7 +38,7 @@ export function JobExecutionProps(props) {
     entries.push({
       id: 'retryTimeCycle',
       component: <RetryTimeCycle element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     });
   }
 
@@ -53,7 +53,7 @@ export function JobExecutionProps(props) {
     entries.push({
       id: 'jobPriority',
       component: <JobPriority element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     });
   }
 
@@ -85,7 +85,7 @@ function JobPriority(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'jobPriority',
     label: translate('Priority'),
@@ -170,7 +170,7 @@ function RetryTimeCycle(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'retryTimeCycle',
     label: translate('Retry time cycle'),

--- a/src/provider/camunda-platform/properties/ListProps.js
+++ b/src/provider/camunda-platform/properties/ListProps.js
@@ -1,5 +1,4 @@
-import List from '@bpmn-io/properties-panel/lib/components/entries/List';
-import Simple from '@bpmn-io/properties-panel/lib/components/entries/Simple';
+import { ListEntry, SimpleEntry } from '@bpmn-io/properties-panel';
 
 import {
   is
@@ -64,7 +63,7 @@ export function ListProps(props) {
     return value === anotherValue ? 0 : value > anotherValue ? 1 : -1;
   }
 
-  return List({
+  return ListEntry({
     element,
     autoFocusEntry: true,
     compareFn,
@@ -130,7 +129,7 @@ function ListValue(props) {
   const debounce = useService('debounceInput', true);
 
   return (
-    <Simple
+    <SimpleEntry
       id={ id }
       getValue={ getValue }
       setValue={ setValue }

--- a/src/provider/camunda-platform/properties/ListenerProps.js
+++ b/src/provider/camunda-platform/properties/ListenerProps.js
@@ -1,7 +1,10 @@
-import ListEntry from '@bpmn-io/properties-panel/lib/components/entries/List';
-import CollapsibleEntry from '@bpmn-io/properties-panel/lib/components/entries/Collapsible';
-import SelectEntry from '@bpmn-io/properties-panel/lib/components/entries/Select';
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import {
+  CollapsibleEntry,
+  ListEntry,
+  SelectEntry,
+  TextFieldEntry,
+  isTextFieldEntryEdited
+} from '@bpmn-io/properties-panel';
 
 
 import { isAny } from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
@@ -290,7 +293,7 @@ function ListenerId({ id, element, listener }) {
     id: id,
     label: translate('Listener ID'),
     debounce,
-    isEdited: textFieldIsEdited,
+    isEdited: isTextFieldEntryEdited,
     setValue: (value) => {
       commandStack.execute('properties-panel.update-businessobject', {
         element: element,
@@ -305,7 +308,7 @@ function ListenerId({ id, element, listener }) {
     }
   };
 
-  return TextField(options);
+  return TextFieldEntry(options);
 }
 
 function ListenerType({ id, element, listener }) {

--- a/src/provider/camunda-platform/properties/MapProps.js
+++ b/src/provider/camunda-platform/properties/MapProps.js
@@ -1,6 +1,4 @@
-import Collapsible from '@bpmn-io/properties-panel/lib/components/entries/Collapsible';
-import List from '@bpmn-io/properties-panel/lib/components/entries/List';
-import TextField from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { CollapsibleEntry, ListEntry, TextFieldEntry } from '@bpmn-io/properties-panel';
 
 import {
   is
@@ -32,7 +30,7 @@ export function MapProps(props) {
     const entryId = `${idPrefix}-mapEntry-${index}`;
 
     return (
-      <Collapsible
+      <CollapsibleEntry
         id={ entryId }
         entries={ MapEntry({ idPrefix: entryId, element, entry }) }
         label={ entry.get('key') || translate('<empty>') }
@@ -65,7 +63,7 @@ export function MapProps(props) {
     return key === anotherKey ? 0 : key > anotherKey ? 1 : -1;
   }
 
-  return List({
+  return ListEntry({
     element,
     autoFocusEntry: true,
     compareFn,
@@ -121,7 +119,7 @@ function MapKey(props) {
     return entry.get('key');
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: entry,
     id: idPrefix + '-key',
     label: translate('Key'),
@@ -167,7 +165,7 @@ function MapValue(props) {
     return entry.get('value');
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: entry,
     id: idPrefix + '-value',
     label: translate('Value'),

--- a/src/provider/camunda-platform/properties/MultiInstanceProps.js
+++ b/src/provider/camunda-platform/properties/MultiInstanceProps.js
@@ -3,8 +3,12 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
-import Checkbox, { isEdited as checkboxIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Checkbox';
+import {
+  TextFieldEntry,
+  isTextFieldEntryEdited,
+  CheckboxEntry,
+  isCheckboxEntryEdited
+} from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -20,7 +24,7 @@ import {
 
 
 /**
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').EntryDefinition } Entry
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
 
 /**
@@ -43,22 +47,22 @@ export function MultiInstanceProps(props) {
     {
       id: 'collection',
       component: <Collection element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'elementVariable',
       component: <ElementVariable element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'multiInstanceAsynchronousBefore',
       component: <MultiInstanceAsynchronousBefore element={ element } />,
-      isEdited: checkboxIsEdited
+      isEdited: isCheckboxEntryEdited
     },
     {
       id: 'multiInstanceAsynchronousAfter',
       component: <MultiInstanceAsynchronousAfter element={ element } />,
-      isEdited: checkboxIsEdited
+      isEdited: isCheckboxEntryEdited
     });
 
   if (isAsync(loopCharacteristics)) {
@@ -71,7 +75,7 @@ export function MultiInstanceProps(props) {
       {
         id: 'multiInstanceRetryTimeCycle',
         component: <MultiInstanceRetryTimeCycle element={ element } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       }
     );
   }
@@ -105,7 +109,7 @@ function Collection(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'collection',
     label: translate('Collection'),
@@ -141,7 +145,7 @@ function ElementVariable(props) {
     );
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'elementVariable',
     label: translate('Element variable'),
@@ -178,7 +182,7 @@ function MultiInstanceAsynchronousBefore(props) {
     });
   };
 
-  return Checkbox({
+  return CheckboxEntry({
     element,
     id: 'multiInstanceAsynchronousBefore',
     label: translate('Asynchronous before'),
@@ -209,7 +213,7 @@ function MultiInstanceAsynchronousAfter(props) {
     });
   };
 
-  return Checkbox({
+  return CheckboxEntry({
     element,
     id: 'multiInstanceAsynchronousAfter',
     label: translate('Asynchronous after'),
@@ -240,7 +244,7 @@ function MultiInstanceExclusive(props) {
     });
   };
 
-  return Checkbox({
+  return CheckboxEntry({
     element,
     id: 'multiInstanceExclusive',
     label: translate('Exclusive'),
@@ -326,7 +330,7 @@ function MultiInstanceRetryTimeCycle(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'multiInstanceRetryTimeCycle',
     label: translate('Retry time cycle'),

--- a/src/provider/camunda-platform/properties/OutMappingPropagationProps.js
+++ b/src/provider/camunda-platform/properties/OutMappingPropagationProps.js
@@ -1,4 +1,4 @@
-import Checkbox, { isEdited as checkboxIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Checkbox';
+import { CheckboxEntry, isCheckboxEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   getBusinessObject,
@@ -38,7 +38,7 @@ export function OutMappingPropagationProps(props) {
     {
       id: 'outMapping-propagation',
       component: <PropagateAll element={ element } />,
-      isEdited: checkboxIsEdited
+      isEdited: isCheckboxEntryEdited
     }
   ];
 
@@ -46,7 +46,7 @@ export function OutMappingPropagationProps(props) {
     entries.push({
       id: 'outMapping-propagation-local',
       component: <Local element={ element } />,
-      isEdited: checkboxIsEdited
+      isEdited: isCheckboxEntryEdited
     });
   }
 
@@ -137,7 +137,7 @@ function PropagateAll(props) {
     });
   }
 
-  return Checkbox({
+  return CheckboxEntry({
     id: 'outMapping-propagation',
     label: translate('Propagate all variables'),
     getValue,
@@ -169,7 +169,7 @@ function Local(props) {
     });
   };
 
-  return Checkbox({
+  return CheckboxEntry({
     element,
     id: 'outMapping-propagation-local',
     label: translate('Local'),

--- a/src/provider/camunda-platform/properties/ScriptProps.js
+++ b/src/provider/camunda-platform/properties/ScriptProps.js
@@ -3,9 +3,14 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextArea, { isEdited as textAreaIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextArea';
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
-import Select, { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
+import {
+  TextAreaEntry,
+  isTextAreaEntryEdited,
+  TextFieldEntry,
+  isTextFieldEntryEdited,
+  SelectEntry,
+  isSelectEntryEdited
+} from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -30,7 +35,7 @@ export function ScriptProps(props) {
   entries.push({
     id: idPrefix + 'scriptFormat',
     component: <Format element={ element } idPrefix={ idPrefix } script={ script } />,
-    isEdited: textFieldIsEdited
+    isEdited: isTextFieldEntryEdited
   });
 
 
@@ -38,7 +43,7 @@ export function ScriptProps(props) {
   entries.push({
     id: idPrefix + 'scriptType',
     component: <Type element={ element } idPrefix={ idPrefix } script={ script } />,
-    isEdited: selectIsEdited
+    isEdited: isSelectEntryEdited
   });
 
   // (3) script
@@ -46,7 +51,7 @@ export function ScriptProps(props) {
     entries.push({
       id: idPrefix + 'scriptValue',
       component: <Script element={ element } idPrefix={ idPrefix } script={ script } />,
-      isEdited: textAreaIsEdited
+      isEdited: isTextAreaEntryEdited
     });
   }
 
@@ -55,7 +60,7 @@ export function ScriptProps(props) {
     entries.push({
       id: idPrefix + 'scriptResource',
       component: <Resource element={ element } idPrefix={ idPrefix } script={ script } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     });
   }
 
@@ -89,7 +94,7 @@ function Format(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: idPrefix + 'scriptFormat',
     label: translate('Format'),
@@ -142,7 +147,7 @@ function Type(props) {
     return options;
   };
 
-  return Select({
+  return SelectEntry({
     element,
     id: idPrefix + 'scriptType',
     label: translate('Type'),
@@ -180,7 +185,7 @@ function Script(props) {
     });
   };
 
-  return TextArea({
+  return TextAreaEntry({
     element,
     id: idPrefix + 'scriptValue',
     label: translate('Script'),
@@ -218,7 +223,7 @@ function Resource(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: idPrefix + 'scriptResource',
     label: translate('Resource'),

--- a/src/provider/camunda-platform/properties/ScriptTaskProps.js
+++ b/src/provider/camunda-platform/properties/ScriptTaskProps.js
@@ -3,7 +3,7 @@ import {
   getBusinessObject
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -30,7 +30,7 @@ export function ScriptTaskProps(props) {
   entries.push({
     id: 'scriptResultVariable',
     component: <ResultVariable element={ element } />,
-    isEdited: textFieldIsEdited
+    isEdited: isTextFieldEntryEdited
   });
 
   return entries;
@@ -60,7 +60,7 @@ function ResultVariable(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'scriptResultVariable',
     label: translate('Result variable'),

--- a/src/provider/camunda-platform/properties/TasklistProps.js
+++ b/src/provider/camunda-platform/properties/TasklistProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import Checkbox from '@bpmn-io/properties-panel/lib/components/entries/Checkbox';
+import { CheckboxEntry } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -57,7 +57,7 @@ function Startable(props) {
     });
   };
 
-  return Checkbox({
+  return CheckboxEntry({
     element,
     id: 'isStartableInTasklist',
     label: translate('Startable'),

--- a/src/provider/camunda-platform/properties/UserAssignmentProps.js
+++ b/src/provider/camunda-platform/properties/UserAssignmentProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -25,32 +25,32 @@ export function UserAssignmentProps(props) {
     {
       id: 'assignee',
       component: <Assignee element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'candidateGroups',
       component: <CandidateGroups element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'candidateUsers',
       component: <CandidateUsers element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'dueDate',
       component: <DueDate element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'followUpDate',
       component: <FollowUpDate element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'priority',
       component: <Priority element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     }
   ];
 }
@@ -78,7 +78,7 @@ function Assignee(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'assignee',
     label: translate('Assignee'),
@@ -111,7 +111,7 @@ function CandidateUsers(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'candidateUsers',
     label: translate('Candidate users'),
@@ -144,7 +144,7 @@ function CandidateGroups(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'candidateGroups',
     label: translate('Candidate groups'),
@@ -177,7 +177,7 @@ function DueDate(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'dueDate',
     label: translate('Due date'),
@@ -211,7 +211,7 @@ function FollowUpDate(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'followUpDate',
     label: translate('Follow up date'),
@@ -246,7 +246,7 @@ function Priority(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'priority',
     label: translate('Priority'),

--- a/src/provider/camunda-platform/properties/VersionTagProps.js
+++ b/src/provider/camunda-platform/properties/VersionTagProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -26,7 +26,7 @@ export function VersionTagProps(props) {
     {
       id: 'versionTag',
       component: <VersionTag element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
   ];
 }
@@ -54,7 +54,7 @@ function VersionTag(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'versionTag',
     label: translate('Version tag'),

--- a/src/provider/element-templates/ElementTemplatesPropertiesProvider.js
+++ b/src/provider/element-templates/ElementTemplatesPropertiesProvider.js
@@ -1,6 +1,6 @@
 import { isAny } from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
 
-import ListGroup from '@bpmn-io/properties-panel/lib/components/ListGroup';
+import { ListGroup } from '@bpmn-io/properties-panel';
 
 import {
   ElementTemplatesGroup,

--- a/src/provider/element-templates/components/ElementTemplatesGroup.js
+++ b/src/provider/element-templates/components/ElementTemplatesGroup.js
@@ -1,11 +1,10 @@
 import {
   ArrowIcon,
-  CreateIcon
-} from '@bpmn-io/properties-panel/lib/components/icons';
-
-import { useLayoutState } from '@bpmn-io/properties-panel/lib/hooks';
-import { DropdownButton } from '@bpmn-io/properties-panel/lib/components/DropdownButton';
-import { HeaderButton } from '@bpmn-io/properties-panel/lib/components/HeaderButton';
+  CreateIcon,
+  DropdownButton,
+  HeaderButton,
+  useLayoutState
+} from '@bpmn-io/properties-panel';
 
 import classnames from 'classnames';
 
@@ -116,7 +115,7 @@ function TemplateGroupButtons({ element }) {
   const templateState = getTemplateState(elementTemplates, element);
 
   if (templateState.type === 'NO_TEMPLATE') {
-    return <SelectTemplate element={ element } />;
+    return <SelectEntryTemplate element={ element } />;
   } else if (templateState.type === 'KNOWN_TEMPLATE') {
     return <AppliedTemplate element={ element } />;
   } else if (templateState.type === 'UNKNOWN_TEMPLATE') {
@@ -126,7 +125,7 @@ function TemplateGroupButtons({ element }) {
   }
 }
 
-function SelectTemplate({ element }) {
+function SelectEntryTemplate({ element }) {
   const translate = useService('translate');
   const eventBus = useService('eventBus');
 
@@ -134,7 +133,7 @@ function SelectTemplate({ element }) {
 
   return (
     <HeaderButton
-      title="Select a template"
+      title="SelectEntry a template"
       class="bio-properties-panel-select-template-button"
       onClick={ selectTemplate }
     >

--- a/src/provider/element-templates/properties/CustomProperties.js
+++ b/src/provider/element-templates/properties/CustomProperties.js
@@ -8,12 +8,13 @@ import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
 import { useService } from '../../../hooks';
 
-import Group from '@bpmn-io/properties-panel/lib/components/Group';
-
-import Checkbox, { isEdited as checkboxIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Checkbox';
-import Select, { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
-import TextArea, { isEdited as textAreaIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextArea';
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import {
+  Group,
+  SelectEntry, isSelectEntryEdited,
+  CheckboxEntry, isCheckboxEntryEdited,
+  TextAreaEntry, isTextAreaEntryEdited,
+  TextFieldEntry, isTextFieldEntryEdited
+} from '@bpmn-io/properties-panel';
 
 import {
   findCamundaErrorEventDefinition,
@@ -155,7 +156,7 @@ function createCustomEntry(id, element, property, scope) {
     return {
       id,
       component: <BooleanProperty element={ element } id={ id } property={ property } scope={ scope } />,
-      isEdited: checkboxIsEdited
+      isEdited: isCheckboxEntryEdited
     };
   }
 
@@ -163,7 +164,7 @@ function createCustomEntry(id, element, property, scope) {
     return {
       id,
       component: <DropdownProperty element={ element } id={ id } property={ property } scope={ scope } />,
-      isEdited: selectIsEdited
+      isEdited: isSelectEntryEdited
     };
   }
 
@@ -171,7 +172,7 @@ function createCustomEntry(id, element, property, scope) {
     return {
       id,
       component: <StringProperty element={ element } id={ id } property={ property } scope={ scope } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     };
   }
 
@@ -179,7 +180,7 @@ function createCustomEntry(id, element, property, scope) {
     return {
       id,
       component: <TextAreaProperty element={ element } id={ id } property={ property } scope={ scope } />,
-      isEdited: textAreaIsEdited
+      isEdited: isTextAreaEntryEdited
     };
   }
 }
@@ -222,7 +223,7 @@ function BooleanProperty(props) {
   const bpmnFactory = useService('bpmnFactory'),
         commandStack = useService('commandStack');
 
-  return Checkbox({
+  return CheckboxEntry({
     element,
     getValue: propertyGetter(element, property, scope),
     id,
@@ -261,7 +262,7 @@ function DropdownProperty(props) {
     });
   };
 
-  return Select({
+  return SelectEntry({
     element,
     id,
     label,
@@ -292,7 +293,7 @@ function StringProperty(props) {
         debounce = useService('debounceInput'),
         translate = useService('translate');
 
-  return TextField({
+  return TextFieldEntry({
     debounce,
     element,
     getValue: propertyGetter(element, property, scope),
@@ -323,7 +324,7 @@ function TextAreaProperty(props) {
         commandStack = useService('commandStack'),
         debounce = useService('debounceInput');
 
-  return TextArea({
+  return TextAreaEntry({
     debounce,
     element,
     id,

--- a/src/provider/element-templates/properties/ErrorProperties.js
+++ b/src/provider/element-templates/properties/ErrorProperties.js
@@ -2,7 +2,7 @@ import { without } from 'min-dash';
 
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry } from '@bpmn-io/properties-panel';
 
 import Error from '../../camunda-platform/properties/Error';
 import { getErrorLabel } from '../../camunda-platform/properties/ErrorsProps';
@@ -88,7 +88,7 @@ function Expression(props) {
     return errorEventDefinition.get('camunda:expression');
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: errorEventDefinition,
     id,
     label: translate('Throw expression'),

--- a/src/provider/element-templates/properties/InputProperties.js
+++ b/src/provider/element-templates/properties/InputProperties.js
@@ -1,6 +1,6 @@
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
-import ToggleSwitch from '@bpmn-io/properties-panel/lib/components/entries/ToggleSwitch';
+import { ToggleSwitchEntry } from '@bpmn-io/properties-panel';
 
 import InputOutputParameter from '../../camunda-platform/properties/InputOutputParameter';
 
@@ -119,7 +119,7 @@ function LocalVariableAssignment(props) {
     }
   };
 
-  return ToggleSwitch({
+  return ToggleSwitchEntry({
     id,
     label: translate('Local variable assignment'),
     switcherLabel: inputParameter ?

--- a/src/provider/element-templates/properties/OutputProperties.js
+++ b/src/provider/element-templates/properties/OutputProperties.js
@@ -1,7 +1,6 @@
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField from '@bpmn-io/properties-panel/lib/components/entries/TextField';
-import ToggleSwitch from '@bpmn-io/properties-panel/lib/components/entries/ToggleSwitch';
+import { TextFieldEntry, ToggleSwitchEntry } from '@bpmn-io/properties-panel';
 
 import { containsSpace } from '../../bpmn/utils/ValidationUtil';
 
@@ -120,7 +119,7 @@ function ProcessVariableAssignment(props) {
     }
   };
 
-  return ToggleSwitch({
+  return ToggleSwitchEntry({
     id,
     label: translate('Process variable assignment'),
     switcherLabel: outputParameter ?
@@ -170,7 +169,7 @@ function AssignToProcessVariable(props) {
     }
   };
 
-  return TextField({
+  return TextFieldEntry({
     debounce,
     element: outputParameter,
     id,

--- a/src/provider/zeebe/ZeebePropertiesProvider.js
+++ b/src/provider/zeebe/ZeebePropertiesProvider.js
@@ -1,5 +1,4 @@
-import Group from '@bpmn-io/properties-panel/lib/components/Group';
-import ListGroup from '@bpmn-io/properties-panel/lib/components/ListGroup';
+import { Group, ListGroup } from '@bpmn-io/properties-panel';
 
 import {
   AssignmentDefinitionProps,

--- a/src/provider/zeebe/properties/AssignmentDefinitionProps.js
+++ b/src/provider/zeebe/properties/AssignmentDefinitionProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   getExtensionElementsList
@@ -31,12 +31,12 @@ export function AssignmentDefinitionProps(props) {
     {
       id: 'assignmentDefinitionAssignee',
       component: <Assignee element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'assignmentDefinitionCandidateGroups',
       component: <CandidateGroups element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     }
   ];
 }
@@ -117,7 +117,7 @@ function Assignee(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'assignmentDefinitionAssignee',
     label: translate('Assignee'),
@@ -202,7 +202,7 @@ function CandidateGroups(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'assignmentDefinitionCandidateGroups',
     label: translate('Candidate groups'),

--- a/src/provider/zeebe/properties/BusinessRuleImplementationProps.js
+++ b/src/provider/zeebe/properties/BusinessRuleImplementationProps.js
@@ -6,7 +6,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import Select from '@bpmn-io/properties-panel/lib/components/entries/Select';
+import { SelectEntry } from '@bpmn-io/properties-panel';
 
 import {
   getExtensionElementsList
@@ -139,7 +139,7 @@ function BusinessRuleImplementation(props) {
     return options;
   };
 
-  return Select({
+  return SelectEntry({
     element,
     id: 'businessRuleImplementation',
     label: translate('Implementation'),

--- a/src/provider/zeebe/properties/CalledDecisionProps.js
+++ b/src/provider/zeebe/properties/CalledDecisionProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   getExtensionElementsList
@@ -37,12 +37,12 @@ export function CalledDecisionProps(props) {
     {
       id: 'decisionId',
       component: <DecisionID element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'resultVariable',
       component: <ResultVariable element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     }
   ];
 }
@@ -123,7 +123,7 @@ function DecisionID(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'decisionId',
     label: translate('ID'),
@@ -209,7 +209,7 @@ function ResultVariable(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'resultVariable',
     label: translate('Result variable'),

--- a/src/provider/zeebe/properties/ConditionProps.js
+++ b/src/provider/zeebe/properties/ConditionProps.js
@@ -15,7 +15,7 @@ import {
   useService
 } from '../../../hooks';
 
-import TextField, { isEdited as defaultIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 
 export function ConditionProps(props) {
@@ -33,7 +33,7 @@ export function ConditionProps(props) {
     conditionProps.push({
       id: 'conditionExpression',
       component: <ConditionExpression element={ element } />,
-      isEdited: defaultIsEdited
+      isEdited: isTextFieldEntryEdited
     });
   }
 
@@ -100,7 +100,7 @@ function ConditionExpression(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'conditionExpression',
     label: translate('Condition expression'),

--- a/src/provider/zeebe/properties/FormProps.js
+++ b/src/provider/zeebe/properties/FormProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextArea, { isEdited as defaultIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextArea';
+import { TextAreaEntry, isTextAreaEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   createElement
@@ -39,7 +39,7 @@ export function FormProps(props) {
     {
       id: 'formConfiguration',
       component: <FormProperty element={ element } />,
-      isEdited: defaultIsEdited
+      isEdited: isTextAreaEntryEdited
     }
   ];
 }
@@ -60,7 +60,7 @@ function FormProperty(props) {
 
   const setValue = (value) => formHelper.set(element, value);
 
-  return TextArea({
+  return TextAreaEntry({
     element,
     id: 'formConfiguration',
     label: translate('Form JSON configuration'),

--- a/src/provider/zeebe/properties/Header.js
+++ b/src/provider/zeebe/properties/Header.js
@@ -1,4 +1,4 @@
-import TextField from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -49,7 +49,7 @@ function KeyProperty(props) {
     return header.key;
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: header,
     id: idPrefix + '-key',
     label: translate('Key'),
@@ -84,7 +84,7 @@ function ValueProperty(props) {
     return header.value;
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: header,
     id: idPrefix + '-value',
     label: translate('Value'),

--- a/src/provider/zeebe/properties/InputOutputParameter.js
+++ b/src/provider/zeebe/properties/InputOutputParameter.js
@@ -2,7 +2,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -53,7 +53,7 @@ function TargetProperty(props) {
     return parameter.target;
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: parameter,
     id: idPrefix + '-target',
     label: translate((is(parameter, 'zeebe:Input') ? 'Local variable name' : 'Process variable name')),
@@ -88,7 +88,7 @@ function SourceProperty(props) {
     return parameter.source;
   };
 
-  return TextField({
+  return TextFieldEntry({
     element: parameter,
     id: idPrefix + '-source',
     label: translate('Variable assignment value'),

--- a/src/provider/zeebe/properties/MessageProps.js
+++ b/src/provider/zeebe/properties/MessageProps.js
@@ -6,7 +6,7 @@ import {
   isEventSubProcess
 } from 'bpmn-js/lib/util/DiUtil';
 
-import TextField, { isEdited as defaultIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -40,7 +40,7 @@ export function MessageProps(props) {
     {
       id: 'messageSubscriptionCorrelationKey',
       component: <SubscriptionCorrelationKey element={ element } />,
-      isEdited: defaultIsEdited
+      isEdited: isTextFieldEntryEdited
     },
   ];
 
@@ -121,7 +121,7 @@ function SubscriptionCorrelationKey(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'messageSubscriptionCorrelationKey',
     label: translate('Subscription correlation key'),

--- a/src/provider/zeebe/properties/MultiInstanceProps.js
+++ b/src/provider/zeebe/properties/MultiInstanceProps.js
@@ -2,7 +2,7 @@ import {
   getBusinessObject
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited as defaultIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   getExtensionElementsList
@@ -30,22 +30,22 @@ export function MultiInstanceProps(props) {
     {
       id: 'multiInstance-inputCollection',
       component: <InputCollection element={ element } />,
-      isEdited: defaultIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'multiInstance-inputElement',
       component: <InputElement element={ element } />,
-      isEdited: defaultIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'multiInstance-outputCollection',
       component: <OutputCollection element={ element } />,
-      isEdited: defaultIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'multiInstance-outputElement',
       component: <OutputElement element={ element } />,
-      isEdited: defaultIsEdited
+      isEdited: isTextFieldEntryEdited
     }
   ];
 }
@@ -68,7 +68,7 @@ function InputCollection(props) {
     return setProperty(element, 'inputCollection', value, commandStack, bpmnFactory);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'multiInstance-inputCollection',
     label: translate('Input collection'),
@@ -96,7 +96,7 @@ function InputElement(props) {
     return setProperty(element, 'inputElement', value, commandStack, bpmnFactory);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'multiInstance-inputElement',
     label: translate('Input element'),
@@ -124,7 +124,7 @@ function OutputCollection(props) {
     return setProperty(element, 'outputCollection', value, commandStack, bpmnFactory);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'multiInstance-outputCollection',
     label: translate('Output collection'),
@@ -152,7 +152,7 @@ function OutputElement(props) {
     return setProperty(element, 'outputElement', value, commandStack, bpmnFactory);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'multiInstance-outputElement',
     label: translate('Output element'),

--- a/src/provider/zeebe/properties/OutputPropagationProps.js
+++ b/src/provider/zeebe/properties/OutputPropagationProps.js
@@ -23,7 +23,7 @@ import {
   useService
 } from '../../../hooks';
 
-import ToggleSwitch, { isEdited as defaultIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/ToggleSwitch';
+import { ToggleSwitchEntry, isToggleSwitchEntryEdited } from '@bpmn-io/properties-panel';
 
 
 export function OutputPropagationProps(props) {
@@ -39,7 +39,7 @@ export function OutputPropagationProps(props) {
     {
       id: 'propagateAllChildVariables',
       component: <PropagateAllChildVariables element={ element } />,
-      isEdited: defaultIsEdited
+      isEdited: isToggleSwitchEntryEdited
     }
   ];
 }
@@ -122,7 +122,7 @@ function PropagateAllChildVariables(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return ToggleSwitch({
+  return ToggleSwitchEntry({
     id: 'propagateAllChildVariables',
     label: translate('Propagate all child process variables'),
     switcherLabel: propagateAllChildVariables ?

--- a/src/provider/zeebe/properties/TargetProps.js
+++ b/src/provider/zeebe/properties/TargetProps.js
@@ -16,7 +16,7 @@ import {
   useService
 } from '../../../hooks';
 
-import TextField, { isEdited as defaultIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 
 export function TargetProps(props) {
@@ -32,7 +32,7 @@ export function TargetProps(props) {
     {
       id: 'targetProcessId',
       component: <TargetProcessId element={ element } />,
-      isEdited: defaultIsEdited
+      isEdited: isTextFieldEntryEdited
     }
   ];
 }
@@ -114,7 +114,7 @@ function TargetProcessId(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'targetProcessId',
     label: translate('Process ID'),

--- a/src/provider/zeebe/properties/TaskDefinitionProps.js
+++ b/src/provider/zeebe/properties/TaskDefinitionProps.js
@@ -2,7 +2,7 @@ import {
   getBusinessObject
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   getExtensionElementsList
@@ -34,12 +34,12 @@ export function TaskDefinitionProps(props) {
     {
       id: 'taskDefinitionType',
       component: <TaskDefinitionType element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     },
     {
       id: 'taskDefinitionRetries',
       component: <TaskDefinitionRetries element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     }
   ];
 }
@@ -120,7 +120,7 @@ function TaskDefinitionType(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'taskDefinitionType',
     label: translate('Type'),
@@ -205,7 +205,7 @@ function TaskDefinitionRetries(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'taskDefinitionRetries',
     label: translate('Retries'),

--- a/src/provider/zeebe/properties/TimerProps.js
+++ b/src/provider/zeebe/properties/TimerProps.js
@@ -13,12 +13,16 @@ import {
   getTimerDefinitionType
 } from '../../bpmn/utils/EventDefinitionUtil';
 
-import SelectEntry, { isEdited as selectIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/Select';
-import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import {
+  SelectEntry,
+  TextFieldEntry,
+  isSelectEntryEdited,
+  isTextFieldEntryEdited
+} from '@bpmn-io/properties-panel';
 
 
 /**
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').EntryDefinition } Entry
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
 
 /**
@@ -50,20 +54,20 @@ export function TimerProps(props) {
     entries.push({
       id: 'timerEventDefinitionDurationValue',
       component: <TimerEventDefinitionDurationValue element={ element } />,
-      isEdited: textFieldIsEdited
+      isEdited: isTextFieldEntryEdited
     });
   } else {
     entries.push({
       id: 'timerEventDefinitionType',
       component: <TimerEventDefinitionType element={ element } />,
-      isEdited: selectIsEdited
+      isEdited: isSelectEntryEdited
     });
 
     if (timerEventDefinitionType) {
       entries.push({
         id: 'timerEventDefinitionValue',
         component: <TimerEventDefinitionValue element={ element } />,
-        isEdited: textFieldIsEdited
+        isEdited: isTextFieldEntryEdited
       });
     }
   }
@@ -167,7 +171,7 @@ function TimerEventDefinitionType(props) {
  * together with timerEventDefinitionType.
  *
  * @param  {type} props
- * @return {TextField}
+ * @return {TextFieldEntry}
  */
 function TimerEventDefinitionValue(props) {
   const {
@@ -197,7 +201,7 @@ function TimerEventDefinitionValue(props) {
     });
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'timerEventDefinitionValue',
     label: translate('Value'),
@@ -213,7 +217,7 @@ function TimerEventDefinitionValue(props) {
  * duration value. This is to be used stand-alone, without the TimerEventDefinitionType
  *
  * @param  {type} props
- * @return {TextField}
+ * @return {TextFieldEntry}
  */
 function TimerEventDefinitionDurationValue(props) {
   const {
@@ -277,7 +281,7 @@ function TimerEventDefinitionDurationValue(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'timerEventDefinitionDurationValue',
     label: translate('Timer duration'),

--- a/src/render/BpmnPropertiesPanel.js
+++ b/src/render/BpmnPropertiesPanel.js
@@ -9,7 +9,7 @@ import {
   reduce
 } from 'min-dash';
 
-import PropertiesPanel from '@bpmn-io/properties-panel/lib/PropertiesPanel';
+import { PropertiesPanel } from '@bpmn-io/properties-panel';
 
 import {
   BpmnPropertiesPanelContext

--- a/src/render/BpmnPropertiesPanel.js
+++ b/src/render/BpmnPropertiesPanel.js
@@ -2,7 +2,7 @@ import {
   useState,
   useMemo,
   useEffect
-} from 'preact/hooks';
+} from '@bpmn-io/properties-panel/preact/hooks';
 
 import {
   find,

--- a/src/render/BpmnPropertiesPanelRenderer.js
+++ b/src/render/BpmnPropertiesPanelRenderer.js
@@ -12,8 +12,8 @@ import {
 const DEFAULT_PRIORITY = 1000;
 
 /**
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').GroupDefinition } GroupDefinition
- * @typedef { import('@bpmn-io/properties-panel/lib/PropertiesPanel').ListGroupDefinition } ListGroupDefinition
+ * @typedef { import('@bpmn-io/properties-panel').GroupDefinition } GroupDefinition
+ * @typedef { import('@bpmn-io/properties-panel').ListGroupDefinition } ListGroupDefinition
  * @typedef { { getGroups: (ModdleElement) => (Array{GroupDefinition|ListGroupDefinition}) => Array{GroupDefinition|ListGroupDefinition}) } PropertiesProvider
  */
 

--- a/src/render/BpmnPropertiesPanelRenderer.js
+++ b/src/render/BpmnPropertiesPanelRenderer.js
@@ -2,7 +2,7 @@ import BpmnPropertiesPanel from './BpmnPropertiesPanel';
 
 import {
   render
-} from 'preact';
+} from '@bpmn-io/properties-panel/preact';
 
 import {
   domify,

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -1,7 +1,7 @@
 import BpmnPropertiesPanelRenderer from './BpmnPropertiesPanelRenderer';
 
 import Commands from '../cmd';
-import DebounceInputModule from '@bpmn-io/properties-panel/lib/features/debounce-input';
+import { DebounceInputModule } from '@bpmn-io/properties-panel';
 
 export default {
   __depends__: [

--- a/test/spec/PanelHeaderProvider.spec.js
+++ b/test/spec/PanelHeaderProvider.spec.js
@@ -14,7 +14,7 @@ import {
   insertCoreStyles
 } from 'test/TestHelper';
 
-import Header from '@bpmn-io/properties-panel/lib/components/Header';
+import { Header } from '@bpmn-io/properties-panel';
 
 import {
   PanelHeaderProvider,

--- a/test/spec/extension/ExamplePropertiesProvider.js
+++ b/test/spec/extension/ExamplePropertiesProvider.js
@@ -2,7 +2,7 @@ import {
   useState,
   useContext,
   useMemo
-} from 'preact/hooks';
+} from '@bpmn-io/properties-panel/preact/hooks';
 
 import {
   useService

--- a/test/spec/extension/ExamplePropertiesProvider.js
+++ b/test/spec/extension/ExamplePropertiesProvider.js
@@ -8,11 +8,10 @@ import {
   useService
 } from 'src/hooks';
 
-import TextField from '@bpmn-io/properties-panel/lib/components/entries/TextField';
-
 import {
-  LayoutContext
-} from '@bpmn-io/properties-panel/lib/context';
+  LayoutContext,
+  TextFieldEntry
+} from '@bpmn-io/properties-panel';
 
 import {
   is
@@ -100,7 +99,7 @@ function SimpleInputEntry(props) {
     return element.businessObject.$attrs.foo;
   };
 
-  return TextField({
+  return TextFieldEntry({
     element,
     id: 'foo',
     label: 'Some custom <Foo> Entry',


### PR DESCRIPTION
This PR:
* adds missing `package.json#files` field to include only the build artifacts
* removes unnecessary `index.js` file in the root
* transforms the package to re-use preact shipped with `@bpmn-io/properties-panel`
* adjusts `@bpmn-io/properties-panel` imports to the new structure introduced in the PR linked below.


Requires https://github.com/bpmn-io/properties-panel/pull/124 to be merged and released
