### PR TITLE
fix(element-templates): do not render empty descriptions

### DIFF
--- a/src/provider/element-templates/components/PropertyDescription.js
+++ b/src/provider/element-templates/components/PropertyDescription.js
@@ -8,7 +8,7 @@ export function PropertyDescription(props) {
     description
   } = props;
 
-  return (
+  return description && (
     <Markup
       markup={ sanitizeHTML(description) }
       trim={ false } />

--- a/test/spec/provider/element-templates/properties/CustomProperties.description.json
+++ b/test/spec/provider/element-templates/properties/CustomProperties.description.json
@@ -67,8 +67,16 @@
         }
       },
       {
-        "label": "string",
+        "label": "withHTML",
         "description": "By the way, you can use <a target='_blank' href=\"https://freemarker.apache.org/\">freemarker templates</a> here",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "string"
+        }
+      },
+      {
+        "label": "empty",
         "type": "String",
         "binding": {
           "type": "property",

--- a/test/spec/provider/element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/provider/element-templates/properties/CustomProperties.spec.js
@@ -1392,6 +1392,19 @@ describe('provider/element-templates - CustomProperties', function() {
         '</div>'
       );
     });
+
+
+    it('should NOT display empty descriptions', async function() {
+
+      // when
+      await expectSelected('Task');
+
+      // then
+      const entry = findEntry('custom-entry-com.camunda.example.description-5', container);
+      const description = domQuery('.bio-properties-panel-description', entry);
+
+      expect(description).to.not.exist;
+    });
   });
 
 


### PR DESCRIPTION
Follow up of #549 

> I've found a problem within the templates example. There's a description with `undefined` as the content.
> 
> ![image](https://user-images.githubusercontent.com/28307541/150386479-a8a1fd76-b37b-421a-b3a8-be85537c673c.png)

_Originally posted by @barmac in https://github.com/bpmn-io/bpmn-js-properties-panel/issues/549#issuecomment-1017721031_
