### PR TITLE
Update Properties Panel Instead of Destroying on New Root Element

### DIFF
--- a/src/render/BpmnPropertiesPanel.js
+++ b/src/render/BpmnPropertiesPanel.js
@@ -109,7 +109,22 @@ export default function BpmnPropertiesPanel(props) {
     };
   }, [ selectedElement ]);
 
-  // (2c) provided entries changed
+  // (2c) root element changed
+  useEffect(() => {
+    const onRootAdded = (e) => {
+      const element = e.element;
+
+      _update(element);
+    };
+
+    eventBus.on('root.added', onRootAdded);
+
+    return () => {
+      eventBus.off('root.added', onRootAdded);
+    };
+  }, [ selectedElement ]);
+
+  // (2d) provided entries changed
   useEffect(() => {
     const onProvidersChanged = () => {
       _update(selectedElement);
@@ -122,7 +137,7 @@ export default function BpmnPropertiesPanel(props) {
     };
   }, [ selectedElement ]);
 
-  // (2d) element templates changed
+  // (2e) element templates changed
   useEffect(() => {
     const onTemplatesChanged = () => {
       _update(selectedElement);

--- a/src/render/BpmnPropertiesPanelRenderer.js
+++ b/src/render/BpmnPropertiesPanelRenderer.js
@@ -33,21 +33,20 @@ export default class BpmnPropertiesPanelRenderer {
 
     this._container = domify('<div style="height: 100%" class="bio-properties-panel-container" input-handle-modified-keys="y,z"></div>');
 
-    this._eventBus.on('root.added', (event) => {
-
-      const { element } = event;
-
-      this._render(element);
-
+    eventBus.on('diagram.init', () => {
       if (parent) {
         this.attachTo(parent);
       }
-
-      return;
     });
 
-    eventBus.on('root.removed', () => {
-      this._destroy();
+    eventBus.on('diagram.destroy', () => {
+      this.detach();
+    });
+
+    eventBus.on('root.added', (event) => {
+      const { element } = event;
+
+      this._render(element);
     });
   }
 

--- a/test/spec/BpmnPropertiesPanel.spec.js
+++ b/test/spec/BpmnPropertiesPanel.spec.js
@@ -156,6 +156,27 @@ describe('<BpmnPropertiesPanel>', function() {
     });
 
 
+    it('should update on root element changed', function() {
+
+      // given
+      const updateSpy = sinon.spy();
+
+      const eventBus = new eventBusMock();
+
+      eventBus.on('propertiesPanel.updated', updateSpy);
+
+      createBpmnPropertiesPanel({ container, eventBus });
+
+      // when
+      eventBus.fire('root.added', { element: noopElement });
+
+      // then
+      expect(updateSpy).to.have.been.calledWith({
+        element: noopElement
+      });
+    });
+
+
     it('should update on providers changed', function() {
 
       // given

--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -214,7 +214,7 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
   });
 
 
-  it('should render properties panel when root element was added', async function() {
+  it('should attach on diagram.init', async function() {
 
     // given
     const diagramXml = require('test/fixtures/simple.bpmn').default;
@@ -223,11 +223,11 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
     await createModeler(diagramXml);
 
     // then
-    expect(domQuery('.bio-properties-panel', propertiesContainer)).to.exist;
+    expect(domQuery('.bio-properties-panel-container', propertiesContainer)).to.exist;
   });
 
 
-  it('should remove properties panel when root element was deleted', async function() {
+  it('should detach on diagram.destroy', async function() {
 
     // given
     const diagramXml = require('test/fixtures/simple.bpmn').default;
@@ -237,10 +237,23 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
     const eventBus = modeler.get('eventBus');
 
     // when
-    eventBus.fire('root.removed');
+    eventBus.fire('diagram.destroy');
 
     // then
-    expect(domQuery('.bio-properties-panel', propertiesContainer)).to.not.exist;
+    expect(domQuery('.bio-properties-panel-container', propertiesContainer)).to.not.exist;
+  });
+
+
+  it('should render on root.added', async function() {
+
+    // given
+    const diagramXml = require('test/fixtures/simple.bpmn').default;
+
+    // when
+    await createModeler(diagramXml);
+
+    // then
+    expect(domQuery('.bio-properties-panel', propertiesContainer)).to.exist;
   });
 
 


### PR DESCRIPTION
# Summary

* there's no use case for removing the root element without immediately adding another one or destroying the diagram so destroying the properties panel on every root.removed isn't necessary
* attach on diagram.init
* detach on diagram.destroy
* render on root.added
* update on root.added

![aAbC39QLjk](https://user-images.githubusercontent.com/7633572/149967814-eaec531f-ff97-41b6-b8ab-9b3115d29bb4.gif)

---

Related to https://github.com/camunda/camunda-modeler/issues/2374