### PR TITLE
Add validation to called element `processId` in Call Activity

### DIFF
--- a/src/provider/zeebe/properties/TargetProps.js
+++ b/src/provider/zeebe/properties/TargetProps.js
@@ -9,7 +9,8 @@ import {
 
 import {
   getCalledElement,
-  getProcessId
+  getProcessId,
+  isIdValid
 } from '../utils/CalledElementUtil.js';
 
 import {
@@ -114,12 +115,17 @@ function TargetProcessId(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
+  const validate = (value) => {
+    return isIdValid(value, translate);
+  };
+
   return TextFieldEntry({
     element,
     id: 'targetProcessId',
     label: translate('Process ID'),
     getValue,
     setValue,
-    debounce
+    debounce,
+    validate
   });
 }

--- a/src/provider/zeebe/utils/CalledElementUtil.js
+++ b/src/provider/zeebe/utils/CalledElementUtil.js
@@ -6,6 +6,13 @@ import {
   getExtensionElementsList
 } from './ExtensionElementsUtil';
 
+const SPACE_REGEX = /\s/;
+
+// for QName validation as per http://www.w3.org/TR/REC-xml/#NT-NameChar
+const QNAME_REGEX = /^([a-z][\w-.]*:)?[a-z_][\w-.]*$/i;
+
+// for ID validation as per BPMN Schema (QName - Namespace)
+const ID_REGEX = /^[a-z_][\w-.]*$/i;
 
 export function getPropagateAllChildVariables(element) {
   const calledElement = getCalledElement(element);
@@ -28,4 +35,32 @@ function getCalledElements(element) {
   const bo = getBusinessObject(element);
   const extElements = getExtensionElementsList(bo, 'zeebe:CalledElement');
   return extElements;
+}
+
+export function isIdValid(idValue, translate) {
+  if (!idValue) {
+    return;
+  }
+
+  return validateId(idValue, translate);
+}
+
+export function validateId(idValue, translate) {
+
+  if (containsSpace(idValue)) {
+    return translate('ID must not contain spaces.');
+  }
+
+  if (!ID_REGEX.test(idValue)) {
+
+    if (QNAME_REGEX.test(idValue)) {
+      return translate('ID must not contain prefix.');
+    }
+
+    return translate('ID must be a valid QName.');
+  }
+}
+
+export function containsSpace(value) {
+  return SPACE_REGEX.test(value);
 }

--- a/test/spec/provider/zeebe/TargetProps.spec.js
+++ b/test/spec/provider/zeebe/TargetProps.spec.js
@@ -222,6 +222,26 @@ describe('provider/zeebe - TargetProps', function() {
       })
     );
 
+    it('should NOT set invalid QName', inject(async function(elementRegistry, selection) {
+
+      // given
+      // given
+      const callActivity = elementRegistry.get('CallActivity_1'),
+            originalValue = getProcessId(callActivity);
+
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      // when
+      const targetProcessIdInput = domQuery('input[name=targetProcessId]', container);
+      changeInput(targetProcessIdInput, '::foo');
+
+      // then
+      expect(getCalledElement(callActivity).processId).to.eql(originalValue);
+    }));
+
+
   });
 
 });


### PR DESCRIPTION
Closes #346

Uses the same validation as `IdProps`, except:
* field remains non-mandatory 
* don't check if id already assigned because this is used to refer to an existing process Id