### PR TITLE
Render HTML descriptions for Element Templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5145,6 +5145,11 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "preact-markup": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/preact-markup/-/preact-markup-2.1.1.tgz",
+      "integrity": "sha512-8JL2p36mzK8XkspOyhBxUSPjYwMxDM0L5BWBZWxsZMVW8WsGQrYQDgVuDKkRspt2hwrle+Cxr/053hpc9BJwfw=="
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ids": "^1.0.0",
     "min-dash": "^3.8.0",
     "min-dom": "^3.1.3",
+    "preact-markup": "^2.1.1",
     "semver": "^7.3.5"
   },
   "devDependencies": {

--- a/src/provider/element-templates/components/PropertyDescription.js
+++ b/src/provider/element-templates/components/PropertyDescription.js
@@ -1,0 +1,16 @@
+import Markup from 'preact-markup';
+
+import { sanitizeHTML } from '../util/sanitize';
+
+export function PropertyDescription(props) {
+
+  const {
+    description
+  } = props;
+
+  return (
+    <Markup
+      markup={ sanitizeHTML(description) }
+      trim={ false } />
+  );
+}

--- a/src/provider/element-templates/properties/CustomProperties.js
+++ b/src/provider/element-templates/properties/CustomProperties.js
@@ -16,6 +16,8 @@ import {
   TextFieldEntry, isTextFieldEntryEdited
 } from '@bpmn-io/properties-panel';
 
+import { PropertyDescription } from '../components/PropertyDescription';
+
 import {
   findCamundaErrorEventDefinition,
   findCamundaInOut,
@@ -42,6 +44,7 @@ import {
   createInputParameter,
   createOutputParameter
 } from '../CreateHelper';
+
 
 const CAMUNDA_ERROR_EVENT_DEFINITION_TYPE = 'camunda:errorEventDefinition',
       CAMUNDA_EXECUTION_LISTENER_TYPE = 'camunda:executionListener',
@@ -228,7 +231,7 @@ function BooleanProperty(props) {
     getValue: propertyGetter(element, property, scope),
     id,
     label,
-    description,
+    description: PropertyDescription({ description }),
     setValue: propertySetter(bpmnFactory, commandStack, element, property, scope),
     disabled: editable === false
   });
@@ -267,7 +270,7 @@ function DropdownProperty(props) {
     id,
     label,
     getOptions,
-    description,
+    description: PropertyDescription({ description }),
     getValue: propertyGetter(element, property, scope),
     setValue: propertySetter(bpmnFactory, commandStack, element, property, scope),
     disabled: editable === false
@@ -299,7 +302,7 @@ function StringProperty(props) {
     getValue: propertyGetter(element, property, scope),
     id,
     label,
-    description,
+    description: PropertyDescription({ description }),
     setValue: propertySetter(bpmnFactory, commandStack, element, property, scope),
     validate: propertyValidator(translate, property),
     disabled: editable === false
@@ -329,7 +332,7 @@ function TextAreaProperty(props) {
     element,
     id,
     label,
-    description,
+    description: PropertyDescription({ description }),
     getValue: propertyGetter(element, property, scope),
     setValue: propertySetter(bpmnFactory, commandStack, element, property, scope),
     disabled: editable === false

--- a/src/provider/element-templates/properties/InputProperties.js
+++ b/src/provider/element-templates/properties/InputProperties.js
@@ -15,6 +15,8 @@ import { without } from 'min-dash';
 
 import { createElement } from '../../../utils/ElementUtil';
 
+import { PropertyDescription } from '../components/PropertyDescription';
+
 import { createInputParameter } from '../CreateHelper';
 
 
@@ -89,7 +91,9 @@ function Description(props) {
   } = props;
 
   return <div class="bio-properties-panel-entry" data-entry-id={ id }>
-    <div class="bio-properties-panel-description">{ text }</div>
+    <div class="bio-properties-panel-description">
+      <PropertyDescription description={ text } />
+    </div>
   </div>;
 }
 

--- a/src/provider/element-templates/properties/OutputProperties.js
+++ b/src/provider/element-templates/properties/OutputProperties.js
@@ -13,6 +13,8 @@ import { useService } from '../../../hooks';
 
 import { without } from 'min-dash';
 
+import { PropertyDescription } from '../components/PropertyDescription';
+
 import { createElement } from '../../../utils/ElementUtil';
 
 import { createOutputParameter } from '../CreateHelper';
@@ -89,7 +91,9 @@ function Description(props) {
   } = props;
 
   return <div class="bio-properties-panel-entry" data-entry-id={ id }>
-    <div class="bio-properties-panel-description">{ text }</div>
+    <div class="bio-properties-panel-description">
+      <PropertyDescription description={ text } />
+    </div>
   </div>;
 }
 

--- a/src/provider/element-templates/util/sanitize.js
+++ b/src/provider/element-templates/util/sanitize.js
@@ -1,0 +1,170 @@
+/**
+ * Copied from existing form-js#Sanitizer
+ * cf. https://github.com/bpmn-io/form-js/blob/master/packages/form-js-viewer/src/render/components/Sanitizer.js
+ */
+
+const NODE_TYPE_TEXT = 3,
+      NODE_TYPE_ELEMENT = 1;
+
+const ALLOWED_NODES = [
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'span',
+  'em',
+  'a',
+  'p',
+  'div',
+  'ul',
+  'ol',
+  'li',
+  'hr',
+  'blockquote',
+  'img',
+  'pre',
+  'code',
+  'br',
+  'strong'
+];
+
+const ALLOWED_ATTRIBUTES = [
+  'align',
+  'alt',
+  'class',
+  'href',
+  'id',
+  'name',
+  'rel',
+  'target',
+  'src'
+];
+
+const ALLOWED_URI_PATTERN = /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i; // eslint-disable-line no-useless-escape
+const ATTR_WHITESPACE_PATTERN = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]/g; // eslint-disable-line no-control-regex
+
+const FORM_ELEMENT = document.createElement('form');
+
+/**
+ * Sanitize a HTML string and return the cleaned, safe version.
+ *
+ * @param {string} html
+ * @return {string}
+ */
+export function sanitizeHTML(html) {
+
+  const doc = new DOMParser().parseFromString(
+    `<!DOCTYPE html>\n<html><body><div>${ html }`,
+    'text/html'
+  );
+
+  doc.normalize();
+
+  const element = doc.body.firstChild;
+
+  if (element) {
+    sanitizeNode(/** @type Element */ (element));
+
+    return new XMLSerializer().serializeToString(element);
+  } else {
+
+    // handle the case that document parsing
+    // does not work at all, due to HTML gibberish
+    return '';
+  }
+}
+
+/**
+ * Recursively sanitize a HTML node, potentially
+ * removing it, its children or attributes.
+ *
+ * Inspired by https://github.com/developit/snarkdown/issues/70
+ * and https://github.com/cure53/DOMPurify. Simplified
+ * for our use-case.
+ *
+ * @param {Element} node
+ */
+function sanitizeNode(node) {
+
+  // allow text nodes
+  if (node.nodeType === NODE_TYPE_TEXT) {
+    return;
+  }
+
+  // disallow all other nodes but Element
+  if (node.nodeType !== NODE_TYPE_ELEMENT) {
+    return node.remove();
+  }
+
+  const lcTag = node.tagName.toLowerCase();
+
+  // disallow non-whitelisted tags
+  if (!ALLOWED_NODES.includes(lcTag)) {
+    return node.remove();
+  }
+
+  const attributes = node.attributes;
+
+  // clean attributes
+  for (let i = attributes.length; i--;) {
+    const attribute = attributes[i];
+
+    const name = attribute.name;
+    const lcName = name.toLowerCase();
+
+    // normalize node value
+    const value = attribute.value.trim();
+
+    node.removeAttribute(name);
+
+    const valid = isValidAttribute(lcTag, lcName, value);
+
+    if (valid) {
+      node.setAttribute(name, value);
+    }
+
+  }
+
+  // force noopener on target="_blank" links
+  if (lcTag === 'a' && node.getAttribute('target') === '_blank' && node.getAttribute('rel') !== 'noopener') {
+    node.setAttribute('rel', 'noopener');
+  }
+
+  for (let i = node.childNodes.length; i--;) {
+    sanitizeNode(/** @type Element */ (node.childNodes[i]));
+  }
+}
+
+
+/**
+ * Validates attributes for validity.
+ *
+ * @param {string} lcTag
+ * @param {string} lcName
+ * @param {string} value
+ * @return {boolean}
+ */
+function isValidAttribute(lcTag, lcName, value) {
+
+  // disallow most attributes based on whitelist
+  if (!ALLOWED_ATTRIBUTES.includes(lcName)) {
+    return false;
+  }
+
+  // disallow "DOM clobbering" / polution of document and wrapping form elements
+  if ((lcName === 'id' || lcName === 'name') && (value in document || value in FORM_ELEMENT)) {
+    return false;
+  }
+
+  if (lcName === 'target' && value !== '_blank') {
+    return false;
+  }
+
+  // allow valid url links only
+  if (lcName === 'href' && !ALLOWED_URI_PATTERN.test(value.replace(ATTR_WHITESPACE_PATTERN, ''))) {
+    return false;
+  }
+
+  return true;
+}

--- a/test/spec/provider/element-templates/properties/CustomProperties.description.json
+++ b/test/spec/provider/element-templates/properties/CustomProperties.description.json
@@ -65,6 +65,15 @@
           "type": "camunda:inputParameter",
           "name": "dropdown"
         }
+      },
+      {
+        "label": "string",
+        "description": "By the way, you can use <a target='_blank' href=\"https://freemarker.apache.org/\">freemarker templates</a> here",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "string"
+        }
       }
     ]
   }

--- a/test/spec/provider/element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/provider/element-templates/properties/CustomProperties.spec.js
@@ -1370,6 +1370,28 @@ describe('provider/element-templates - CustomProperties', function() {
 
       expect(entry.textContent).to.contain('DROPDOWN_DESCRIPTION');
     });
+
+
+    it('should display HTML descriptions', async function() {
+
+      // when
+      await expectSelected('Task');
+
+      // then
+      const entry = findEntry('custom-entry-com.camunda.example.description-4', container);
+      const description = domQuery('.bio-properties-panel-description', entry);
+
+      expect(description).to.exist;
+      expect(description.innerHTML).to.eql(
+        '<div class="markup">' +
+          '<div xmlns="http://www.w3.org/1999/xhtml">' +
+            'By the way, you can use ' +
+            '<a href="https://freemarker.apache.org/" target="_blank" rel="noopener">freemarker templates</a> '+
+            'here' +
+          '</div>' +
+        '</div>'
+      );
+    });
   });
 
 

--- a/test/spec/provider/element-templates/properties/InputProperties.json
+++ b/test/spec/provider/element-templates/properties/InputProperties.json
@@ -41,6 +41,14 @@
           "type": "camunda:inputParameter",
           "name": "notCreated"
         }
+      },
+      {
+        "label": "withHtmlDescription",
+        "description": "By the way, you can use <a target='_blank' href=\"https://freemarker.apache.org/\">freemarker templates</a> here",
+        "binding": {
+          "type": "camunda:inputParameter",
+          "name": "withHtmlDescription"
+        }
       }
     ]
   },

--- a/test/spec/provider/element-templates/properties/InputProperties.spec.js
+++ b/test/spec/provider/element-templates/properties/InputProperties.spec.js
@@ -164,6 +164,33 @@ describe('provider/element-templates - InputProperties', function() {
       expect(description.innerText).to.equal('foo bar');
     });
 
+
+    it('should render HTML description', async function() {
+
+      // when
+      await expectSelected('SimpleTask');
+
+      // then
+      const entry = findEntry('SimpleTask-inputParameter-5', container);
+
+      expect(entry).to.exist;
+
+      const description = findEntry('SimpleTask-inputParameter-5-description', entry);
+
+      expect(description).to.exist;
+      expect(description.innerHTML).to.eql(
+        '<div class="bio-properties-panel-description">' +
+          '<div class="markup">' +
+            '<div xmlns="http://www.w3.org/1999/xhtml">' +
+              'By the way, you can use ' +
+              '<a href="https://freemarker.apache.org/" target="_blank" rel="noopener">freemarker templates</a> '+
+              'here' +
+            '</div>' +
+          '</div>' +
+        '</div>'
+      );
+    });
+
   });
 
 

--- a/test/spec/provider/element-templates/properties/OutputProperties.json
+++ b/test/spec/provider/element-templates/properties/OutputProperties.json
@@ -58,6 +58,14 @@
           "type": "camunda:outputParameter",
           "source": "notCreated_2"
         }
+      },
+      {
+        "label": "withHtmlDescription",
+        "description": "By the way, you can use <a target='_blank' href=\"https://freemarker.apache.org/\">freemarker templates</a> here",
+        "binding": {
+          "type": "camunda:outputParameter",
+          "source": "html"
+        }
       }
     ]
   },

--- a/test/spec/provider/element-templates/properties/OutputProperties.spec.js
+++ b/test/spec/provider/element-templates/properties/OutputProperties.spec.js
@@ -165,6 +165,33 @@ describe('provider/element-templates - OutputProperties', function() {
       expect(description.innerText).to.equal('foo bar');
     });
 
+
+    it('should render HTML description', async function() {
+
+      // when
+      await expectSelected('SimpleTask');
+
+      // then
+      const entry = findEntry('SimpleTask-outputParameter-7', container);
+
+      expect(entry).to.exist;
+
+      const description = findEntry('SimpleTask-outputParameter-7-description', entry);
+
+      expect(description).to.exist;
+      expect(description.innerHTML).to.eql(
+        '<div class="bio-properties-panel-description">' +
+          '<div class="markup">' +
+            '<div xmlns="http://www.w3.org/1999/xhtml">' +
+              'By the way, you can use ' +
+              '<a href="https://freemarker.apache.org/" target="_blank" rel="noopener">freemarker templates</a> '+
+              'here' +
+            '</div>' +
+          '</div>' +
+        '</div>'
+      );
+    });
+
   });
 
 

--- a/test/spec/provider/element-templates/util/sanitize.spec.js
+++ b/test/spec/provider/element-templates/util/sanitize.spec.js
@@ -1,0 +1,162 @@
+import { sanitizeHTML } from 'src/provider/element-templates/util/sanitize';
+
+
+describe('provider/element-template - sanitize', function() {
+
+  it('should keep safe links', function() {
+
+    // given
+    const html =
+      '<p>' +
+        '<a href="#l">a</a>' +
+        '<a href="http://b">b</a>' +
+        '<a href="https://c">c</a>' +
+        '<a href="./d">d</a>' +
+        '<a href="/e">e</a>' +
+        '<a href="mailto:f">f</a>' +
+        '<a href="/g" target="_blank" rel="noopener">g</a>' +
+      '</p>';
+
+    // when
+    const sanitized = sanitizeHTML(html);
+
+    // then
+    expect(sanitized).to.eql(
+      '<div xmlns="http://www.w3.org/1999/xhtml"><p>' +
+        '<a href="#l">a</a>' +
+        '<a href="http://b">b</a>' +
+        '<a href="https://c">c</a>' +
+        '<a href="./d">d</a>' +
+        '<a href="/e">e</a>' +
+        '<a href="mailto:f">f</a>' +
+        '<a rel="noopener" target="_blank" href="/g">g</a>' +
+      '</p></div>'
+    );
+  });
+
+
+  it('should remove disallowed tags', function() {
+
+    // given
+    const html = '<h1>Foo<script>alert(\'foo\');</script><video /><iframe></h1>';
+
+    // when
+    const sanitized = sanitizeHTML(html);
+
+    // then
+    expect(sanitized).to.equal('<div xmlns="http://www.w3.org/1999/xhtml"><h1>Foo</h1></div>');
+  });
+
+
+  it('should remove disallowed attributes', function() {
+
+    // given
+    const html = '<h1 onclick="alert(\'foo\');">Foo</h1>';
+
+    // when
+    const sanitized = sanitizeHTML(html);
+
+    // then
+    expect(sanitized).to.equal('<div xmlns="http://www.w3.org/1999/xhtml"><h1>Foo</h1></div>');
+  });
+
+
+  it('should add <rel="noopener"> to target="_blank" links', function() {
+
+    // given
+    const html = '<a href="/g" target="_blank"></a>';
+
+    // when
+    const sanitized = sanitizeHTML(html);
+
+    // then
+    expect(sanitized).to.equal('<div xmlns="http://www.w3.org/1999/xhtml"><a target="_blank" href="/g" rel="noopener"></a></div>');
+  });
+
+
+  it('should remove bogus target from links', function() {
+
+    // given
+    const html = '<a href="/g" target="_parent"></a>';
+
+    // when
+    const sanitized = sanitizeHTML(html);
+
+    // then
+    expect(sanitized).to.equal('<div xmlns="http://www.w3.org/1999/xhtml"><a href="/g"></a></div>');
+  });
+
+
+  it('should remove HTML clobbering attributes', function() {
+
+    // given
+    const html = '<h1 name="createElement" id=createElement>Foo</h1>';
+
+    // when
+    const sanitized = sanitizeHTML(html);
+
+    // then
+    expect(sanitized).to.equal('<div xmlns="http://www.w3.org/1999/xhtml"><h1>Foo</h1></div>');
+  });
+
+
+  describe('should remove <javascript:> href attributes', function() {
+
+    it('basic', function() {
+
+      // given
+      const html = '<a href="javascript:throw onerror=alert,\'some string\',123,\'haha\'">Foo</a>';
+
+      // when
+      const sanitized = sanitizeHTML(html);
+
+      // then
+      expect(sanitized).to.equal('<div xmlns="http://www.w3.org/1999/xhtml"><a>Foo</a></div>');
+    });
+
+
+    it('with whitespace', function() {
+
+      // given
+      const html = '<a href=" j\navas\tcript:throw onerror=alert,\'some string\',123,\'haha\'">Foo</a>';
+
+      // when
+      const sanitized = sanitizeHTML(html);
+
+      // then
+      expect(sanitized).to.equal('<div xmlns="http://www.w3.org/1999/xhtml"><a>Foo</a></div>');
+    });
+
+  });
+
+
+  describe('should remove <data:> href attributes', function() {
+
+    it('basic', function() {
+
+      // given
+      const html = '<a href="data:foo">Foo</a>';
+
+      // when
+      const sanitized = sanitizeHTML(html);
+
+      // then
+      expect(sanitized).to.equal('<div xmlns="http://www.w3.org/1999/xhtml"><a>Foo</a></div>');
+    });
+
+
+    it('with whitespace', function() {
+
+      // given
+      const html = '<a href=" da\t\nta:foo">Foo</a>';
+
+      // when
+      const sanitized = sanitizeHTML(html);
+
+      // then
+      expect(sanitized).to.equal('<div xmlns="http://www.w3.org/1999/xhtml"><a>Foo</a></div>');
+    });
+
+  });
+
+});


### PR DESCRIPTION
Closes #547 
Closes #375 

This uses the same `preact-markup` and sanitization setup as we already use in `form-js`. I checked out the Sanitizer and believe we can safely use the rules as we have with our Markdown support in form-js, I don't see a need for specific rules in properties panel land. We already sanitize pretty carefully over there.

After a chat with @MaxTru I decided to keep it simple for now and only bring back the [HTML support for element template field descriptions](https://github.com/camunda/camunda-modeler/blob/develop/docs/element-templates/README.md#defining-template-properties). The introduction of `preact-markup` would allow us to do even crazier things as a core feature, e.g. using markdown / HTML to provide my custom properties - instead of the existing JSX syntax.

This can be easily achieved if we decide on it in the future.

<image src="https://user-images.githubusercontent.com/9433996/150322182-3702bece-c968-44b7-8522-738746267933.png" height="500px" />
