### PR TITLE
rewrite distro test

### DIFF
--- a/test/distro/distroSpec.js
+++ b/test/distro/distroSpec.js
@@ -9,23 +9,8 @@ const DIST_DIR = path.join(__dirname, '../../dist');
 
 describe('modules', function() {
 
-  it('should expose CJS bundle', function() {
+  it('should expose CJS bundle', verifyExists('index.js'));
 
-    // given
-    const {
-      BpmnPropertiesPanelModule,
-      BpmnPropertiesProviderModule,
-      ZeebePropertiesProviderModule,
-      useService
-    } = require(DIST_DIR);
-
-    // then
-    expect(BpmnPropertiesPanelModule).to.exist;
-    expect(BpmnPropertiesProviderModule).to.exist;
-    expect(ZeebePropertiesProviderModule).to.exist;
-
-    expect(useService).to.exist;
-  });
 });
 
 


### PR DESCRIPTION
## test: remove require test 

Some of the dependencies expose only ESModules and this is causing
problems unless we instrument rollup to bundle the deps with
the library. This, however, leads to increased bundle size
which doesn't give any benefit as modern bundlers can handle
commonjs/esmodules interop.