### PR TITLE
test(camunda-platform): add test case to verify layout config

### DIFF
--- a/test/spec/provider/camunda-platform/CamundaPlatformPropertiesProvider.spec.js
+++ b/test/spec/provider/camunda-platform/CamundaPlatformPropertiesProvider.spec.js
@@ -1390,6 +1390,58 @@ describe('<CamundaPlatformPropertiesProvider>', function() {
 
     });
 
+
+    describe('layout config', function() {
+
+      let container;
+
+      function expectOpen(id, open) {
+        const group = getGroup(container, id);
+        const header = domQuery('.bio-properties-panel-group-header', group);
+
+        expect(header.classList.contains('open')).to.equal(open);
+      }
+
+      beforeEach(function() {
+        container = TestContainer.get(this);
+      });
+
+      beforeEach(bootstrapPropertiesPanel(processDiagramXML, {
+        modules: testModules.concat(BpmnPropertiesProvider),
+        moddleExtensions,
+        debounceInput: false,
+        propertiesPanel: {
+          layout: {
+            groups: {
+              'general': { open: true },
+              'documentation': { open: false },
+              'CamundaPlatform__UserAssignment': { open: true }
+            }
+          }
+        }
+      }));
+
+
+      it('should pre-open configured groups', inject(
+        async function(elementRegistry, selection) {
+
+          // given
+          const task = elementRegistry.get('UserTask_1');
+
+          // when
+          await act(() => {
+            selection.select(task);
+          });
+
+          // then
+          expectOpen('general', true);
+          expectOpen('documentation', false);
+          expectOpen('CamundaPlatform__UserAssignment', true);
+          expectOpen('CamundaPlatform__Form', false);
+        })
+      );
+    });
+
   });
 });
 


### PR DESCRIPTION
This adds a test case to verify our layout config feature we don't actively promote yet, but use internally. It's possible to pre-define the `open` state of certain groups with it. Example:

```js
import BpmnModeler from 'bpmn-js/lib/Modeler';

const modeler = new BpmnModeler({
  container: '#canvas',
  propertiesPanel: {
    parent: '#properties',
    layout: {
      groups: {
        'general': { open: true },
        'documentation': { open: false },
        'CamundaPlatform__UserAssignment': { open: true }
      }
    }
  }
});
```

<img src="https://user-images.githubusercontent.com/9433996/145958245-38e5df78-5a0a-4ba6-a468-1cb1c2687c61.png" width="320px" />
