### PR TITLE
Sprint 1 - C8 Templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6653,9 +6653,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.10.0.tgz",
-      "integrity": "sha512-1wnUWYPVLFxAEM78hiN7kO2NmKK0OHGnT0DcI/MP6KO6HcmdHBgTjsSY4qRNM3G1MeKA/zVJ1OZ0Onz9krbeZg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.11.0.tgz",
+      "integrity": "sha512-ehNQa2Kt9B1bwWJCF8Fs4SkroaSe+VH5Y4ql4T1hHuOSMJiwuMekFIs3UAJyS0ZyBhcJbUW1C1NPwXcD8u5IRA==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "start:platform": "cross-env SINGLE_START=platform npm run dev",
     "start:bpmn": "cross-env SINGLE_START=bpmn npm run dev",
     "start:templates": "cross-env SINGLE_START=templates npm run dev",
+    "start:cloud-templates": "cross-env SINGLE_START=cloud-templates npm run dev",
     "prepare": "run-s bundle"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "sinon-chai": "^3.7.0",
     "sirv-cli": "^1.0.12",
     "webpack": "^5.38.1",
-    "zeebe-bpmn-moddle": "^0.10.0"
+    "zeebe-bpmn-moddle": "^0.11.0"
   },
   "peerDependencies": {
     "bpmn-js": "8.x",

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ export { default as BpmnPropertiesPanelModule } from './render';
 export { default as BpmnPropertiesProviderModule } from './provider/bpmn';
 export { default as ZeebePropertiesProviderModule } from './provider/zeebe';
 export { default as CamundaPlatformPropertiesProviderModule } from './provider/camunda-platform';
+export { default as CloudElementTemplatesPropertiesProviderModule } from './provider/cloud-element-templates';
 export { default as ElementTemplatesPropertiesProviderModule } from './provider/element-templates';
 export { DescriptionProvider as ZeebeDescriptionProvider } from './contextProvider/zeebe';
 

--- a/src/provider/cloud-element-templates/CreateHelper.js
+++ b/src/provider/cloud-element-templates/CreateHelper.js
@@ -1,0 +1,76 @@
+/**
+ * Create an input parameter representing the given
+ * binding and value.
+ *
+ * @param {PropertyBinding} binding
+ * @param {String} value
+ * @param {BpmnFactory} bpmnFactory
+ *
+ * @return {ModdleElement}
+ */
+export function createInputParameter(binding, value, bpmnFactory) {
+  const {
+    name
+  } = binding;
+
+  return bpmnFactory.create('zeebe:Input', {
+    source: value,
+    target: name
+  });
+}
+
+/**
+ * Create an output parameter representing the given
+ * binding and value.
+ *
+ * @param {PropertyBinding} binding
+ * @param {String} value
+ * @param {BpmnFactory} bpmnFactory
+ *
+ * @return {ModdleElement}
+ */
+export function createOutputParameter(binding, value, bpmnFactory) {
+  const {
+    source
+  } = binding;
+
+  return bpmnFactory.create('zeebe:Output', {
+    source,
+    target: value
+  });
+}
+
+/**
+ * Create a task header representing the given
+ * binding and value.
+ *
+ * @param {PropertyBinding} binding
+ * @param {String} value
+ * @param {BpmnFactory} bpmnFactory
+ *
+ * @return {ModdleElement}
+ */
+export function createTaskHeader(binding, value, bpmnFactory) {
+  const {
+    key
+  } = binding;
+
+  return bpmnFactory.create('zeebe:Header', {
+    key,
+    value
+  });
+}
+
+/**
+ * Create a task definition representing the given value.
+ *
+ * @param {String} value
+ * @param {BpmnFactory} bpmnFactory
+ *
+ * @return {ModdleElement}
+ */
+export function createTaskDefinitionWithType(value, bpmnFactory) {
+  return bpmnFactory.create('zeebe:TaskDefinition', {
+    type: value
+  });
+}

--- a/src/provider/cloud-element-templates/ElementTemplates.js
+++ b/src/provider/cloud-element-templates/ElementTemplates.js
@@ -1,0 +1,53 @@
+import {
+  isString,
+  isUndefined
+} from 'min-dash';
+
+import {
+  getTemplateId,
+  getTemplateVersion
+} from './Helper';
+
+import { default as DefaultElementTemplates } from '../element-templates/ElementTemplates';
+
+/**
+ * Registry for element templates.
+ */
+export default class ElementTemplates extends DefaultElementTemplates {
+  constructor() {
+    super();
+    this._templates = {};
+  }
+
+  /**
+   * Get template with given ID and optional version or for element.
+   *
+   * @param {String|djs.model.Base} id
+   * @param {number} [version]
+   *
+   * @return {ElementTemplate}
+   */
+  get(id, version) {
+    const templates = this._templates;
+
+    let element;
+
+    if (isUndefined(id)) {
+      return null;
+    } else if (isString(id)) {
+
+      if (isUndefined(version)) {
+        version = '_';
+      }
+
+      if (templates[ id ] && templates[ id ][ version ]) {
+        return templates[ id ][ version ];
+      } else {
+        return null;
+      }
+    } else {
+      element = id;
+      return this.get(getTemplateId(element), getTemplateVersion(element));
+    }
+  }
+}

--- a/src/provider/cloud-element-templates/ElementTemplatesLoader.js
+++ b/src/provider/cloud-element-templates/ElementTemplatesLoader.js
@@ -1,0 +1,34 @@
+import { Validator } from './Validator';
+
+import { default as TemplatesLoader } from '../element-templates/ElementTemplatesLoader';
+export default class ElementTemplatesLoader extends TemplatesLoader {
+  constructor(loadTemplates, eventBus, elementTemplates) {
+
+    super(loadTemplates, eventBus, elementTemplates);
+
+    this._elementTemplates = elementTemplates;
+  }
+
+  setTemplates(templates) {
+    const elementTemplates = this._elementTemplates;
+
+    const validator = new Validator().addAll(templates);
+
+    const errors = validator.getErrors(),
+          validTemplates = validator.getValidTemplates();
+
+    elementTemplates.set(validTemplates);
+
+    if (errors.length) {
+      this.templateErrors(errors);
+    }
+
+    this.templatesChanged();
+  }
+}
+
+ElementTemplatesLoader.$inject = [
+  'config.elementTemplates',
+  'eventBus',
+  'elementTemplates'
+];

--- a/src/provider/cloud-element-templates/ElementTemplatesLoader.js
+++ b/src/provider/cloud-element-templates/ElementTemplatesLoader.js
@@ -1,6 +1,7 @@
 import { Validator } from './Validator';
 
 import { default as TemplatesLoader } from '../element-templates/ElementTemplatesLoader';
+
 export default class ElementTemplatesLoader extends TemplatesLoader {
   constructor(loadTemplates, eventBus, elementTemplates) {
 

--- a/src/provider/cloud-element-templates/ElementTemplatesPropertiesProvider.js
+++ b/src/provider/cloud-element-templates/ElementTemplatesPropertiesProvider.js
@@ -1,0 +1,112 @@
+import { isAny } from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
+
+import {
+  TemplateProps
+} from '../element-templates/components';
+
+import { ElementTemplatesGroup } from './components';
+
+import {
+  CustomProperties
+} from './properties';
+
+import { getTemplateId } from './Helper';
+
+const LOWER_PRIORITY = 300;
+
+
+export default class ElementTemplatesPropertiesProvider {
+
+  constructor(elementTemplates, propertiesPanel, injector) {
+    propertiesPanel.registerProvider(LOWER_PRIORITY, this);
+
+    this._elementTemplates = elementTemplates;
+    this._injector = injector;
+  }
+
+  getGroups(element) {
+    return (groups) => {
+      if (!this._shouldShowTemplateProperties(element)) {
+        return groups;
+      }
+
+      // (0) Copy provided groups
+      groups = groups.slice();
+
+      const templatesGroup = {
+        element,
+        id: 'ElementTemplates__Template',
+        label: 'Template',
+        component: ElementTemplatesGroup,
+        entries: TemplateProps({ element, elementTemplates: this._elementTemplates })
+      };
+
+      // (1) Add templates group
+      addGroupsAfter('documentation', groups, [ templatesGroup ]);
+
+      const elementTemplate = this._elementTemplates.get(element);
+
+      if (elementTemplate) {
+        const templateSpecificGroups = [].concat(
+          CustomProperties({ element, elementTemplate })
+        );
+
+        // (2) add template-specific properties groups
+        addGroupsAfter('ElementTemplates__Template', groups, templateSpecificGroups);
+      }
+
+      // (3) apply entries visible
+      if (getTemplateId(element)) {
+        groups = filterWithEntriesVisible(elementTemplate || {}, groups);
+      }
+
+      return groups;
+    };
+  }
+
+  _shouldShowTemplateProperties(element) {
+    return getTemplateId(element) || this._elementTemplates.getAll().some(template => {
+      return isAny(element, template.appliesTo);
+    });
+  }
+}
+
+ElementTemplatesPropertiesProvider.$inject = [
+  'elementTemplates',
+  'propertiesPanel',
+  'injector'
+];
+
+
+// helper /////////////////////
+
+/**
+ *
+ * @param {string} id
+ * @param {Array<{ id: string }} groups
+ * @param {Array<{ id: string }>} groupsToAdd
+ */
+function addGroupsAfter(id, groups, groupsToAdd) {
+  const index = groups.findIndex(group => group.id === id);
+
+  if (index !== -1) {
+    groups.splice(index + 1, 0, ...groupsToAdd);
+  } else {
+
+    // add in the beginning if group with provided id is missing
+    groups.unshift(...groupsToAdd);
+  }
+}
+
+function filterWithEntriesVisible(template, groups) {
+  if (!template.entriesVisible) {
+    return groups.filter(group => {
+      return (
+        group.id === 'general' ||
+        group.id.startsWith('ElementTemplates__')
+      );
+    });
+  }
+
+  return groups;
+}

--- a/src/provider/cloud-element-templates/Helper.js
+++ b/src/provider/cloud-element-templates/Helper.js
@@ -1,0 +1,103 @@
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+/**
+ * The BPMN 2.0 extension attribute name under
+ * which the element template ID is stored.
+ *
+ * @type {String}
+ */
+export const TEMPLATE_ID_ATTR = 'zeebe:modelerTemplate';
+
+/**
+ * The BPMN 2.0 extension attribute name under
+ * which the element template version is stored.
+ *
+ * @type {String}
+ */
+export const TEMPLATE_VERSION_ATTR = 'zeebe:modelerTemplateVersion';
+
+
+/**
+ * Get template id for a given diagram element.
+ *
+ * @param {djs.model.Base} element
+ *
+ * @return {String}
+ */
+export function getTemplateId(element) {
+  const businessObject = getBusinessObject(element);
+
+  if (businessObject) {
+    return businessObject.get(TEMPLATE_ID_ATTR);
+  }
+}
+
+/**
+ * Get template version for a given diagram element.
+ *
+ * @param {djs.model.Base} element
+ *
+ * @return {String}
+ */
+export function getTemplateVersion(element) {
+  const businessObject = getBusinessObject(element);
+
+  if (businessObject) {
+    return businessObject.get(TEMPLATE_VERSION_ATTR);
+  }
+}
+
+/**
+ * Find extension with given type in
+ * BPMN element, diagram element or ExtensionElement.
+ *
+ * @param {ModdleElement|djs.model.Base} element
+ * @param {String} type
+ *
+ * @return {ModdleElement} the extension
+ */
+export function findExtension(element, type) {
+  const businessObject = getBusinessObject(element);
+
+  let extensionElements;
+
+  if (is(businessObject, 'bpmn:ExtensionElements')) {
+    extensionElements = businessObject;
+  } else {
+    extensionElements = businessObject.get('extensionElements');
+  }
+
+  if (!extensionElements) {
+    return null;
+  }
+
+  return extensionElements.get('values').find((value) => {
+    return is(value, type);
+  });
+}
+
+export function findInputParameter(ioMapping, binding) {
+  const parameters = ioMapping.get('inputParameters');
+
+  return parameters.find((parameter) => {
+    return parameter.target === binding.name;
+  });
+}
+
+export function findOutputParameter(ioMapping, binding) {
+  const parameters = ioMapping.get('outputParameters');
+
+  return parameters.find((parameter) => {
+    return parameter.source === binding.source;
+  });
+}
+
+export function findTaskHeader(taskHeaders, binding) {
+  const headers = taskHeaders.get('values');
+
+  return headers.find((header) => {
+    return header.key === binding.key;
+  });
+}

--- a/src/provider/cloud-element-templates/Validator.js
+++ b/src/provider/cloud-element-templates/Validator.js
@@ -1,0 +1,38 @@
+import { Validator as BaseValidator } from '../element-templates/Validator';
+
+
+/**
+ * A Camunda Cloud element template validator.
+ */
+export class Validator extends BaseValidator {
+  constructor() {
+    super();
+  }
+
+  /**
+   * TODO(pinussilvestrus): we disable JSON schema validation for now.
+   *
+   * Validate given template and return error (if any).
+   *
+   * @param {TemplateDescriptor} template
+   *
+   * @return {Error} validation error, if any
+   */
+  _validateTemplate(template) {
+    let err;
+
+    const id = template.id,
+          version = template.version || '_';
+
+    // (1) versioning
+    if (this._templatesById[ id ] && this._templatesById[ id ][ version ]) {
+      if (version === '_') {
+        return this._logError(`template id <${ id }> already used`, template);
+      } else {
+        return this._logError(`template id <${ id }> and version <${ version }> already used`, template);
+      }
+    }
+
+    return err;
+  }
+}

--- a/src/provider/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/provider/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -1,0 +1,175 @@
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  find
+} from 'min-dash';
+
+/**
+ * Applies an element template to an element. Sets `zeebe:modelerTemplate` and
+ * `zeebe:modelerTemplateVersion`.
+ */
+export default class ChangeElementTemplateHandler {
+  constructor(bpmnFactory, commandStack, modeling) {
+    this._bpmnFactory = bpmnFactory;
+    this._commandStack = commandStack;
+    this._modeling = modeling;
+  }
+
+  /**
+   * Change an element's template and update its properties as specified in `newTemplate`. Specify
+   * `oldTemplate` to update from one template to another. If `newTemplate` isn't specified the
+   * `zeebe:modelerTemplate` and `zeebe:modelerTemplateVersion` properties will be removed from
+   * the element.
+   *
+   * @param {Object} context
+   * @param {Object} context.element
+   * @param {Object} [context.oldTemplate]
+   * @param {Object} [context.newTemplate]
+   */
+  preExecute(context) {
+    const element = context.element,
+          newTemplate = context.newTemplate,
+          oldTemplate = context.oldTemplate;
+
+    // update zeebe:modelerTemplate attribute
+    this._updateZeebeModelerTemplate(element, newTemplate);
+
+    if (newTemplate) {
+
+      // update properties
+      this._updateProperties(element, oldTemplate, newTemplate);
+    }
+  }
+
+  _getOrCreateExtensionElements(element) {
+    const bpmnFactory = this._bpmnFactory,
+          modeling = this._modeling;
+
+    const businessObject = getBusinessObject(element);
+
+    let extensionElements = businessObject.get('extensionElements');
+
+    if (!extensionElements) {
+      extensionElements = bpmnFactory.create('bpmn:ExtensionElements', {
+        values: []
+      });
+
+      extensionElements.$parent = businessObject;
+
+      modeling.updateProperties(element, {
+        extensionElements: extensionElements
+      });
+    }
+
+    return extensionElements;
+  }
+
+  _updateZeebeModelerTemplate(element, newTemplate) {
+    const modeling = this._modeling;
+
+    modeling.updateProperties(element, {
+      'zeebe:modelerTemplate': newTemplate && newTemplate.id,
+      'zeebe:modelerTemplateVersion': newTemplate && newTemplate.version
+    });
+  }
+
+  _updateProperties(element, oldTemplate, newTemplate) {
+    const commandStack = this._commandStack;
+
+    const newProperties = newTemplate.properties.filter((newProperty) => {
+      const newBinding = newProperty.binding,
+            newBindingType = newBinding.type;
+
+      return newBindingType === 'property';
+    });
+
+    if (!newProperties.length) {
+      return;
+    }
+
+    const businessObject = getBusinessObject(element);
+
+    newProperties.forEach((newProperty) => {
+      const oldProperty = findOldProperty(oldTemplate, newProperty),
+            newBinding = newProperty.binding,
+            newBindingName = newBinding.name,
+            newPropertyValue = newProperty.value,
+            changedElement = businessObject;
+
+      let properties = {};
+
+      if (oldProperty && propertyChanged(changedElement, oldProperty)) {
+        return;
+      }
+
+      properties[ newBindingName ] = newPropertyValue;
+
+      commandStack.execute('element.updateModdleProperties', {
+        element,
+        moddleElement: businessObject,
+        properties
+      });
+    });
+  }
+}
+
+ChangeElementTemplateHandler.$inject = [
+  'bpmnFactory',
+  'commandStack',
+  'modeling'
+];
+
+
+// helpers //////////
+
+/**
+ * Find old property matching specified new property.
+ *
+ * @param {Object} oldTemplate
+ * @param {Object} newProperty
+ *
+ * @returns {Object}
+ */
+function findOldProperty(oldTemplate, newProperty) {
+  if (!oldTemplate) {
+    return;
+  }
+
+  const oldProperties = oldTemplate.properties,
+        newBinding = newProperty.binding,
+        newBindingName = newBinding.name,
+        newBindingType = newBinding.type;
+
+  if (newBindingType === 'property') {
+    return find(oldProperties, function(oldProperty) {
+      const oldBinding = oldProperty.binding,
+            oldBindingName = oldBinding.name,
+            oldBindingType = oldBinding.type;
+
+      return oldBindingType === 'property' && oldBindingName === newBindingName;
+    });
+  }
+}
+
+/**
+ * Check whether property was changed after being set by template.
+ *
+ * @param {djs.model.Base|ModdleElement} element
+ * @param {Object} oldProperty
+ *
+ * @returns {boolean}
+ */
+function propertyChanged(element, oldProperty) {
+  const businessObject = getBusinessObject(element);
+
+  const oldBinding = oldProperty.binding,
+        oldBindingName = oldBinding.name,
+        oldBindingType = oldBinding.type,
+        oldPropertyValue = oldProperty.value;
+
+  if (oldBindingType === 'property') {
+    return businessObject.get(oldBindingName) !== oldPropertyValue;
+  }
+}

--- a/src/provider/cloud-element-templates/cmd/index.js
+++ b/src/provider/cloud-element-templates/cmd/index.js
@@ -1,0 +1,40 @@
+import ChangeElementTemplateHandler from './ChangeElementTemplateHandler';
+
+function registerHandlers(commandStack, elementTemplates, eventBus) {
+  commandStack.registerHandler(
+    'propertiesPanel.zeebe.changeTemplate',
+    ChangeElementTemplateHandler
+  );
+
+  // apply default element templates on shape creation
+  eventBus.on([ 'commandStack.shape.create.postExecuted' ], function(context) {
+    applyDefaultTemplate(context.context.shape, elementTemplates, commandStack);
+  });
+
+  // apply default element templates on connection creation
+  eventBus.on([ 'commandStack.connection.create.postExecuted' ], function(context) {
+    applyDefaultTemplate(context.context.connection, elementTemplates, commandStack);
+  });
+}
+
+registerHandlers.$inject = [ 'commandStack', 'elementTemplates', 'eventBus' ];
+
+
+export default {
+  __init__: [ registerHandlers ]
+};
+
+
+function applyDefaultTemplate(element, elementTemplates, commandStack) {
+
+  if (!elementTemplates.get(element) && elementTemplates.getDefault(element)) {
+
+    const command = 'propertiesPanel.zeebe.changeTemplate';
+    const commandContext = {
+      element: element,
+      newTemplate: elementTemplates.getDefault(element)
+    };
+
+    commandStack.execute(command, commandContext);
+  }
+}

--- a/src/provider/cloud-element-templates/components/ElementTemplatesGroup.js
+++ b/src/provider/cloud-element-templates/components/ElementTemplatesGroup.js
@@ -1,0 +1,296 @@
+import {
+  ArrowIcon,
+  CreateIcon,
+  DropdownButton,
+  HeaderButton,
+  useLayoutState
+} from '@bpmn-io/properties-panel';
+
+import classnames from 'classnames';
+
+import { isUndefined } from 'min-dash';
+
+import {
+  useService
+} from '../../../hooks';
+import { getTemplateId } from '../Helper';
+
+import {
+  getVersionOrDateFromTemplate,
+  removeTemplate,
+  unlinkTemplate,
+  updateTemplate
+} from '../util/templateUtil';
+
+
+/**
+ * @typedef {NoTemplate|KnownTemplate|UnknownTemplate|OutdatedTemplate} TemplateState
+ */
+
+/**
+ * @typedef NoTemplate
+ * @property {'NO_TEMPLATE'} type
+ *
+ * @typedef KnownTemplate
+ * @property {'KNOWN_TEMPLATE'} type
+ * @property {object} template
+ *
+ * @typedef UnknownTemplate
+ * @property {'UNKNOWN_TEMPLATE'} type
+ * @property {string} templateId
+ *
+ * @typedef OutdatedTemplate
+ * @property {'OUTDATED_TEMPLATE'} type
+ * @property {object} template
+ * @property {object} newerTemplate
+ */
+
+
+export function ElementTemplatesGroup(props) {
+  const {
+    id,
+    label,
+    element,
+    entries = []
+  } = props;
+
+  const [ open, setOpen ] = useLayoutState(
+    [ 'groups', id, 'open' ],
+    false
+  );
+
+  const empty = !entries.length;
+
+  const toggleOpen = () => !empty && setOpen(!open);
+
+  return <div class="bio-properties-panel-group bio-properties-panel-templates-group" data-group-id={ 'group-' + id }>
+    <div class={ classnames(
+      'bio-properties-panel-group-header',
+      {
+        empty,
+        open: open && !empty
+      }
+    ) } onClick={ toggleOpen }
+    >
+      <div title={ label } class="bio-properties-panel-group-header-title">
+        { label }
+      </div>
+
+      <div class="bio-properties-panel-group-header-buttons">
+        <TemplateGroupButtons element={ element } />
+        { !empty && <SectionToggle open={ open } /> }
+      </div>
+    </div>
+
+    <div class={ classnames(
+      'bio-properties-panel-group-entries',
+      { open: open && !empty }
+    ) }>
+      {
+        entries.map(e => e.component)
+      }
+    </div>
+  </div>;
+}
+
+
+function SectionToggle({ open }) {
+  return <HeaderButton
+    title="Toggle section"
+    class="bio-properties-panel-arrow"
+  >
+    <ArrowIcon class={ open ? 'bio-properties-panel-arrow-down' : 'bio-properties-panel-arrow-right' } />
+  </HeaderButton>;
+}
+
+
+/**
+ *
+ * @param {object} props
+ * @param {object} props.element
+ */
+function TemplateGroupButtons({ element }) {
+  const elementTemplates = useService('elementTemplates');
+
+  const templateState = getTemplateState(elementTemplates, element);
+
+  if (templateState.type === 'NO_TEMPLATE') {
+    return <SelectEntryTemplate element={ element } />;
+  } else if (templateState.type === 'KNOWN_TEMPLATE') {
+    return <AppliedTemplate element={ element } />;
+  } else if (templateState.type === 'UNKNOWN_TEMPLATE') {
+    return <UnknownTemplate element={ element } />;
+  } else if (templateState.type === 'OUTDATED_TEMPLATE') {
+    return <OutdatedTemplate element={ element } templateState={ templateState } />;
+  }
+}
+
+function SelectEntryTemplate({ element }) {
+  const translate = useService('translate');
+  const eventBus = useService('eventBus');
+
+  const selectTemplate = () => eventBus.fire('elementTemplates.select', { element });
+
+  return (
+    <HeaderButton
+      title="SelectEntry a template"
+      class="bio-properties-panel-select-template-button"
+      onClick={ selectTemplate }
+    >
+      <CreateIcon />
+      <span>{ translate('Select') }</span>
+    </HeaderButton>
+  );
+}
+
+function AppliedTemplate({ element }) {
+  const translate = useService('translate'),
+        injector = useService('injector');
+
+  const menuItems = [
+    { entry: translate('Unlink'), action: () => unlinkTemplate(element, injector) },
+    { entry: <RemoveTemplate />, action: () => removeTemplate(element, injector) }
+  ];
+
+  return (
+    <DropdownButton menuItems={ menuItems } class="bio-properties-panel-applied-template-button">
+      <HeaderButton>
+        <span>{ translate('Applied') }</span>
+        <ArrowIcon class="bio-properties-panel-arrow-down" />
+      </HeaderButton>
+    </DropdownButton>
+  );
+}
+
+function RemoveTemplate() {
+  const translate = useService('translate');
+
+  return <span class="bio-properties-panel-remove-template">{ translate('Remove') }</span>;
+}
+
+function UnknownTemplate({ element }) {
+  const translate = useService('translate'),
+        injector = useService('injector');
+
+  const menuItems = [
+    { entry: <NotFoundText /> },
+    { separator: true },
+    { entry: translate('Unlink'), action: () => unlinkTemplate(element, injector) },
+    { entry: <RemoveTemplate />, action: () => removeTemplate(element, injector) }
+  ];
+
+  return (
+    <DropdownButton menuItems={ menuItems } class="bio-properties-panel-template-not-found">
+      <HeaderButton>
+        <span>{ translate('Not found') }</span>
+        <ArrowIcon class="bio-properties-panel-arrow-down" />
+      </HeaderButton>
+    </DropdownButton>
+  );
+}
+
+function NotFoundText() {
+  const translate = useService('translate');
+
+  return (
+    <div class="bio-properties-panel-template-not-found-text">
+      { translate(
+        'The template applied was not found. Therefore, its properties cannot be shown. Unlink to access the data.'
+      ) }
+    </div>
+  );
+}
+
+/**
+ *
+ * @param {object} props
+ * @param {object} element
+ * @param {UnknownTemplate} templateState
+ */
+function OutdatedTemplate({ element, templateState }) {
+  const { newerTemplate } = templateState;
+
+  const translate = useService('translate'),
+        injector = useService('injector');
+
+  const menuItems = [
+    { entry: <UpdateAvailableText newerTemplate={ newerTemplate } /> },
+    { separator: true },
+    { entry: translate('Update'), action: () => updateTemplate(element, newerTemplate, injector) },
+    { entry: translate('Unlink'), action: () => unlinkTemplate(element, injector) },
+    { entry: <RemoveTemplate />, action: () => removeTemplate(element, injector) }
+  ];
+
+  return (
+    <DropdownButton menuItems={ menuItems } class="bio-properties-panel-template-update-available">
+      <HeaderButton>
+        <span>{ translate('Update available') }</span>
+        <ArrowIcon class="bio-properties-panel-arrow-down" />
+      </HeaderButton>
+    </DropdownButton>
+  );
+}
+
+function UpdateAvailableText({ newerTemplate }) {
+  const translate = useService('translate');
+
+  const text = translate(
+    'A new version of the template is available: {templateVersion}',
+    { templateVersion: getVersionOrDateFromTemplate(newerTemplate) }
+  );
+
+  return <div class="bio-properties-panel-template-update-available-text">{text}</div>;
+}
+
+
+// helper //////
+
+/**
+ * Determine template state in the current element.
+ *
+ * @param {object} elementTemplates
+ * @param {object} element
+ * @returns {TemplateState}
+ */
+function getTemplateState(elementTemplates, element) {
+  const templateId = getTemplateId(element),
+        template = elementTemplates.get(element);
+
+  if (!templateId) {
+    return { type: 'NO_TEMPLATE' };
+  }
+
+  if (!template) {
+    return { type: 'UNKNOWN_TEMPLATE', templateId };
+  }
+
+  const newerTemplate = findNewestElementTemplate(elementTemplates, template);
+  if (newerTemplate) {
+    return { type: 'OUTDATED_TEMPLATE', template, newerTemplate };
+  }
+
+  return { type: 'KNOWN_TEMPLATE', template };
+}
+
+function findNewestElementTemplate(elementTemplates, currentElementTemplate) {
+  if (isUndefined(currentElementTemplate.version)) {
+    return null;
+  }
+
+  return elementTemplates
+    .getAll()
+    .filter(function(elementTemplate) {
+      return currentElementTemplate.id === elementTemplate.id && !isUndefined(elementTemplate.version);
+    })
+    .reduce(function(newestElementTemplate, elementTemplate) {
+      if (currentElementTemplate.version < elementTemplate.version) {
+        return elementTemplate;
+      }
+
+      if (newestElementTemplate && newestElementTemplate.version < elementTemplate.version) {
+        return elementTemplate;
+      }
+
+      return newestElementTemplate;
+    }, null);
+}

--- a/src/provider/cloud-element-templates/components/index.js
+++ b/src/provider/cloud-element-templates/components/index.js
@@ -1,0 +1,1 @@
+export { ElementTemplatesGroup } from './ElementTemplatesGroup';

--- a/src/provider/cloud-element-templates/index.js
+++ b/src/provider/cloud-element-templates/index.js
@@ -1,0 +1,23 @@
+import translateModule from 'diagram-js/lib/i18n/translate';
+
+import ElementTemplates from './ElementTemplates';
+import ElementTemplatesLoader from './ElementTemplatesLoader';
+import ReplaceBehavior from '../element-templates/ReplaceBehavior';
+import commandsModule from './cmd';
+
+import zeebePropertiesProviderModule from '../zeebe';
+
+export default {
+  __depends__: [
+    commandsModule,
+    translateModule,
+    zeebePropertiesProviderModule
+  ],
+  __init__: [
+    'elementTemplatesLoader',
+    'replaceBehavior'
+  ],
+  elementTemplates: [ 'type', ElementTemplates ],
+  elementTemplatesLoader: [ 'type', ElementTemplatesLoader ],
+  replaceBehavior: [ 'type', ReplaceBehavior ]
+};

--- a/src/provider/cloud-element-templates/index.js
+++ b/src/provider/cloud-element-templates/index.js
@@ -4,6 +4,7 @@ import ElementTemplates from './ElementTemplates';
 import ElementTemplatesLoader from './ElementTemplatesLoader';
 import ReplaceBehavior from '../element-templates/ReplaceBehavior';
 import commandsModule from './cmd';
+import ElementTemplatesPropertiesProvider from './ElementTemplatesPropertiesProvider';
 
 import zeebePropertiesProviderModule from '../zeebe';
 
@@ -15,9 +16,11 @@ export default {
   ],
   __init__: [
     'elementTemplatesLoader',
-    'replaceBehavior'
+    'replaceBehavior',
+    'elementTemplatesPropertiesProvider'
   ],
   elementTemplates: [ 'type', ElementTemplates ],
   elementTemplatesLoader: [ 'type', ElementTemplatesLoader ],
-  replaceBehavior: [ 'type', ReplaceBehavior ]
+  replaceBehavior: [ 'type', ReplaceBehavior ],
+  elementTemplatesPropertiesProvider: [ 'type', ElementTemplatesPropertiesProvider ]
 };

--- a/src/provider/cloud-element-templates/properties/CustomProperties.js
+++ b/src/provider/cloud-element-templates/properties/CustomProperties.js
@@ -144,6 +144,7 @@ function getDefaultType(property) {
 
   if ([
     PROPERTY_TYPE,
+    ZEEBE_TASK_DEFINITION_TYPE_TYPE,
     ZEBBE_INPUT_TYPE,
     ZEEBE_OUTPUT_TYPE,
     ZEEBE_TASK_HEADER_TYPE

--- a/src/provider/cloud-element-templates/properties/CustomProperties.js
+++ b/src/provider/cloud-element-templates/properties/CustomProperties.js
@@ -1,0 +1,627 @@
+import {
+  isString,
+  isUndefined
+} from 'min-dash';
+
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import { useService } from '../../../hooks';
+
+import { PropertyDescription } from '../../element-templates/components/PropertyDescription';
+
+import {
+  Group,
+  SelectEntry, isSelectEntryEdited,
+  CheckboxEntry, isCheckboxEntryEdited,
+  TextAreaEntry, isTextAreaEntryEdited,
+  TextFieldEntry, isTextFieldEntryEdited
+} from '@bpmn-io/properties-panel';
+
+import {
+  findExtension,
+  findInputParameter,
+  findOutputParameter,
+  findTaskHeader
+} from '../Helper';
+
+import {
+  createInputParameter,
+  createOutputParameter,
+  createTaskDefinitionWithType,
+  createTaskHeader
+} from '../CreateHelper';
+
+import { createElement } from '../../../utils/ElementUtil';
+
+const PROPERTY_TYPE = 'property';
+
+const PRIMITIVE_MODDLE_TYPES = [
+  'Boolean',
+  'Integer',
+  'String'
+];
+
+const ZEBBE_INPUT_TYPE = 'zeebe:input',
+      ZEEBE_OUTPUT_TYPE = 'zeebe:output',
+      ZEEBE_TASK_DEFINITION_TYPE_TYPE = 'zeebe:taskDefinition:type',
+      ZEEBE_TASK_HEADER_TYPE = 'zeebe:taskHeader';
+
+const EXTENSION_BINDING_TYPES = [
+  ZEBBE_INPUT_TYPE,
+  ZEEBE_OUTPUT_TYPE,
+  ZEEBE_TASK_DEFINITION_TYPE_TYPE,
+  ZEEBE_TASK_HEADER_TYPE
+];
+
+const TASK_DEFINITION_TYPES = [
+  ZEEBE_TASK_DEFINITION_TYPE_TYPE
+];
+
+const IO_BINDING_TYPES = [
+  ZEBBE_INPUT_TYPE,
+  ZEEBE_OUTPUT_TYPE
+];
+
+
+export function CustomProperties(props) {
+  const {
+    element,
+    elementTemplate
+  } = props;
+
+  const groups = [];
+
+  const {
+    id
+  } = elementTemplate;
+
+  const customPropertiesGroup = {
+    id: 'ElementTemplates__CustomProperties',
+    label: 'Custom properties',
+    component: Group,
+    entries: []
+  };
+
+  elementTemplate.properties.forEach((property, index) => {
+    const entry = createCustomEntry(`custom-entry-${ id }-${ index }`, element, property);
+
+    if (entry) {
+      customPropertiesGroup.entries.push(entry);
+    }
+  });
+
+  if (customPropertiesGroup.entries.length) {
+    groups.push(customPropertiesGroup);
+  }
+
+  return groups;
+}
+
+function createCustomEntry(id, element, property) {
+  let { type } = property;
+
+  if (!type) {
+    type = getDefaultType(property);
+  }
+
+  if (type === 'Boolean') {
+    return {
+      id,
+      component: <BooleanProperty element={ element } id={ id } property={ property } />,
+      isEdited: isCheckboxEntryEdited
+    };
+  }
+
+  if (type === 'Dropdown') {
+    return {
+      id,
+      component: <DropdownProperty element={ element } id={ id } property={ property } />,
+      isEdited: isSelectEntryEdited
+    };
+  }
+
+  if (type === 'String') {
+    return {
+      id,
+      component: <StringProperty element={ element } id={ id } property={ property } />,
+      isEdited: isTextFieldEntryEdited
+    };
+  }
+
+  if (type === 'Text') {
+    return {
+      id,
+      component: <TextAreaProperty element={ element } id={ id } property={ property } />,
+      isEdited: isTextAreaEntryEdited
+    };
+  }
+}
+
+function getDefaultType(property) {
+  const { binding } = property;
+
+  const { type } = binding;
+
+  if ([
+    PROPERTY_TYPE,
+    ZEBBE_INPUT_TYPE,
+    ZEEBE_OUTPUT_TYPE,
+    ZEEBE_TASK_HEADER_TYPE
+  ].includes(type)) {
+    return 'String';
+  }
+}
+
+function BooleanProperty(props) {
+  const {
+    element,
+    id,
+    property
+  } = props;
+
+  const {
+    description,
+    editable,
+    label
+  } = property;
+
+  const bpmnFactory = useService('bpmnFactory'),
+        commandStack = useService('commandStack');
+
+  return CheckboxEntry({
+    element,
+    getValue: propertyGetter(element, property),
+    id,
+    label,
+    description: PropertyDescription({ description }),
+    setValue: propertySetter(bpmnFactory, commandStack, element, property),
+    disabled: editable === false
+  });
+}
+
+function DropdownProperty(props) {
+  const {
+    element,
+    id,
+    property
+  } = props;
+
+  const {
+    description,
+    editable,
+    label
+  } = property;
+
+  const bpmnFactory = useService('bpmnFactory'),
+        commandStack = useService('commandStack');
+
+  const getOptions = () => {
+    const { choices } = property;
+
+    return choices.map(({ name, value }) => {
+      return {
+        label: name,
+        value
+      };
+    });
+  };
+
+  return SelectEntry({
+    element,
+    id,
+    label,
+    getOptions,
+    description: PropertyDescription({ description }),
+    getValue: propertyGetter(element, property),
+    setValue: propertySetter(bpmnFactory, commandStack, element, property),
+    disabled: editable === false
+  });
+}
+
+function StringProperty(props) {
+  const {
+    element,
+    id,
+    property
+  } = props;
+
+  const {
+    description,
+    editable,
+    label
+  } = property;
+
+  const bpmnFactory = useService('bpmnFactory'),
+        commandStack = useService('commandStack'),
+        debounce = useService('debounceInput'),
+        translate = useService('translate');
+
+  return TextFieldEntry({
+    debounce,
+    element,
+    getValue: propertyGetter(element, property),
+    id,
+    label,
+    description: PropertyDescription({ description }),
+    setValue: propertySetter(bpmnFactory, commandStack, element, property),
+    validate: propertyValidator(translate, property),
+    disabled: editable === false
+  });
+}
+
+function TextAreaProperty(props) {
+  const {
+    element,
+    id,
+    property
+  } = props;
+
+  const {
+    description,
+    editable,
+    label
+  } = property;
+
+  const bpmnFactory = useService('bpmnFactory'),
+        commandStack = useService('commandStack'),
+        debounce = useService('debounceInput');
+
+  return TextAreaEntry({
+    debounce,
+    element,
+    id,
+    label,
+    description: PropertyDescription({ description }),
+    getValue: propertyGetter(element, property),
+    setValue: propertySetter(bpmnFactory, commandStack, element, property),
+    disabled: editable === false
+  });
+}
+
+function propertyGetter(element, property) {
+  return function getValue() {
+    let businessObject = getBusinessObject(element);
+
+    const {
+      binding,
+      value: defaultValue = ''
+    } = property;
+
+    const {
+      name,
+      type
+    } = binding;
+
+    // property
+    if (type === 'property') {
+      const value = businessObject.get(name);
+
+      if (!isUndefined(value)) {
+        return value;
+      }
+
+      return defaultValue;
+    }
+
+    // zeebe:taskDefinition
+    if (TASK_DEFINITION_TYPES.includes(type)) {
+      const taskDefinition = findExtension(businessObject, 'zeebe:TaskDefinition');
+
+      if (taskDefinition) {
+        if (type === ZEEBE_TASK_DEFINITION_TYPE_TYPE) {
+          return taskDefinition.get('type');
+        }
+      }
+
+      return defaultValue;
+    }
+
+    if (IO_BINDING_TYPES.includes(type)) {
+      const ioMapping = findExtension(businessObject, 'zeebe:IoMapping');
+
+      if (!ioMapping) {
+        return defaultValue;
+      }
+
+      // zeebe:Input
+      if (type === ZEBBE_INPUT_TYPE) {
+        const inputParameter = findInputParameter(ioMapping, binding);
+
+        if (inputParameter) {
+          return inputParameter.get('source');
+        }
+
+        return defaultValue;
+      }
+
+      // zeebe:Output
+      if (type === ZEEBE_OUTPUT_TYPE) {
+        const outputParameter = findOutputParameter(ioMapping, binding);
+
+        if (outputParameter) {
+          return outputParameter.get('target');
+        }
+
+        return defaultValue;
+      }
+    }
+
+    // zeebe:taskHeaders
+    if (type === ZEEBE_TASK_HEADER_TYPE) {
+      const taskHeaders = findExtension(businessObject, 'zeebe:TaskHeaders');
+
+      if (!taskHeaders) {
+        return defaultValue;
+      }
+
+      const header = findTaskHeader(taskHeaders, binding);
+
+      if (header) {
+        return header.get('value');
+      }
+
+      return defaultValue;
+    }
+
+    // should never throw as templates are validated beforehand
+    throw unknownBindingError(element, property);
+  };
+}
+
+function propertySetter(bpmnFactory, commandStack, element, property) {
+  return function setValue(value) {
+    let businessObject = getBusinessObject(element);
+
+    const { binding } = property;
+
+    const {
+      name,
+      type
+    } = binding;
+
+    let extensionElements;
+
+    let propertyValue;
+
+    const commands = [];
+
+    // ensure extension elements
+    if (EXTENSION_BINDING_TYPES.includes(type)) {
+      extensionElements = businessObject.get('extensionElements');
+
+      if (!extensionElements) {
+        extensionElements = createElement('bpmn:ExtensionElements', null, businessObject, bpmnFactory);
+
+        commands.push({
+          cmd: 'element.updateModdleProperties',
+          context: {
+            element,
+            moddleElement: businessObject,
+            properties: { extensionElements }
+          }
+        });
+      }
+    }
+
+    // property
+    if (type === 'property') {
+
+      const propertyDescriptor = businessObject.$descriptor.propertiesByName[ name ];
+
+      const { type: propertyType } = propertyDescriptor;
+
+      // do not override non-primitive types
+      if (!PRIMITIVE_MODDLE_TYPES.includes(propertyType)) {
+        throw new Error(`cannot set property of type <${ propertyType }>`);
+      }
+
+      if (propertyType === 'Boolean') {
+        propertyValue = !!value;
+      } else if (propertyType === 'Integer') {
+        propertyValue = parseInt(value, 10);
+
+        if (isNaN(propertyValue)) {
+
+          // do not set NaN value
+          propertyValue = undefined;
+        }
+      } else {
+
+        // make sure we don't remove the property
+        propertyValue = value || '';
+      }
+
+      if (!isUndefined(propertyValue)) {
+        commands.push({
+          cmd: 'element.updateModdleProperties',
+          context: {
+            element,
+            moddleElement: businessObject,
+            properties: { [ name ]: propertyValue }
+          }
+        });
+      }
+    }
+
+    // zeebe:taskDefinition
+    if (TASK_DEFINITION_TYPES.includes(type)) {
+      const oldTaskDefinition = findExtension(extensionElements, 'zeebe:TaskDefinition');
+
+      let newTaskDefinition;
+
+      if (type === ZEEBE_TASK_DEFINITION_TYPE_TYPE) {
+        newTaskDefinition = createTaskDefinitionWithType(value, bpmnFactory);
+      } else {
+        return unknownBindingError(element, property);
+      }
+
+      const values = extensionElements.get('values').filter((value) => value !== oldTaskDefinition);
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: extensionElements,
+          properties: { values: [ ...values, newTaskDefinition ] }
+        }
+      });
+    }
+
+    if (IO_BINDING_TYPES.includes(type)) {
+      let ioMapping = findExtension(extensionElements, 'zeebe:IoMapping');
+
+      if (!ioMapping) {
+        ioMapping = createElement('zeebe:IoMapping', null, businessObject, bpmnFactory);
+
+        commands.push({
+          cmd: 'element.updateModdleProperties',
+          context: {
+            element,
+            moddleElement: extensionElements,
+            properties: { values: [ ...extensionElements.get('values'), ioMapping ] }
+          }
+        });
+      }
+
+      // zeebe:Input
+      if (type === ZEBBE_INPUT_TYPE) {
+        const oldZeebeInputParameter = findInputParameter(ioMapping, binding);
+
+        const newZeebeInputParameter = createInputParameter(binding, value, bpmnFactory);
+
+        const values = ioMapping.get('inputParameters').filter((value) => value !== oldZeebeInputParameter);
+
+        commands.push({
+          cmd: 'element.updateModdleProperties',
+          context: {
+            element,
+            moddleElement: ioMapping,
+            properties: { inputParameters: [ ...values, newZeebeInputParameter ] }
+          }
+        });
+      }
+
+      // zeebe:Output
+      if (type === ZEEBE_OUTPUT_TYPE) {
+        const oldZeebeOutputParameter = findOutputParameter(ioMapping, binding);
+
+        const newZeebeOutputParameter = createOutputParameter(binding, value, bpmnFactory);
+
+        const values = ioMapping.get('outputParameters').filter((value) => value !== oldZeebeOutputParameter);
+
+        commands.push({
+          cmd: 'element.updateModdleProperties',
+          context: {
+            element,
+            moddleElement: ioMapping,
+            properties: { 'outputParameters': [ ...values, newZeebeOutputParameter ] }
+          }
+        });
+      }
+    }
+
+    // zeebe:taskHeaders
+    if (type === ZEEBE_TASK_HEADER_TYPE) {
+      let taskHeaders = findExtension(extensionElements, 'zeebe:TaskHeaders');
+
+      if (!taskHeaders) {
+        taskHeaders = createElement('zeebe:TaskHeaders', null, businessObject, bpmnFactory);
+
+        commands.push({
+          cmd: 'element.updateModdleProperties',
+          context: {
+            element,
+            moddleElement: extensionElements,
+            properties: { values: [ ...extensionElements.get('values'), taskHeaders ] }
+          }
+        });
+      }
+
+      const oldTaskHeader = findTaskHeader(taskHeaders, binding);
+
+      const newTaskHeader = createTaskHeader(binding, value, bpmnFactory);
+
+      const values = taskHeaders.get('values').filter((value) => value !== oldTaskHeader);
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: taskHeaders,
+          properties: { values: [ ...values, newTaskHeader ] }
+        }
+      });
+    }
+
+    if (commands.length) {
+      commandStack.execute(
+        'properties-panel.multi-command-executor',
+        commands
+      );
+
+      return;
+    }
+
+    // should never throw as templates are validated beforehand
+    throw unknownBindingError(element, property);
+  };
+}
+
+function propertyValidator(translate, property) {
+  return function validate(value) {
+    const { constraints = {} } = property;
+
+    const {
+      maxLength,
+      minLength,
+      notEmpty
+    } = constraints;
+
+    if (notEmpty && isEmptyString(value)) {
+      return translate('Must not be empty.');
+    }
+
+    if (maxLength && value.length > maxLength) {
+      return translate('Must have max length {maxLength}.', { maxLength });
+    }
+
+    if (minLength && value.length < minLength) {
+      return translate('Must have min length {minLength}.', { minLength });
+    }
+
+    let { pattern } = constraints;
+
+    if (pattern) {
+      let message;
+
+      if (!isString(pattern)) {
+        message = pattern.message;
+        pattern = pattern.value;
+      }
+
+      if (!matchesPattern(value, pattern)) {
+        return message || translate('Must match pattern {pattern}.', { pattern });
+      }
+    }
+  };
+}
+
+function unknownBindingError(element, property) {
+  const businessObject = getBusinessObject(element);
+
+  const id = businessObject.get('id');
+
+  const { binding } = property;
+
+  const { type } = binding;
+
+  return new Error(`unknown binding <${ type }> for element <${ id }>, this should never happen`);
+}
+
+function isEmptyString(string) {
+  return !string || !string.trim().length;
+}
+
+function matchesPattern(string, pattern) {
+  return new RegExp(pattern).test(string);
+}

--- a/src/provider/cloud-element-templates/properties/index.js
+++ b/src/provider/cloud-element-templates/properties/index.js
@@ -1,0 +1,1 @@
+export { CustomProperties } from './CustomProperties';

--- a/src/provider/cloud-element-templates/util/templateUtil.js
+++ b/src/provider/cloud-element-templates/util/templateUtil.js
@@ -1,0 +1,98 @@
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import { isUndefined } from 'min-dash';
+
+
+export function unlinkTemplate(element, injector) {
+  const modeling = injector.get('modeling');
+
+  modeling.updateProperties(element, {
+    'zeebe:modelerTemplate': null,
+    'zeebe:modelerTemplateVersion': null
+  });
+}
+
+export function removeTemplate(element, injector) {
+  const replace = injector.get('replace'),
+        selection = injector.get('selection');
+
+  const businessObject = getBusinessObject(element);
+
+  const type = businessObject.$type,
+        eventDefinitionType = getEventDefinitionType(businessObject);
+
+  const newElement = replace.replaceElement(element, {
+    type: type,
+    eventDefinitionType: eventDefinitionType
+  });
+
+  selection.select(newElement);
+}
+
+export function updateTemplate(element, newTemplate, injector) {
+  const commandStack = injector.get('commandStack'),
+        elementTemplates = injector.get('elementTemplates');
+
+  const oldTemplate = elementTemplates.get(element);
+
+  commandStack.execute('propertiesPanel.zeebe.changeTemplate', {
+    element: element,
+    newTemplate,
+    oldTemplate
+  });
+}
+
+export function getVersionOrDateFromTemplate(template) {
+  var metadata = template.metadata,
+      version = template.version;
+
+  if (metadata) {
+    if (!isUndefined(metadata.created)) {
+      return toDateString(metadata.created);
+    } else if (!isUndefined(metadata.updated)) {
+      return toDateString(metadata.updated);
+    }
+  }
+
+  if (isUndefined(version)) {
+    return null;
+  }
+
+  return version;
+}
+
+
+// helper //////
+function getEventDefinitionType(businessObject) {
+  if (!businessObject.eventDefinitions) {
+    return null;
+  }
+
+  var eventDefinition = businessObject.eventDefinitions[ 0 ];
+
+  if (!eventDefinition) {
+    return null;
+  }
+
+  return eventDefinition.$type;
+}
+
+function toDateString(timestamp) {
+  var date = new Date(timestamp);
+
+  var year = date.getFullYear();
+
+  var month = leftPad(String(date.getMonth() + 1), 2, '0');
+
+  var day = leftPad(String(date.getDate()), 2, '0');
+
+  return day + '.' + month + '.' + year;
+}
+
+function leftPad(string, length, character) {
+  while (string.length < length) {
+    string = character + string;
+  }
+
+  return string;
+}

--- a/src/provider/cloud-element-templates/util/validate.js
+++ b/src/provider/cloud-element-templates/util/validate.js
@@ -1,0 +1,13 @@
+import { Validator } from '../Validator';
+
+/**
+ * Validate the given template descriptors and
+ * return a list of errors.
+ *
+ * @param {Array<TemplateDescriptor>} descriptors
+ *
+ * @return {Array<Error>}
+ */
+export default function validate(descriptors) {
+  return new Validator().addAll(descriptors).getErrors();
+}

--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -25,6 +25,7 @@ import BpmnPropertiesProvider from 'src/provider/bpmn';
 import CamundaPropertiesProvider from 'src/provider/camunda-platform';
 import ZeebePropertiesProvider from 'src/provider/zeebe';
 import ElementTemplatesPropertiesProvider from 'src/provider/element-templates';
+import CloudElementTemplatesPropertiesProvider from 'src/provider/cloud-element-templates';
 
 import CamundaModdle from 'camunda-bpmn-moddle/resources/camunda';
 import CamundaModdleExtension from 'camunda-bpmn-moddle/lib';
@@ -204,6 +205,35 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
         ],
         moddleExtensions: {
           camunda: CamundaModdle
+        },
+        elementTemplates
+      }
+    );
+
+    // then
+    expect(result.error).not.to.exist;
+  });
+
+
+  (singleStart === 'cloud-templates' ? it.only : it)('should import simple process (cloud-templates)', async function() {
+
+    // given
+    const diagramXml = require('test/spec/provider/cloud-element-templates/fixtures/connectors.bpmn').default;
+
+    const elementTemplates = require('test/spec/provider/cloud-element-templates/fixtures/connectors.json');
+
+    // when
+    const result = await createModeler(
+      diagramXml,
+      {
+        additionalModules: [
+          ZeebeModdleExtension,
+          BpmnPropertiesPanel,
+          BpmnPropertiesProvider,
+          CloudElementTemplatesPropertiesProvider
+        ],
+        moddleExtensions: {
+          zeebe: ZeebeModdle
         },
         elementTemplates
       }

--- a/test/spec/provider/cloud-element-templates/ElementTemplates.bpmn
+++ b/test/spec/provider/cloud-element-templates/ElementTemplates.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_08adx7k" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:task id="Task_1" zeebe:modelerTemplate="foo" />
+    <bpmn:task id="Task_2" zeebe:modelerTemplate="foo" zeebe:modelerTemplateVersion="1" />
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="UnknownTemplateTask" zeebe:modelerTemplate="unknown" />
+    <bpmn:serviceTask id="ServiceTask" zeebe:modelerTemplate="default" zeebe:modelerTemplateVersion="1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_1srimyz_di" bpmnElement="Task_1">
+        <dc:Bounds x="150" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0z29dre_di" bpmnElement="Task_2">
+        <dc:Bounds x="270" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1m5rz19_di" bpmnElement="Task_3">
+        <dc:Bounds x="390" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UnknownTemplateTask_di" bpmnElement="UnknownTemplateTask">
+        <dc:Bounds x="390" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_di" bpmnElement="ServiceTask">
+        <dc:Bounds x="150" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/cloud-element-templates/ElementTemplates.spec.js
+++ b/test/spec/provider/cloud-element-templates/ElementTemplates.spec.js
@@ -1,0 +1,130 @@
+import TestContainer from 'mocha-test-container-support';
+
+import { bootstrapModeler, inject } from 'test/TestHelper';
+
+import coreModule from 'bpmn-js/lib/core';
+import elementTemplatesModule from 'src/provider/cloud-element-templates';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+
+import zeebeModdlePackage from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import diagramXML from './ElementTemplates.bpmn';
+
+import templates from './fixtures/simple';
+
+
+describe('provider/cloud-element-templates - ElementTemplates', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    container: container,
+    modules: [
+      coreModule,
+      elementTemplatesModule,
+      modelingModule,
+      {
+        propertiesPanel: [ 'value', { registerProvider() {} } ]
+      }
+    ],
+    moddleExtensions: {
+      zeebe: zeebeModdlePackage
+    }
+  }));
+
+  beforeEach(inject(function(elementTemplates) {
+    elementTemplates.set(templates);
+  }));
+
+
+  describe('get', function() {
+
+    it('should get template by ID', inject(function(elementTemplates) {
+
+      // when
+      const template = elementTemplates.get('foo');
+
+      // then
+      expect(template.id).to.equal('foo');
+      expect(template.version).not.to.exist;
+    }));
+
+
+    it('should get template by ID and version', inject(function(elementTemplates) {
+
+      // when
+      const template = elementTemplates.get('foo', 1);
+
+      // then
+      expect(template.id).to.equal('foo');
+      expect(template.version).to.equal(1);
+    }));
+
+
+    it('should get template by element (template ID)', inject(function(elementRegistry, elementTemplates) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const template = elementTemplates.get(task);
+
+      // then
+      expect(template.id).to.equal('foo');
+      expect(template.version).not.to.exist;
+    }));
+
+
+    it('should get template by element (template ID and version)', inject(function(elementRegistry, elementTemplates) {
+
+      // given
+      const task = elementRegistry.get('Task_2');
+
+      // when
+      const template = elementTemplates.get(task);
+
+      // then
+      expect(template.id).to.equal('foo');
+      expect(template.version).to.equal(1);
+    }));
+
+
+    it('should not get template (no template with ID)', inject(function(elementTemplates) {
+
+      // when
+      const template = elementTemplates.get('oof');
+
+      // then
+      expect(template).to.be.null;
+    }));
+
+
+    it('should not get template (no template with ID)', inject(function(elementTemplates) {
+
+      // when
+      const template = elementTemplates.get('foo', -1);
+
+      // then
+      expect(template).to.be.null;
+    }));
+
+
+    it('should not get template (no template applied to element)', inject(function(elementRegistry, elementTemplates) {
+
+      // given
+      const task = elementRegistry.get('Task_3');
+
+      // when
+      const template = elementTemplates.get(task);
+
+      // then
+      expect(template).to.be.null;
+    }));
+
+  });
+
+});

--- a/test/spec/provider/cloud-element-templates/ElementTemplatesPropertiesProvider.bpmn
+++ b/test/spec/provider/cloud-element-templates/ElementTemplatesPropertiesProvider.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_08adx7k" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:task id="Task_1" zeebe:modelerTemplate="foo" />
+    <bpmn:task id="Task_2" zeebe:modelerTemplate="foo" zeebe:modelerTemplateVersion="1" />
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="UnknownTemplateTask" zeebe:modelerTemplate="unknown" />
+    <bpmn:serviceTask id="ServiceTask" zeebe:modelerTemplate="default" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_1srimyz_di" bpmnElement="Task_1">
+        <dc:Bounds x="150" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0z29dre_di" bpmnElement="Task_2">
+        <dc:Bounds x="270" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1m5rz19_di" bpmnElement="Task_3">
+        <dc:Bounds x="390" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UnknownTemplateTask_di" bpmnElement="UnknownTemplateTask">
+        <dc:Bounds x="390" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_di" bpmnElement="ServiceTask">
+        <dc:Bounds x="150" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/cloud-element-templates/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/provider/cloud-element-templates/ElementTemplatesPropertiesProvider.spec.js
@@ -1,0 +1,502 @@
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  act
+} from '@testing-library/preact';
+
+import {
+  query as domQuery,
+  queryAll as domQueryAll
+} from 'min-dom';
+
+import { map } from 'min-dash';
+
+import coreModule from 'bpmn-js/lib/core';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import zeebeModdlePackage from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import {
+  bootstrapPropertiesPanel,
+  clickInput as click,
+  inject
+} from 'test/TestHelper';
+
+import BpmnPropertiesPanel from 'src/render';
+import elementTemplatesModule from 'src/provider/cloud-element-templates';
+import bpmnPropertiesProvider from 'src/provider/bpmn';
+
+import diagramXML from './ElementTemplatesPropertiesProvider.bpmn';
+import templates from './fixtures/simple.json';
+import entriesVisibleDiagramXML from './fixtures/entries-visible.bpmn';
+import entriesVisibleTemplates from './fixtures/entries-visible.json';
+
+
+describe('provider/cloud-element-templates - ElementTemplates', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    container,
+    modules: [
+      BpmnPropertiesPanel,
+      coreModule,
+      bpmnPropertiesProvider,
+      elementTemplatesModule,
+      modelingModule
+    ],
+    moddleExtensions: {
+      zeebe: zeebeModdlePackage
+    },
+    debounceInput: false,
+    elementTemplates: templates
+  }));
+
+
+  describe('basics', function() {
+
+    it('should display template group', inject(
+      async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('Task_1');
+
+        // when
+        await act(() => {
+          selection.select(element);
+        });
+
+        // then
+        const group = domQuery('[data-group-id="group-ElementTemplates__Template"]', container);
+
+        expect(group).to.exist;
+      })
+    );
+
+
+    it('should NOT display template group if no templates are available for element', inject(
+      async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('Process_1');
+
+        // when
+        await act(() => {
+          selection.select(element);
+        });
+
+        // then
+        const group = domQuery('[data-group-id="group-ElementTemplates__Template"]', container);
+
+        expect(group).not.to.exist;
+      })
+    );
+
+
+    it('should display update template button update is available', inject(
+      async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('Task_2');
+
+        // when
+        await act(() => {
+          selection.select(element);
+        });
+
+        // then
+        const updateAvailable = domQuery('.bio-properties-panel-template-update-available', container);
+
+        expect(updateAvailable).to.exist;
+      })
+    );
+
+
+    it('should NOT display update template button when no update is available', inject(
+      async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('ServiceTask');
+
+        // when
+        await act(() => {
+          selection.select(element);
+        });
+
+        // then
+        const updateAvailable = domQuery('.bio-properties-panel-template-update-available', container);
+
+        expect(updateAvailable).not.to.exist;
+      })
+    );
+  });
+
+
+  describe('template#entriesVisible', function() {
+
+    beforeEach(bootstrapPropertiesPanel(entriesVisibleDiagramXML, {
+      container,
+      modules: [
+        BpmnPropertiesPanel,
+        coreModule,
+        bpmnPropertiesProvider,
+        elementTemplatesModule,
+        modelingModule
+      ],
+      moddleExtensions: {
+        zeebe: zeebeModdlePackage
+      },
+      debounceInput: false,
+      elementTemplates: entriesVisibleTemplates
+    }));
+
+
+    it('should show only general group, and template-related entries when entriesVisible is unset',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('ServiceTask');
+
+        // when
+        await act(() => {
+          selection.select(element);
+        });
+
+        // then
+        expectOnlyGroups(container, [
+          'general',
+          'ElementTemplates__Template'
+        ]);
+      })
+    );
+
+
+    it('should show only general group, and template-related entries when entriesVisible=false',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('Task_2');
+
+        // when
+        await act(() => {
+          selection.select(element);
+        });
+
+        // then
+        expectOnlyGroups(container, [
+          'general',
+          'ElementTemplates__Template'
+        ]);
+      })
+    );
+
+
+    it('should show only general group, and template group when template is unknown',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('UnknownTemplateTask');
+
+        // when
+        await act(() => {
+          selection.select(element);
+        });
+
+        // then
+        expectOnlyGroups(container, [
+          'general',
+          'ElementTemplates__Template'
+        ]);
+      })
+    );
+
+
+    it('should show all available groups when entriesVisible=true',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('Task_1');
+
+        // when
+        await act(() => {
+          selection.select(element);
+        });
+
+        // then
+        const groups = getGroupIds(container);
+
+        expect(groups).to.contain('general');
+        expect(groups).to.contain('ElementTemplates__Template');
+        expect(groups).to.contain('documentation');
+      })
+    );
+  });
+
+
+  describe('template#select', function() {
+
+    it('should fire `elementTemplates.select` when button is clicked template group', inject(
+      async function(elementRegistry, selection, eventBus) {
+
+        // given
+        const spy = sinon.spy();
+        const element = elementRegistry.get('Task_3');
+
+        eventBus.on('elementTemplates.select', spy);
+
+        await act(() => {
+          selection.select(element);
+        });
+        const group = domQuery('[data-group-id="group-ElementTemplates__Template"]', container);
+        const selectButton = domQuery('.bio-properties-panel-select-template-button', group);
+
+        // when
+        await act(() => {
+          selectButton.click();
+        });
+
+        // then
+        expect(spy).to.have.been.calledOnce;
+        expect(spy).to.have.been.calledWithMatch({ element });
+      })
+    );
+  });
+
+
+  describe('template#remove', function() {
+
+    it('should remove applied template', inject(
+      async function(elementRegistry, selection, elementTemplates) {
+
+        // given
+        let task = elementRegistry.get('Task_1');
+        await act(() => selection.select(task));
+
+        // when
+        await removeTemplate(container);
+
+        // then
+        task = elementRegistry.get('Task_1');
+        const template = elementTemplates.get(task);
+
+        expect(template).to.not.exist;
+      })
+    );
+
+
+    it('should remove outdated template', inject(
+      async function(elementRegistry, selection, elementTemplates) {
+
+        // given
+        let task = elementRegistry.get('Task_2');
+        await act(() => selection.select(task));
+
+        // when
+        await removeTemplate(container);
+
+        // then
+        task = elementRegistry.get('Task_2');
+        const template = elementTemplates.get(task);
+
+        expect(template).to.not.exist;
+      })
+    );
+
+
+    it('should remove unknown template', inject(
+      async function(elementRegistry, selection, elementTemplates) {
+
+        // given
+        let task = elementRegistry.get('UnknownTemplateTask');
+        await act(() => selection.select(task));
+
+        // when
+        await removeTemplate(container);
+
+        // then
+        task = elementRegistry.get('UnknownTemplateTask');
+        const template = elementTemplates.get(task);
+
+        expect(template).to.not.exist;
+      })
+    );
+
+  });
+
+
+  describe('template#unlink', function() {
+
+    it('should unlink applied template', inject(
+      async function(elementRegistry, selection, elementTemplates) {
+
+        // given
+        let task = elementRegistry.get('Task_1');
+        await act(() => selection.select(task));
+
+        // when
+        await unlinkTemplate(container);
+
+        // then
+        task = elementRegistry.get('Task_1');
+        const template = elementTemplates.get(task);
+
+        expect(template).to.not.exist;
+      })
+    );
+
+
+    it('should unlink outdated template', inject(
+      async function(elementRegistry, selection, elementTemplates) {
+
+        // given
+        let task = elementRegistry.get('Task_2');
+        await act(() => selection.select(task));
+
+        // when
+        await unlinkTemplate(container);
+
+        // then
+        task = elementRegistry.get('Task_2');
+        const template = elementTemplates.get(task);
+
+        expect(template).to.not.exist;
+      })
+    );
+
+
+    it('should unlink unknown template', inject(
+      async function(elementRegistry, selection, elementTemplates) {
+
+        // given
+        let task = elementRegistry.get('UnknownTemplateTask');
+        await act(() => selection.select(task));
+
+        // when
+        await unlinkTemplate(container);
+
+        // then
+        task = elementRegistry.get('UnknownTemplateTask');
+        const template = elementTemplates.get(task);
+
+        expect(template).to.not.exist;
+      })
+    );
+  });
+
+
+  describe('template#update', function() {
+
+    it('should update template', inject(
+      async function(elementRegistry, selection, elementTemplates) {
+
+        // given
+        let task = elementRegistry.get('Task_2');
+        await act(() => selection.select(task));
+
+        // when
+        await updateTemplate(container);
+
+        // then
+        task = elementRegistry.get('Task_2');
+        const template = elementTemplates.get(task);
+
+        expect(template).to.have.property('id', 'foo');
+        expect(template).to.have.property('version', 3);
+      })
+    );
+  });
+});
+
+
+
+// helper ////
+
+/**
+ * Remove template via dropdown menu.
+ *
+ * @param {Element} container
+ */
+function removeTemplate(container) {
+  return clickDropdownItemWhere(container,
+    button => domQuery('.bio-properties-panel-remove-template', button));
+}
+
+/**
+ * Unlink template via dropdown menu.
+ *
+ * @param {Element} container
+ */
+function unlinkTemplate(container) {
+  return clickDropdownItemWhere(container, element => element.textContent === 'Unlink');
+}
+
+/**
+ * Update template via dropdown menu.
+ *
+ * @param {Element} container
+ */
+function updateTemplate(container) {
+  return clickDropdownItemWhere(container, element => element.textContent === 'Update');
+}
+
+/**
+ * Click dropdown item matching the condition.
+ *
+ * @param {Element} container
+ * @param {(button: Element) => boolean} predicate
+ * @returns
+ */
+function clickDropdownItemWhere(container, predicate) {
+  if (!container) {
+    throw new Error('container is missing');
+  }
+
+  const buttons = domQueryAll('.bio-properties-panel-dropdown-button__menu-item', container);
+
+  for (const button of buttons) {
+    if (predicate(button)) {
+      return click(button);
+    }
+  }
+
+  throw new Error('button is missing');
+}
+
+/**
+ * Check if rendered groups match the provided ids.
+ *
+ * @param {Element} container
+ * @param {string[]} expectedGroupIds
+ */
+function expectOnlyGroups(container, expectedGroupIds) {
+  const groupIds = getGroupIds(container);
+
+  expect(groupIds).to.deep.equal(expectedGroupIds);
+}
+
+/**
+ * Get ids of rendered groups.
+ *
+ * @param {Element} container
+ */
+function getGroupIds(container) {
+  if (!container) {
+    throw new Error('container is missing');
+  }
+
+  const groups = domQueryAll('[data-group-id]', container);
+  const groupIds = map(groups, group => withoutPrefix(group.dataset.groupId));
+
+  return groupIds;
+}
+
+/**
+ * @param {`group-${string}`} groupId
+ * @returns {string}
+ */
+function withoutPrefix(groupId) {
+  return groupId.slice(6);
+}

--- a/test/spec/provider/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
+++ b/test/spec/provider/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
@@ -1,0 +1,1535 @@
+import {
+  bootstrapModeler,
+  getBpmnJS,
+  inject
+} from 'test/TestHelper';
+
+import TestContainer from 'mocha-test-container-support';
+
+import CoreModule from 'bpmn-js/lib/core';
+import ElementTemplatesModule from 'src/provider/cloud-element-templates';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+import PropertiesPanelCommandsModule from 'src/cmd';
+
+import zeebeModdlePackage from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  findExtension
+} from 'src/provider/cloud-element-templates/Helper';
+
+import {
+  find,
+  isArray,
+  isString,
+  isUndefined
+} from 'min-dash';
+
+const modules = [
+  CoreModule,
+  ElementTemplatesModule,
+  ModelingModule,
+  PropertiesPanelCommandsModule,
+  {
+    propertiesPanel: [ 'value', { registerProvider() {} } ]
+  }
+];
+
+const moddleExtensions = {
+  zeebe: zeebeModdlePackage
+};
+
+
+describe('cloud-element-templates - ChangeElementTemplateHandler', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  function bootstrap(diagramXML) {
+    return bootstrapModeler(diagramXML, {
+      container,
+      modules,
+      moddleExtensions
+    });
+  }
+
+
+  describe('change template (new template specified)', function() {
+
+    describe('update zeebe:modelerTemplate and zeebe:modelerTemplateVersion', function() {
+
+      beforeEach(bootstrap(require('./task.bpmn').default));
+
+      const newTemplate = require('./task-template-1.json');
+
+
+      it('execute', inject(function(elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        // when
+        changeTemplate(task, newTemplate);
+
+        // then
+        expectElementTemplate(task, 'task-template', 1);
+      }));
+
+
+      it('undo', inject(function(commandStack, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        changeTemplate(task, newTemplate);
+
+        // when
+        commandStack.undo();
+
+        // then
+        expectNoElementTemplate(task);
+      }));
+
+
+      it('redo', inject(function(commandStack, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        changeTemplate(task, newTemplate);
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expectElementTemplate(task, 'task-template', 1);
+      }));
+
+    });
+
+
+    describe('update name', function() {
+
+      beforeEach(bootstrap(require('./task.bpmn').default));
+
+      const newTemplate = require('./task-template-1.json');
+
+
+      it('execute', inject(function(elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1'),
+              businessObject = getBusinessObject(task);
+
+        // when
+        changeTemplate(task, newTemplate);
+
+        // then
+        expectElementTemplate(task, 'task-template', 1);
+
+        const name = businessObject.get('bpmn:name');
+
+        expect(name).to.exist;
+        expect(name).to.equal('task-name');
+      }));
+
+
+      it('undo', inject(function(commandStack, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1'),
+              businessObject = task.businessObject;
+
+        changeTemplate(task, newTemplate);
+
+        // when
+        commandStack.undo();
+
+        // then
+        expectNoElementTemplate(task);
+
+        const name = businessObject.get('bpmn:name');
+
+        expect(name).not.to.exist;
+      }));
+
+
+      it('redo', inject(function(commandStack, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1'),
+              businessObject = task.businessObject;
+
+        changeTemplate(task, newTemplate);
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expectElementTemplate(task, 'task-template', 1);
+
+        const name = businessObject.get('bpmn:name');
+
+        expect(name).to.exist;
+        expect(name).to.equal('task-name');
+      }));
+
+    });
+
+
+    describe('update zeebe:taskDefinition', function() {
+
+      describe('zeebe:taskDefinition:type specified', function() {
+
+        beforeEach(bootstrap(require('./task.bpmn').default));
+
+        const newTemplate = require('./task-template-1.json');
+
+
+        it('execute', inject(function(elementRegistry) {
+
+          // given
+          const task = elementRegistry.get('Task_1');
+
+          // when
+          changeTemplate(task, newTemplate);
+
+          // then
+          expectElementTemplate(task, 'task-template', 1);
+
+          const taskDefinition = findExtension(task, 'zeebe:TaskDefinition');
+
+          expect(taskDefinition).to.exist;
+          expect(taskDefinition.get('type')).to.equal('task-type');
+        }));
+
+
+        it('undo', inject(function(commandStack, elementRegistry) {
+
+          // given
+          const task = elementRegistry.get('Task_1');
+
+          changeTemplate(task, newTemplate);
+
+          // when
+          commandStack.undo();
+
+          // then
+          expectNoElementTemplate(task);
+
+          const taskDefinition = findExtension(task, 'zeebe:TaskDefinition');
+
+          expect(taskDefinition).not.to.exist;
+        }));
+
+
+        it('redo', inject(function(commandStack, elementRegistry) {
+
+          // given
+          const task = elementRegistry.get('Task_1');
+
+          changeTemplate(task, newTemplate);
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expectElementTemplate(task, 'task-template', 1);
+
+          const taskDefinition = findExtension(task, 'zeebe:TaskDefinition');
+
+          expect(taskDefinition).to.exist;
+          expect(taskDefinition.get('type')).to.equal('task-type');
+        }));
+
+      });
+
+
+      describe('zeebe:taskDefinition:type not specified', function() {
+
+        beforeEach(bootstrap(require('./task-definition.bpmn').default));
+
+        const newTemplate = require('./task-template-no-properties.json');
+
+
+        it('should not override existing', inject(function(elementRegistry) {
+
+          // given
+          const task = elementRegistry.get('Task_1');
+
+          // when
+          changeTemplate(task, newTemplate);
+
+          // then
+          expectElementTemplate(task, 'task-template-no-properties');
+
+          const taskDefinition = findExtension(task, 'zeebe:TaskDefinition');
+
+          expect(taskDefinition).to.exist;
+          expect(taskDefinition.get('type')).to.equal('task-type');
+        }));
+
+      });
+
+    });
+
+
+    describe('update zeebe:ioMapping', function() {
+
+      describe('zeebe:Input and zeebe:Output specified', function() {
+
+        beforeEach(bootstrap(require('./task.bpmn').default));
+
+        const newTemplate = require('./task-template-1.json');
+
+
+        it('execute', inject(function(elementRegistry) {
+
+          // given
+          const task = elementRegistry.get('Task_1');
+
+          // when
+          changeTemplate(task, newTemplate);
+
+          // then
+          expectElementTemplate(task, 'task-template', 1);
+
+          const ioMapping = findExtension(task, 'zeebe:IoMapping');
+
+          expect(ioMapping).to.exist;
+          expect(ioMapping.get('zeebe:inputParameters')).to.have.length(2);
+          expect(ioMapping.get('zeebe:outputParameters')).to.have.length(2);
+
+          expect(ioMapping.get('zeebe:inputParameters')).to.jsonEqual([
+            {
+              $type: 'zeebe:Input',
+              source: 'input-1-source',
+              target: 'input-1-target'
+            },
+            {
+              $type: 'zeebe:Input',
+              source: 'input-2-source',
+              target: 'input-2-target'
+            }
+          ]);
+
+          expect(ioMapping.get('zeebe:outputParameters')).to.jsonEqual([
+            {
+              $type: 'zeebe:Output',
+              source: 'output-1-source',
+              target: 'output-1-target'
+            },
+            {
+              $type: 'zeebe:Output',
+              source: 'output-2-source',
+              target: 'output-2-target'
+            }
+          ]);
+        }));
+
+
+        it('undo', inject(function(commandStack, elementRegistry) {
+
+          // given
+          const task = elementRegistry.get('Task_1');
+
+          changeTemplate(task, newTemplate);
+
+          // when
+          commandStack.undo();
+
+          // then
+          expectNoElementTemplate(task);
+
+          const ioMapping = findExtension(task, 'zeebe:IoMapping');
+
+          expect(ioMapping).not.to.exist;
+        }));
+
+
+        it('redo', inject(function(commandStack, elementRegistry) {
+
+          // given
+          const task = elementRegistry.get('Task_1');
+
+          changeTemplate(task, newTemplate);
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expectElementTemplate(task, 'task-template', 1);
+
+          const ioMapping = findExtension(task, 'zeebe:IoMapping');
+
+          expect(ioMapping).to.exist;
+          expect(ioMapping.get('zeebe:inputParameters')).to.have.length(2);
+          expect(ioMapping.get('zeebe:outputParameters')).to.have.length(2);
+
+          expect(ioMapping.get('zeebe:inputParameters')).to.jsonEqual([
+            {
+              $type: 'zeebe:Input',
+              source: 'input-1-source',
+              target: 'input-1-target'
+            },
+            {
+              $type: 'zeebe:Input',
+              source: 'input-2-source',
+              target: 'input-2-target'
+            }
+          ]);
+
+          expect(ioMapping.get('zeebe:outputParameters')).to.jsonEqual([
+            {
+              $type: 'zeebe:Output',
+              source: 'output-1-source',
+              target: 'output-1-target'
+            },
+            {
+              $type: 'zeebe:Output',
+              source: 'output-2-source',
+              target: 'output-2-target'
+            }
+          ]);
+        }));
+
+      });
+
+
+      describe('zeebe:Input and zeebe:Output not specified', function() {
+
+        beforeEach(bootstrap(require('./task-input-output.bpmn').default));
+
+        const newTemplate = require('./task-template-no-properties.json');
+
+
+        it('should not override existing', inject(function(elementRegistry) {
+
+          // given
+          const task = elementRegistry.get('Task_1');
+
+          // when
+          changeTemplate(task, newTemplate);
+
+          // then
+          expectElementTemplate(task, 'task-template-no-properties');
+
+          const ioMapping = findExtension(task, 'zeebe:IoMapping');
+
+          expect(ioMapping).to.exist;
+          expect(ioMapping.inputParameters).to.have.length(1);
+          expect(ioMapping.outputParameters).to.have.length(1);
+
+          expect(ioMapping.inputParameters).to.jsonEqual([
+            {
+              $type: 'zeebe:Input',
+              target: 'input-1-target',
+              source: 'input-1-source'
+            }
+          ]);
+
+          expect(ioMapping.outputParameters).to.jsonEqual([
+            {
+              $type: 'zeebe:Output',
+              target: 'output-1-target',
+              source: 'output-1-source'
+            }
+          ]);
+        }));
+
+      });
+
+    });
+
+
+    describe('update zeebe:taskHeaders', function() {
+
+      describe('zeebe:Header specified', function() {
+
+        beforeEach(bootstrap(require('./task.bpmn').default));
+
+        const newTemplate = require('./task-template-1.json');
+
+
+        it('execute', inject(function(elementRegistry) {
+
+          // given
+          const task = elementRegistry.get('Task_1');
+
+          // when
+          changeTemplate(task, newTemplate);
+
+          // then
+          expectElementTemplate(task, 'task-template', 1);
+
+          const taskHeaders = findExtension(task, 'zeebe:TaskHeaders');
+
+          expect(taskHeaders).to.exist;
+          expect(taskHeaders.get('zeebe:values')).to.have.length(2);
+
+          expect(taskHeaders.get('zeebe:values')).to.jsonEqual([
+            {
+              $type: 'zeebe:Header',
+              key: 'header-1-key',
+              value: 'header-1-value'
+            },
+            {
+              $type: 'zeebe:Header',
+              key: 'header-2-key',
+              value: 'header-2-value'
+            }
+          ]);
+        }));
+
+
+        it('undo', inject(function(commandStack, elementRegistry) {
+
+          // given
+          const task = elementRegistry.get('Task_1');
+
+          changeTemplate(task, newTemplate);
+
+          // when
+          commandStack.undo();
+
+          // then
+          expectNoElementTemplate(task);
+
+          const taskHeaders = findExtension(task, 'zeebe:TaskHeaders');
+
+          expect(taskHeaders).not.to.exist;
+        }));
+
+
+        it('redo', inject(function(commandStack, elementRegistry) {
+
+          // given
+          const task = elementRegistry.get('Task_1');
+
+          changeTemplate(task, newTemplate);
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expectElementTemplate(task, 'task-template', 1);
+
+          const taskHeaders = findExtension(task, 'zeebe:TaskHeaders');
+
+          expect(taskHeaders).to.exist;
+          expect(taskHeaders.get('zeebe:values')).to.have.length(2);
+
+          expect(taskHeaders.get('zeebe:values')).to.jsonEqual([
+            {
+              $type: 'zeebe:Header',
+              key: 'header-1-key',
+              value: 'header-1-value'
+            },
+            {
+              $type: 'zeebe:Header',
+              key: 'header-2-key',
+              value: 'header-2-value'
+            }
+          ]);
+        }));
+
+      });
+
+
+      describe('zeebe:Header not specified', function() {
+
+        beforeEach(bootstrap(require('./task-headers.bpmn').default));
+
+        const newTemplate = require('./task-template-no-properties.json');
+
+
+        it('should not override existing', inject(function(elementRegistry) {
+
+          // given
+          const task = elementRegistry.get('Task_1');
+
+          // when
+          changeTemplate(task, newTemplate);
+
+          // then
+          expectElementTemplate(task, 'task-template-no-properties');
+
+          const taskHeaders = findExtension(task, 'zeebe:TaskHeaders');
+
+          expect(taskHeaders).to.exist;
+          expect(taskHeaders.values).to.have.length(2);
+
+          expect(taskHeaders.values).to.jsonEqual([
+            {
+              $type: 'zeebe:Header',
+              key: 'header-1-key',
+              value: 'header-1-value'
+            },
+            {
+              $type: 'zeebe:Header',
+              key: 'header-2-key',
+              value: 'header-2-value'
+            }
+          ]);
+
+        }));
+
+      });
+
+    });
+
+  });
+
+
+  describe('change template (new and old template specified)', function() {
+
+    describe('update zeebe:modelerTemplate and zeebe:modelerTemplateVersion', function() {
+
+      beforeEach(bootstrap(require('./task-template.bpmn').default));
+
+      const newTemplate = require('./task-template-2.json');
+
+
+      it('execute', inject(function(elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        // when
+        changeTemplate(task, newTemplate);
+
+        // then
+        expectElementTemplate(task, 'task-template', 2);
+      }));
+
+    });
+
+
+    describe('update properties', function() {
+
+      describe('update name', function() {
+
+        beforeEach(bootstrap(require('./task.bpmn').default));
+
+
+        it('property changed', inject(function(elementRegistry) {
+
+          // given
+          const task = elementRegistry.get('Task_1'),
+                businessObject = getBusinessObject(task);
+
+          const oldTemplate = createTemplate({
+            value: 'task-old-name',
+            binding: {
+              type: 'property',
+              name: 'name'
+            }
+          });
+
+          const newTemplate = createTemplate({
+            value: 'task-new-name',
+            binding: {
+              type: 'property',
+              name: 'name'
+            }
+          });
+
+          changeTemplate('Task_1', oldTemplate);
+
+          let name = businessObject.get('bpmn:name');
+
+          updateBusinessObject('Task_1', businessObject, {
+            'name': 'task-name-changed'
+          });
+
+          // when
+          changeTemplate(task, newTemplate, oldTemplate);
+
+          // then
+          name = businessObject.get('bpmn:name');
+
+          expect(name).to.exist;
+          expect(name).to.equal('task-name-changed');
+        }));
+
+
+        it('property unchanged', inject(function(elementRegistry) {
+
+          // given
+          const task = elementRegistry.get('Task_1'),
+                businessObject = getBusinessObject(task);
+
+          const oldTemplate = createTemplate({
+            value: 'task-old-name',
+            binding: {
+              type: 'property',
+              name: 'name'
+            }
+          });
+
+          const newTemplate = createTemplate({
+            value: 'task-new-name',
+            binding: {
+              type: 'property',
+              name: 'name'
+            }
+          });
+
+          changeTemplate('Task_1', oldTemplate);
+
+          // when
+          changeTemplate(task, newTemplate, oldTemplate);
+
+          // then
+          const name = businessObject.get('bpmn:name');
+
+          expect(name).to.exist;
+          expect(name).to.equal('task-new-name');
+        }));
+
+      });
+
+    });
+
+
+    describe('update zeebe:taskDefinition', function() {
+
+      beforeEach(bootstrap(require('./task.bpmn').default));
+
+
+      it('property changed', inject(function(elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: 'task-type-old',
+            binding: {
+              type: 'zeebe:taskDefinition:type'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: 'task-type-new',
+            binding: {
+              type: 'zeebe:taskDefinition:type'
+            }
+          }
+        ]);
+
+        changeTemplate('Task_1', oldTemplate);
+
+        let taskDefinition = findExtension(task, 'zeebe:TaskDefinition');
+
+        updateBusinessObject('Task_1', taskDefinition, {
+          type: 'task-type-changed'
+        });
+
+        // when
+        changeTemplate(task, newTemplate, oldTemplate);
+
+        // then
+        taskDefinition = findExtension(task, 'zeebe:TaskDefinition');
+
+        expect(taskDefinition).to.exist;
+        expect(taskDefinition.get('type')).to.equal('task-type-changed');
+      }));
+
+
+      it('property unchanged', inject(function(elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: 'task-type-old',
+            binding: {
+              type: 'zeebe:taskDefinition:type'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: 'task-type-new',
+            binding: {
+              type: 'zeebe:taskDefinition:type'
+            }
+          }
+        ]);
+
+        changeTemplate('Task_1', oldTemplate);
+
+        // when
+        changeTemplate(task, newTemplate, oldTemplate);
+
+        // then
+        const taskDefinition = findExtension(task, 'zeebe:TaskDefinition');
+
+        expect(taskDefinition).to.exist;
+        expect(taskDefinition.get('type')).to.equal('task-type-new');
+      }));
+
+    });
+
+
+    describe('update zeebe:Input and zeebe:Output', function() {
+
+      beforeEach(bootstrap(require('./task.bpmn').default));
+
+
+      it('property changed', inject(function(elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: 'input-1-old-value',
+            binding: {
+              type: 'zeebe:input',
+              name: 'input-1-target'
+            }
+          },
+          {
+            value: 'output-1-old-value',
+            binding: {
+              type: 'zeebe:output',
+              source: 'output-1-source'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: 'input-1-new-value',
+            binding: {
+              type: 'zeebe:input',
+              name: 'input-1-target'
+            }
+          },
+          {
+            value: 'output-1-new-value',
+            binding: {
+              type: 'zeebe:output',
+              source: 'output-1-source'
+            }
+          }
+        ]);
+
+        changeTemplate('Task_1', oldTemplate);
+
+        const input = getInputParameter(task, 'input-1-target');
+
+        updateBusinessObject('Task_1', input, {
+          source: 'input-1-changed-value'
+        });
+
+        const output = getOutputParameter(task, 'output-1-source');
+
+        updateBusinessObject('Task_1', output, {
+          target: 'output-1-changed-value'
+        });
+
+        // when
+        changeTemplate(task, newTemplate, oldTemplate);
+
+        // then
+        const ioMapping = findExtension(task, 'zeebe:IoMapping');
+
+        expect(ioMapping).to.exist;
+        expect(ioMapping.get('zeebe:inputParameters')).to.have.length(1);
+        expect(ioMapping.get('zeebe:outputParameters')).to.have.length(1);
+
+        expect(ioMapping.get('zeebe:inputParameters')).to.jsonEqual([
+          {
+            $type: 'zeebe:Input',
+            source: 'input-1-changed-value',
+            target: 'input-1-target',
+          }
+        ]);
+
+        expect(ioMapping.get('zeebe:outputParameters')).to.jsonEqual([
+          {
+            $type: 'zeebe:Output',
+            source: 'output-1-source',
+            target: 'output-1-changed-value'
+          }
+        ]);
+      }));
+
+
+      it('property unchanged', inject(function(elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: 'input-1-old-value',
+            binding: {
+              type: 'zeebe:input',
+              name: 'input-1-target'
+            }
+          },
+          {
+            value: 'output-1-old-value',
+            binding: {
+              type: 'zeebe:output',
+              source: 'output-1-source'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: 'input-1-new-value',
+            binding: {
+              type: 'zeebe:input',
+              name: 'input-1-target'
+            }
+          },
+          {
+            value: 'output-1-new-value',
+            binding: {
+              type: 'zeebe:output',
+              source: 'output-1-source'
+            }
+          }
+        ]);
+
+        changeTemplate('Task_1', oldTemplate);
+
+        // when
+        changeTemplate(task, newTemplate, oldTemplate);
+
+        // then
+        const ioMapping = findExtension(task, 'zeebe:IoMapping');
+
+        expect(ioMapping).to.exist;
+        expect(ioMapping.get('zeebe:inputParameters')).to.have.length(1);
+        expect(ioMapping.get('zeebe:outputParameters')).to.have.length(1);
+
+        expect(ioMapping.get('zeebe:inputParameters')).to.jsonEqual([
+          {
+            $type: 'zeebe:Input',
+            source: 'input-1-new-value',
+            target: 'input-1-target'
+          }
+        ]);
+
+        expect(ioMapping.get('zeebe:outputParameters')).to.jsonEqual([
+          {
+            $type: 'zeebe:Output',
+            source: 'output-1-source',
+            target: 'output-1-new-value'
+          }
+        ]);
+      }));
+
+
+      it('complex', inject(function(elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: 'input-1-old-value',
+            binding: {
+              type: 'zeebe:input',
+              name: 'input-1-target'
+            }
+          },
+          {
+            value: 'output-1-old-value',
+            binding: {
+              type: 'zeebe:output',
+              source: 'output-1-source'
+            }
+          },
+          {
+            value: 'input-2-old-value',
+            binding: {
+              type: 'zeebe:input',
+              name: 'input-2-target'
+            }
+          },
+          {
+            value: 'output-2-old-value',
+            binding: {
+              type: 'zeebe:output',
+              source: 'output-2-source'
+            }
+          },
+          {
+            value: 'input-3-old-value',
+            binding: {
+              type: 'zeebe:input',
+              name: 'input-3-target'
+            }
+          },
+          {
+            value: 'output-3-old-value',
+            binding: {
+              type: 'zeebe:output',
+              source: 'output-3-source'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: 'input-1-new-value',
+            binding: {
+              type: 'zeebe:input',
+              name: 'input-1-target'
+            }
+          },
+          {
+            value: 'output-1-new-value',
+            binding: {
+              type: 'zeebe:output',
+              source: 'output-1-source'
+            }
+          },
+          {
+            value: 'input-2-new-value',
+            binding: {
+              type: 'zeebe:input',
+              name: 'input-2-target'
+            }
+          },
+          {
+            value: 'output-2-new-value',
+            binding: {
+              type: 'zeebe:output',
+              source: 'output-2-source'
+            }
+          },
+          {
+            value: 'input-4-new-value',
+            binding: {
+              type: 'zeebe:input',
+              name: 'input-4-target'
+            }
+          },
+          {
+            value: 'output-4-new-value',
+            binding: {
+              type: 'zeebe:output',
+              source: 'output-4-source'
+            }
+          }
+        ]);
+
+        changeTemplate('Task_1', oldTemplate);
+
+        const input1 = getInputParameter(task, 'input-1-target');
+
+        updateBusinessObject('Task_1', input1, {
+          source: 'input-1-changed-value'
+        });
+
+        const output1 = getOutputParameter(task, 'output-1-source');
+
+        updateBusinessObject('Task_1', output1, {
+          target: 'output-1-changed-value'
+        });
+
+        // when
+        changeTemplate(task, newTemplate, oldTemplate);
+
+        // then
+        const ioMapping = findExtension(task, 'zeebe:IoMapping');
+
+        expect(ioMapping).to.exist;
+        expect(ioMapping.get('zeebe:inputParameters')).to.have.length(3);
+        expect(ioMapping.get('zeebe:outputParameters')).to.have.length(3);
+
+        // Expect 1st input to not have been overridden because it was changed
+        // Expect 2nd input to have been updated
+        // Expect 3rd input to have been removed
+        // Expect 4th input to have been added
+        expect(ioMapping.get('zeebe:inputParameters')).to.jsonEqual([
+          {
+            $type: 'zeebe:Input',
+            source: 'input-1-changed-value',
+            target: 'input-1-target'
+          },
+          {
+            $type: 'zeebe:Input',
+            source: 'input-2-new-value',
+            target: 'input-2-target'
+          },
+          {
+            $type: 'zeebe:Input',
+            source: 'input-4-new-value',
+            target: 'input-4-target'
+          }
+        ]);
+
+        // Expect 1st output to not have been overridden because it was changed
+        // Expect 2nd output to have been updated
+        // Expect 3rd output to have been removed
+        // Expect 4th output to have been added
+        expect(ioMapping.get('zeebe:outputParameters')).to.jsonEqual([
+          {
+            $type: 'zeebe:Output',
+            source: 'output-1-source',
+            target: 'output-1-changed-value'
+          },
+          {
+            $type: 'zeebe:Output',
+            source: 'output-2-source',
+            target: 'output-2-new-value'
+          },
+          {
+            $type: 'zeebe:Output',
+            source: 'output-4-source',
+            target: 'output-4-new-value'
+          }
+        ]);
+      }));
+
+    });
+
+
+    describe('update zeebe:Header', function() {
+
+      beforeEach(bootstrap(require('./task.bpmn').default));
+
+
+      it('property changed', inject(function(elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: 'header-1-old-value',
+            binding: {
+              type: 'zeebe:taskHeader',
+              key: 'header-1-key'
+            }
+          },
+          {
+            value: 'header-2-old-value',
+            binding: {
+              type: 'zeebe:taskHeader',
+              key: 'header-2-key'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: 'header-1-new-value',
+            binding: {
+              type: 'zeebe:taskHeader',
+              key: 'header-1-key'
+            }
+          },
+          {
+            value: 'header-2-new-value',
+            binding: {
+              type: 'zeebe:taskHeader',
+              key: 'header-2-key'
+            }
+          }
+        ]);
+
+        changeTemplate('Task_1', oldTemplate);
+
+        const header = getTaskHeader(task, 'header-1-key');
+
+        updateBusinessObject('Task_1', header, {
+          value: 'header-1-changed-value'
+        });
+
+        // when
+        changeTemplate(task, newTemplate, oldTemplate);
+
+        // then
+        const taskHeaders = findExtension(task, 'zeebe:TaskHeaders');
+
+        expect(taskHeaders).to.exist;
+        expect(taskHeaders.get('zeebe:values')).to.have.length(2);
+
+        expect(taskHeaders.get('zeebe:values')).to.jsonEqual([
+          {
+            $type: 'zeebe:Header',
+            key: 'header-1-key',
+            value: 'header-1-changed-value',
+          },
+          {
+            $type: 'zeebe:Header',
+            key: 'header-2-key',
+            value: 'header-2-new-value',
+          }
+        ]);
+      }));
+
+
+      it('property unchanged', inject(function(elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: 'header-1-old-value',
+            binding: {
+              type: 'zeebe:taskHeader',
+              key: 'header-1-key'
+            }
+          },
+          {
+            value: 'header-2-old-value',
+            binding: {
+              type: 'zeebe:taskHeader',
+              key: 'header-2-key'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: 'header-1-new-value',
+            binding: {
+              type: 'zeebe:taskHeader',
+              key: 'header-1-key'
+            }
+          },
+          {
+            value: 'header-2-new-value',
+            binding: {
+              type: 'zeebe:taskHeader',
+              key: 'header-2-key'
+            }
+          }
+        ]);
+
+        changeTemplate('Task_1', oldTemplate);
+
+        // when
+        changeTemplate(task, newTemplate, oldTemplate);
+
+        // then
+        const taskHeaders = findExtension(task, 'zeebe:TaskHeaders');
+
+        expect(taskHeaders).to.exist;
+        expect(taskHeaders.get('zeebe:values')).to.have.length(2);
+
+        expect(taskHeaders.get('zeebe:values')).to.jsonEqual([
+          {
+            $type: 'zeebe:Header',
+            key: 'header-1-key',
+            value: 'header-1-new-value'
+          },
+          {
+            $type: 'zeebe:Header',
+            key: 'header-2-key',
+            value: 'header-2-new-value'
+          }
+        ]);
+      }));
+
+
+      it('complex', inject(function(elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: 'header-1-old-value',
+            binding: {
+              type: 'zeebe:taskHeader',
+              key: 'header-1-key'
+            }
+          },
+          {
+            value: 'header-2-old-value',
+            binding: {
+              type: 'zeebe:taskHeader',
+              key: 'header-2-key'
+            }
+          },
+          {
+            value: 'header-3-old-value',
+            binding: {
+              type: 'zeebe:taskHeader',
+              key: 'header-3-key'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: 'header-1-new-value',
+            binding: {
+              type: 'zeebe:taskHeader',
+              key: 'header-1-key'
+            }
+          },
+          {
+            value: 'header-2-new-value',
+            binding: {
+              type: 'zeebe:taskHeader',
+              key: 'header-2-key'
+            }
+          },
+          {
+            value: 'header-4-new-value',
+            binding: {
+              type: 'zeebe:taskHeader',
+              key: 'header-4-key'
+            }
+          }
+        ]);
+
+        changeTemplate('Task_1', oldTemplate);
+
+        const header1 = getTaskHeader(task, 'header-1-key');
+
+        updateBusinessObject('Task_1', header1, {
+          value: 'header-1-changed-value'
+        });
+
+        // when
+        changeTemplate(task, newTemplate, oldTemplate);
+
+        // then
+        const taskHeaders = findExtension(task, 'zeebe:TaskHeaders');
+
+        expect(taskHeaders).to.exist;
+        expect(taskHeaders.get('zeebe:values')).to.have.length(3);
+
+        // Expect 1st header to not have been overridden because it was changed
+        // Expect 2nd header to have been updated
+        // Expect 3rd header to have been removed
+        // Expect 4th header to have been added
+        expect(taskHeaders.get('zeebe:values')).to.jsonEqual([
+          {
+            $type: 'zeebe:Header',
+            key: 'header-1-key',
+            value: 'header-1-changed-value'
+          },
+          {
+            $type: 'zeebe:Header',
+            key: 'header-2-key',
+            value: 'header-2-new-value'
+          },
+          {
+            $type: 'zeebe:Header',
+            key: 'header-4-key',
+            value: 'header-4-new-value'
+          },
+        ]);
+      }));
+
+    });
+
+  });
+
+
+  describe('change template (no new template specified)', function() {
+
+    describe('should not remove properties', function() {
+
+      beforeEach(bootstrap(require('./task-template.bpmn').default));
+
+
+      it('execute', inject(function(elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        // when
+        changeTemplate(task, null);
+
+        // then
+        expectNoElementTemplate(task);
+
+        expect(findExtension(task, 'zeebe:TaskDefinition')).to.exist;
+        expect(findExtension(task, 'zeebe:IoMapping')).to.exist;
+        expect(findExtension(task, 'zeebe:TaskHeaders')).to.exist;
+      }));
+
+
+      it('undo', inject(function(commandStack, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        changeTemplate(task, null);
+
+        // when
+        commandStack.undo();
+
+        // then
+        expectElementTemplate(task, 'task-template', 1);
+      }));
+
+
+      it('redo', inject(function(commandStack, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        changeTemplate(task, null);
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expectNoElementTemplate(task);
+
+        expect(findExtension(task, 'zeebe:TaskDefinition')).to.exist;
+        expect(findExtension(task, 'zeebe:IoMapping')).to.exist;
+        expect(findExtension(task, 'zeebe:TaskHeaders')).to.exist;
+      }));
+
+    });
+
+  });
+
+});
+
+
+
+// helpers //////////
+
+function changeTemplate(element, newTemplate, oldTemplate) {
+  return getBpmnJS().invoke(function(commandStack, elementRegistry) {
+    if (isString(element)) {
+      element = elementRegistry.get(element);
+    }
+
+    expect(element).to.exist;
+
+    return commandStack.execute('propertiesPanel.zeebe.changeTemplate', {
+      element: element,
+      newTemplate: newTemplate,
+      oldTemplate: oldTemplate
+    });
+  });
+}
+
+function expectElementTemplate(element, id, version) {
+  getBpmnJS().invoke(function(elementRegistry) {
+    if (isString(element)) {
+      element = elementRegistry.get(element);
+    }
+
+    expect(element).to.exist;
+
+    const businessObject = getBusinessObject(element);
+
+    expect(businessObject.get('zeebe:modelerTemplate')).to.exist;
+    expect(businessObject.get('zeebe:modelerTemplate')).to.equal(id);
+
+    if (isUndefined(version)) {
+      return;
+    }
+
+    expect(businessObject.get('zeebe:modelerTemplateVersion')).to.exist;
+    expect(businessObject.get('zeebe:modelerTemplateVersion')).to.equal(version);
+  });
+}
+
+function expectNoElementTemplate(element) {
+  getBpmnJS().invoke(function(elementRegistry) {
+    if (isString(element)) {
+      element = elementRegistry.get(element);
+    }
+
+    expect(element).to.exist;
+
+    const businessObject = getBusinessObject(element);
+
+    expect(businessObject.get('zeebe:modelerTemplate')).not.to.exist;
+    expect(businessObject.get('zeebe:modelerTemplateVersion')).not.to.exist;
+  });
+}
+
+function createTemplate(properties, scope) {
+  if (!isArray(properties)) {
+    properties = [ properties ];
+  }
+
+  const template = {
+    properties: [],
+    scopes: []
+  };
+
+  if (scope) {
+    template.scopes = [
+      {
+        type: scope,
+        properties: properties
+      }
+    ];
+  } else {
+    template.properties = properties;
+  }
+
+  return template;
+}
+
+function getInputParameter(element, name) {
+  const ioMapping = findExtension(element, 'zeebe:IoMapping');
+
+  return find(ioMapping.get('zeebe:inputParameters'), function(inputParameter) {
+    return inputParameter.get('zeebe:target') === name;
+  });
+}
+
+function getOutputParameter(element, source) {
+  const ioMapping = findExtension(element, 'zeebe:IoMapping');
+
+  return find(ioMapping.get('zeebe:outputParameters'), function(outputParameter) {
+    return outputParameter.get('zeebe:source') === source;
+  });
+}
+
+function getTaskHeader(element, key) {
+  const taskHeaders = findExtension(element, 'zeebe:TaskHeaders');
+
+  return find(taskHeaders.get('zeebe:values'), function(outputParameter) {
+    return outputParameter.get('zeebe:key') === key;
+  });
+}
+
+function updateBusinessObject(element, businessObject, properties) {
+  getBpmnJS().invoke(function(commandStack, elementRegistry) {
+    if (isString(element)) {
+      element = elementRegistry.get(element);
+    }
+
+    expect(element).to.exist;
+
+    commandStack.execute('element.updateModdleProperties', {
+      element,
+      moddleElement: businessObject,
+      properties
+    });
+  });
+}

--- a/test/spec/provider/cloud-element-templates/cmd/task-definition.bpmn
+++ b/test/spec/provider/cloud-element-templates/cmd/task-definition.bpmn
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="Task_1">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="task-type" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="0" y="0" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/cloud-element-templates/cmd/task-headers.bpmn
+++ b/test/spec/provider/cloud-element-templates/cmd/task-headers.bpmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="Task_1">
+      <bpmn:extensionElements>
+        <zeebe:taskHeaders>
+          <zeebe:header key="header-1-key" value="header-1-value" />
+          <zeebe:header key="header-2-key" value="header-2-value" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="0" y="0" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/cloud-element-templates/cmd/task-input-output.bpmn
+++ b/test/spec/provider/cloud-element-templates/cmd/task-input-output.bpmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="Task_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input target="input-1-target" source="input-1-source" />
+          <zeebe:output target="output-1-target" source="output-1-source" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="0" y="0" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/cloud-element-templates/cmd/task-template-1.json
+++ b/test/spec/provider/cloud-element-templates/cmd/task-template-1.json
@@ -1,0 +1,73 @@
+{
+  "name": "Task Template v1",
+  "version": 1,
+  "id": "task-template",
+  "appliesTo": [
+    "bpmn:ServiceTask"
+  ],
+  "properties": [
+    {
+      "type": "String",
+      "value": "task-name",
+      "binding": {
+        "type": "property",
+        "name": "name"
+      }
+    },
+    {
+      "type": "Hidden",
+      "value": "task-type",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      }
+    },
+    {
+      "type": "String",
+      "value": "header-1-value",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "header-1-key"
+      }
+    },
+    {
+      "type": "String",
+      "value": "header-2-value",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "header-2-key"
+      }
+    },
+    {
+      "value": "input-1-source",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "input-1-target"
+      }
+    },
+    {
+      "value": "input-2-source",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "input-2-target"
+      }
+    },
+    {
+      "value": "output-1-target",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:output",
+        "source": "output-1-source"
+      }
+    },
+    {
+      "value": "output-2-target",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:output",
+        "source": "output-2-source"
+      }
+    }
+  ]
+}

--- a/test/spec/provider/cloud-element-templates/cmd/task-template-2.json
+++ b/test/spec/provider/cloud-element-templates/cmd/task-template-2.json
@@ -1,0 +1,73 @@
+{
+  "name": "Task Template v2",
+  "version": 2,
+  "id": "task-template",
+  "appliesTo": [
+    "bpmn:ServiceTask"
+  ],
+  "properties": [
+    {
+      "type": "String",
+      "value": "Rest task",
+      "binding": {
+        "type": "property",
+        "name": "name"
+      }
+    },
+    {
+      "type": "Hidden",
+      "value": "task-type",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      }
+    },
+    {
+      "type": "String",
+      "value": "header-1-value",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "header-1-key"
+      }
+    },
+    {
+      "type": "String",
+      "value": "header-2-value",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "header-2-key"
+      }
+    },
+    {
+      "value": "input-1-source",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "input-1-target"
+      }
+    },
+    {
+      "value": "input-2-source",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "input-2-target"
+      }
+    },
+    {
+      "value": "output-1-target",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:output",
+        "source": "output-1-source"
+      }
+    },
+    {
+      "value": "output-2-target",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:output",
+        "source": "output-2-source"
+      }
+    }
+  ]
+}

--- a/test/spec/provider/cloud-element-templates/cmd/task-template-no-properties.json
+++ b/test/spec/provider/cloud-element-templates/cmd/task-template-no-properties.json
@@ -1,0 +1,8 @@
+{
+  "name": "Task Template No Properties",
+  "id": "task-template-no-properties",
+  "appliesTo": [
+    "bpmn:ServiceTask"
+  ],
+  "properties": []
+}

--- a/test/spec/provider/cloud-element-templates/cmd/task-template.bpmn
+++ b/test/spec/provider/cloud-element-templates/cmd/task-template.bpmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_039bbyr" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="Task_1" zeebe:modelerTemplate="task-template" zeebe:modelerTemplateVersion="1">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="task-type" />
+        <zeebe:ioMapping>
+          <zeebe:input target="input-1-target" source="input-1-source" />
+          <zeebe:input target="input-2-target" source="input-2-source" />
+          <zeebe:output target="output-1-target" source="output-1-source" />
+          <zeebe:output target="output-2-target" source="output-2-source" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="header-1-key" value="header-1-value" />
+          <zeebe:header key="header-2-key" value="header-2-value" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="0" y="0" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/cloud-element-templates/cmd/task.bpmn
+++ b/test/spec/provider/cloud-element-templates/cmd/task.bpmn
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_039bbyr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="Task_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="0" y="0" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
+        <dc:Bounds x="0" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/cloud-element-templates/fixtures/connectors.bpmn
+++ b/test/spec/provider/cloud-element-templates/fixtures/connectors.bpmn
@@ -24,6 +24,21 @@
       <bpmn:incoming>Flow_0gw5hlt</bpmn:incoming>
       <bpmn:outgoing>Flow_0636r17</bpmn:outgoing>
     </bpmn:serviceTask>
+    <bpmn:serviceTask id="Activity_14akiy6" name="entries visible" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-entriesVisible">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="http" />
+        <zeebe:taskHeaders>
+          <zeebe:header key="method" value="get" />
+          <zeebe:header key="url" />
+        </zeebe:taskHeaders>
+        <zeebe:ioMapping>
+          <zeebe:input source="= invoiceDetails" target="body" />
+          <zeebe:output source="= body" target="response" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Activity_1x04xy0" name="outdated" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-outdated" zeebe:modelerTemplateVersion="1" />
+    <bpmn:serviceTask id="Activity_166ntf9" name="missing template" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-missingTemplate" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0vvlc66">
@@ -43,6 +58,15 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1328y3k_di" bpmnElement="ServiceTask_1">
         <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_14akiy6_di" bpmnElement="Activity_14akiy6">
+        <dc:Bounds x="270" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1x04xy0_di" bpmnElement="Activity_1x04xy0">
+        <dc:Bounds x="270" y="360" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_166ntf9_di" bpmnElement="Activity_166ntf9">
+        <dc:Bounds x="410" y="240" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/cloud-element-templates/fixtures/connectors.bpmn
+++ b/test/spec/provider/cloud-element-templates/fixtures/connectors.bpmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_165ah7c" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.13.0-nightly.20220113" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.3.0">
+  <bpmn:process id="Process_0vvlc66" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0gw5hlt</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0gw5hlt" sourceRef="StartEvent_1" targetRef="ServiceTask_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_0636r17</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0636r17" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
+    <bpmn:serviceTask id="ServiceTask_1" name="REST" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-s1">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="http" />
+        <zeebe:taskHeaders>
+          <zeebe:header key="method" value="get" />
+          <zeebe:header key="url" />
+        </zeebe:taskHeaders>
+        <zeebe:ioMapping>
+          <zeebe:input source="= invoiceDetails" target="body" />
+          <zeebe:output source="= body" target="response" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0gw5hlt</bpmn:incoming>
+      <bpmn:outgoing>Flow_0636r17</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0vvlc66">
+      <bpmndi:BPMNEdge id="Flow_0636r17_di" bpmnElement="Flow_0636r17">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0gw5hlt_di" bpmnElement="Flow_0gw5hlt">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0vyda7b_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1328y3k_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/cloud-element-templates/fixtures/connectors.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/connectors.json
@@ -1,0 +1,77 @@
+[
+  {
+    "name": "REST Connector",
+    "id": "io.camunda.connectors.RestConnector-s1",
+    "description": "A generic REST service.",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "http",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "REST Endpoint URL",
+        "description": "Specify the url of the REST API to talk to.",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "url"
+        },
+        "constraints": {
+          "notEmpty": true,
+          "pattern": {
+            "value": "^https?://.*",
+            "message": "Must be http(s) URL."
+          }
+        }
+      },
+      {
+        "label": "REST Method",
+        "description": "Specify the HTTP method to use.",
+        "type": "Dropdown",
+        "value": "get",
+        "choices": [
+          { "name": "GET", "value": "get" },
+          { "name": "POST", "value": "post" },
+          { "name": "PATCH", "value": "patch" },
+          { "name": "DELETE", "value": "delete" }
+        ],
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "method"
+        }
+      },
+      {
+        "label": "Request Body",
+        "description": "Data to send to the endpoint.",
+        "value": "",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "body"
+        },
+        "constraints": {
+          "optional": true
+        }
+      },
+      {
+        "label": "Result Variable",
+        "description": "Name of variable to store the response data in.",
+        "value": "response",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:output",
+          "source": "= body"
+        },
+        "constraints": {
+          "optional": true
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/connectors.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/connectors.json
@@ -54,9 +54,6 @@
         "binding": {
           "type": "zeebe:input",
           "name": "body"
-        },
-        "constraints": {
-          "optional": true
         }
       },
       {
@@ -67,9 +64,216 @@
         "binding": {
           "type": "zeebe:output",
           "source": "= body"
+        }
+      }
+    ]
+  },
+  {
+    "name": "REST Connector (entries visible)",
+    "id": "io.camunda.connectors.RestConnector-entriesVisible",
+    "description": "A generic REST service.",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "entriesVisible": true,
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "http",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "REST Endpoint URL",
+        "description": "Specify the url of the REST API to talk to.",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "url"
         },
         "constraints": {
-          "optional": true
+          "notEmpty": true,
+          "pattern": {
+            "value": "^https?://.*",
+            "message": "Must be http(s) URL."
+          }
+        }
+      },
+      {
+        "label": "REST Method",
+        "description": "Specify the HTTP method to use.",
+        "type": "Dropdown",
+        "value": "get",
+        "choices": [
+          { "name": "GET", "value": "get" },
+          { "name": "POST", "value": "post" },
+          { "name": "PATCH", "value": "patch" },
+          { "name": "DELETE", "value": "delete" }
+        ],
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "method"
+        }
+      },
+      {
+        "label": "Request Body",
+        "description": "Data to send to the endpoint.",
+        "value": "",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "body"
+        }
+      },
+      {
+        "label": "Result Variable",
+        "description": "Name of variable to store the response data in.",
+        "value": "response",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:output",
+          "source": "= body"
+        }
+      }
+    ]
+  },
+  {
+    "name": "REST Connector (outdated)",
+    "id": "io.camunda.connectors.RestConnector-outdated",
+    "description": "A generic REST service.",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "version": 1,
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "http",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "REST Endpoint URL",
+        "description": "Specify the url of the REST API to talk to.",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "url"
+        },
+        "constraints": {
+          "notEmpty": true,
+          "pattern": {
+            "value": "^https?://.*",
+            "message": "Must be http(s) URL."
+          }
+        }
+      },
+      {
+        "label": "REST Method",
+        "description": "Specify the HTTP method to use.",
+        "type": "Dropdown",
+        "value": "get",
+        "choices": [
+          { "name": "GET", "value": "get" },
+          { "name": "POST", "value": "post" },
+          { "name": "PATCH", "value": "patch" },
+          { "name": "DELETE", "value": "delete" }
+        ],
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "method"
+        }
+      },
+      {
+        "label": "Request Body",
+        "description": "Data to send to the endpoint.",
+        "value": "",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "body"
+        }
+      },
+      {
+        "label": "Result Variable",
+        "description": "Name of variable to store the response data in.",
+        "value": "response",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:output",
+          "source": "= body"
+        }
+      }
+    ]
+  },
+  {
+    "name": "REST Connector (outdated)",
+    "id": "io.camunda.connectors.RestConnector-outdated",
+    "description": "A generic REST service.",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "version": 2,
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "http",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "REST Endpoint URL",
+        "description": "Specify the url of the REST API to talk to.",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "url"
+        },
+        "constraints": {
+          "notEmpty": true,
+          "pattern": {
+            "value": "^https?://.*",
+            "message": "Must be http(s) URL."
+          }
+        }
+      },
+      {
+        "label": "REST Method",
+        "description": "Specify the HTTP method to use.",
+        "type": "Dropdown",
+        "value": "get",
+        "choices": [
+          { "name": "GET", "value": "get" },
+          { "name": "POST", "value": "post" },
+          { "name": "PATCH", "value": "patch" },
+          { "name": "DELETE", "value": "delete" }
+        ],
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "method"
+        }
+      },
+      {
+        "label": "Request Body",
+        "description": "Data to send to the endpoint.",
+        "value": "",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "body"
+        }
+      },
+      {
+        "label": "Result Variable",
+        "description": "Name of variable to store the response data in.",
+        "value": "response_new",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:output",
+          "source": "= body"
         }
       }
     ]

--- a/test/spec/provider/cloud-element-templates/fixtures/entries-visible.bpmn
+++ b/test/spec/provider/cloud-element-templates/fixtures/entries-visible.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_08adx7k" targetNamespace="http://bpmn.io/schema/bpmn" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" exporter="Camunda Modeler" exporterVersion="4.12.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:task id="Task_1" zeebe:modelerTemplate="foo" />
+    <bpmn:task id="Task_2" zeebe:modelerTemplate="foo" zeebe:modelerTemplateVersion="1" />
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="UnknownTemplateTask" zeebe:modelerTemplate="unknown" />
+    <bpmn:serviceTask id="ServiceTask" zeebe:modelerTemplate="default" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_1srimyz_di" bpmnElement="Task_1">
+        <dc:Bounds x="150" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0z29dre_di" bpmnElement="Task_2">
+        <dc:Bounds x="270" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1m5rz19_di" bpmnElement="Task_3">
+        <dc:Bounds x="390" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UnknownTemplateTask_di" bpmnElement="UnknownTemplateTask">
+        <dc:Bounds x="390" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_di" bpmnElement="ServiceTask">
+        <dc:Bounds x="150" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/cloud-element-templates/fixtures/entries-visible.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/entries-visible.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "foo",
+    "name":"EntriesVisible=true",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": [],
+    "entriesVisible": true
+  },
+  {
+    "id": "foo",
+    "name":"EntriesVisible=false",
+    "version": 1,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "id": "default",
+    "name": "EntriesVisible unset",
+    "isDefault": true,
+    "appliesTo": [ "bpmn:ServiceTask" ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/simple.bpmn
+++ b/test/spec/provider/cloud-element-templates/fixtures/simple.bpmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1hbw7f4" targetNamespace="http://bpmn.io/schema/bpmn" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.3.0">
+  <bpmn:process id="Process_1l2fj9o" isExecutable="true">
+    <bpmn:serviceTask id="Task_1" name="MailTask" zeebe:modelerTemplate="my.mail.Task" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1l2fj9o">
+      <bpmndi:BPMNShape id="Activity_1yvrs8u_di" bpmnElement="Task_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/cloud-element-templates/fixtures/simple.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/simple.json
@@ -1,0 +1,75 @@
+[
+  {
+    "name": "MailTask",
+    "id": "my.mail.Task",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "label": "Name",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "name",
+          "value": "Mail Task"
+        }
+      }
+    ]
+  },
+  {
+    "id": "foo",
+    "name":"Foo",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "id": "foo",
+    "name":"Foo 1",
+    "version": 1,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "id": "foo",
+    "name":"Foo 2",
+    "version": 2,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "id": "foo",
+    "name":"Foo 3",
+    "version": 3,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "id": "bar",
+    "name":"Bar 1",
+    "version": 1,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "id": "bar",
+    "name":"Bar 2",
+    "version": 2,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "id": "baz",
+    "name":"Baz",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "id": "default",
+    "name": "Default Template",
+    "version": 1,
+    "isDefault": true,
+    "appliesTo": [ "bpmn:ServiceTask" ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/template-util.bpmn
+++ b/test/spec/provider/cloud-element-templates/fixtures/template-util.bpmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_08adx7k" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.13.0-nightly.20220123">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:task id="Task_1" name="foo" zeebe:modelerTemplate="foo" zeebe:modelerTemplateVersion="1" />
+    <bpmn:startEvent id="ConditionalEvent" zeebe:modelerTemplate="foo" zeebe:modelerTemplateVersion="1">
+      <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_0jsqwvo">
+        <bpmn:condition xsi:type="bpmn:tFormalExpression">myExpression == true</bpmn:condition>
+      </bpmn:conditionalEventDefinition>
+    </bpmn:startEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_1srimyz_di" bpmnElement="Task_1">
+        <dc:Bounds x="150" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1688xoq_di" bpmnElement="ConditionalEvent">
+        <dc:Bounds x="182" y="232" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="193" y="275" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/cloud-element-templates/fixtures/template-util.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/template-util.json
@@ -1,0 +1,60 @@
+[
+  {
+    "id": "foo",
+    "name":"Foo",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "id": "foo",
+    "name":"Foo 1",
+    "version": 1,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": [
+      {
+        "type": "String",
+        "value": "foo",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        }
+      }
+    ]
+  },
+  {
+    "id": "foo",
+    "name":"Foo 2",
+    "version": 2,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": [
+      {
+        "type": "String",
+        "value": "foobar",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        }
+      }
+    ]
+  },
+  {
+    "id": "bar",
+    "name":"Bar 1",
+    "version": 1,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "id": "bar",
+    "name":"Bar 2",
+    "version": 2,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "id": "baz",
+    "name":"Baz",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.bpmn
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_00cqa19" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.13.0-nightly.20220123">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="RestTask" name="REST Task" zeebe:modelerTemplate="com.example.rest">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="task-type" />
+        <zeebe:ioMapping>
+          <zeebe:input source="input-1-source" target="input-1-target" />
+          <zeebe:output source="output-1-source" target="output-1-target" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="header-1-key" value="header-1-value" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:task id="Task_1" name="My task" zeebe:modelerTemplate="my.example.template" />
+    <bpmn:userTask id="DropdownTask" name="low" zeebe:modelerTemplate="my.example.dropdown" />
+    <bpmn:task id="ValidateTask" zeebe:modelerTemplate="com.validated-inputs.Task" />
+    <bpmn:serviceTask id="RestTask_noData" name="REST Task no data" zeebe:modelerTemplate="com.example.rest" />
+    <bpmn:serviceTask id="RestTask_hidden" name="Hidden Task Type" zeebe:modelerTemplate="com.example.rest-hidden">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="task-type" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_1d5ac68_di" bpmnElement="RestTask">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0tip4qx_di" bpmnElement="Task_1">
+        <dc:Bounds x="160" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0sxtp96_di" bpmnElement="DropdownTask">
+        <dc:Bounds x="220" y="480" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0p6pet6_di" bpmnElement="ValidateTask">
+        <dc:Bounds x="310" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1hbryo1_di" bpmnElement="RestTask_noData">
+        <dc:Bounds x="300" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0sz43pp_di" bpmnElement="RestTask_hidden">
+        <dc:Bounds x="470" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.default-types.bpmn
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.default-types.bpmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_00cqa19" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.13.0-nightly.20220123">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="RestTask" name="REST Task" zeebe:modelerTemplate="com.example.default-types">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="task-type" />
+        <zeebe:ioMapping>
+          <zeebe:input source="input-1-source" target="input-1-target" />
+          <zeebe:output source="output-1-source" target="output-1-target" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="header-1-key" value="header-1-value" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_1d5ac68_di" bpmnElement="RestTask">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.default-types.json
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.default-types.json
@@ -1,0 +1,45 @@
+[
+  {
+    "name": "Rest Template",
+    "id": "com.example.default-types",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "value": "foo",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        }
+      },
+      {
+        "value": "task-type",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "value": "header-1-value",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "header-1-key"
+        }
+      },
+      {
+        "value": "input-1-source",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "input-1-target"
+        }
+      },
+      {
+        "value": "output-1-target",
+        "binding": {
+          "type": "zeebe:output",
+          "source": "output-1-source"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.description.bpmn
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.description.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_118jbsm" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1" >
+  <bpmn:process id="Process_1gpk8uz" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0344xap</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Task" zeebe:modelerTemplate="com.zeebe.example.description">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input target="dropdown" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0344xap</bpmn:incoming>
+      <bpmn:outgoing>Flow_125ahdo</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0344xap" sourceRef="StartEvent_1" targetRef="Task" />
+    <bpmn:endEvent id="Event_0a0h3zr">
+      <bpmn:incoming>Flow_125ahdo</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_125ahdo" sourceRef="Task" targetRef="Event_0a0h3zr" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1gpk8uz">
+      <bpmndi:BPMNEdge id="Flow_125ahdo_di" bpmnElement="Flow_125ahdo">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0344xap_di" bpmnElement="Flow_0344xap">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_di" bpmnElement="Task">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0a0h3zr_di" bpmnElement="Event_0a0h3zr">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.description.json
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.description.json
@@ -1,0 +1,87 @@
+[
+  {
+    "name": "Description Task",
+    "id": "com.zeebe.example.description",
+    "description": "Shows description for each type of property",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": [
+      {
+        "label": "string",
+        "description": "STRING_DESCRIPTION",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "string"
+        }
+      },
+      {
+        "label": "text",
+        "description": "TEXT_DESCRIPTION",
+        "type": "Text",
+        "binding": {
+          "type": "property",
+          "name": "text"
+        }
+      },
+      {
+        "label": "boolean",
+        "description": "BOOLEAN_DESCRIPTION",
+        "type": "Boolean",
+        "binding": {
+          "type": "property",
+          "name": "boolean"
+        }
+      },
+      {
+        "label": "dropdown",
+        "description": "DROPDOWN_DESCRIPTION",
+        "type": "Dropdown",
+        "choices": [
+          {
+            "value": "GET",
+            "name": "GET"
+          },
+          {
+            "value": "POST",
+            "name": "POST"
+          },
+          {
+            "value": "PUT",
+            "name": "PUT"
+          },
+          {
+            "value": "PATCH",
+            "name": "PATCH"
+          },
+          {
+            "value": "DELETE",
+            "name": "DELETE"
+          }
+        ],
+        "binding": {
+          "type": "zeebe:input",
+          "name": "dropdown"
+        }
+      },
+      {
+        "label": "withHTML",
+        "description": "By the way, you can use <a target='_blank' href=\"https://freemarker.apache.org/\">freemarker templates</a> here",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "string"
+        }
+      },
+      {
+        "label": "empty",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "string"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.editable.bpmn
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.editable.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_118jbsm" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1" >
+  <bpmn:process id="Process_1gpk8uz" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0344xap</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Task" zeebe:modelerTemplate="com.zeebe.example.editable" string="string editable=false" text="text editable=false" boolean="true" string-editable-unset="string editable unset" string-editable-true="string editable=true">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input target="dropdown" source="GET" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0344xap</bpmn:incoming>
+      <bpmn:outgoing>Flow_125ahdo</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0344xap" sourceRef="StartEvent_1" targetRef="Task" />
+    <bpmn:endEvent id="Event_0a0h3zr">
+      <bpmn:incoming>Flow_125ahdo</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_125ahdo" sourceRef="Task" targetRef="Event_0a0h3zr" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1gpk8uz">
+      <bpmndi:BPMNEdge id="Flow_125ahdo_di" bpmnElement="Flow_125ahdo">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0344xap_di" bpmnElement="Flow_0344xap">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_di" bpmnElement="Task">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0a0h3zr_di" bpmnElement="Event_0a0h3zr">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.editable.json
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.editable.json
@@ -1,0 +1,93 @@
+[
+  {
+    "name": "Editable Task",
+    "id": "com.zeebe.example.editable",
+    "description": "Shows editable for each type of property",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": [
+      {
+        "label": "string editable=false",
+        "editable": false,
+        "value": "string editable=false",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "string"
+        }
+      },
+      {
+        "label": "text editable=false",
+        "editable": false,
+        "value": "text editable=false",
+        "type": "Text",
+        "binding": {
+          "type": "property",
+          "name": "text"
+        }
+      },
+      {
+        "label": "boolean editable=false",
+        "editable": false,
+        "value": true,
+        "type": "Boolean",
+        "binding": {
+          "type": "property",
+          "name": "boolean"
+        }
+      },
+      {
+        "label": "dropdown",
+        "editable": false,
+        "value": "GET",
+        "type": "Dropdown",
+        "choices": [
+          {
+            "value": "GET",
+            "name": "GET"
+          },
+          {
+            "value": "POST",
+            "name": "POST"
+          },
+          {
+            "value": "PUT",
+            "name": "PUT"
+          },
+          {
+            "value": "PATCH",
+            "name": "PATCH"
+          },
+          {
+            "value": "DELETE",
+            "name": "DELETE"
+          }
+        ],
+        "binding": {
+          "type": "zeebe:input",
+          "name": "dropdown"
+        }
+      },
+      {
+        "label": "string editable unset",
+        "type": "String",
+        "value": "string editable unset",
+        "binding": {
+          "type": "property",
+          "name": "string-editable-unset"
+        }
+      },
+      {
+        "label": "string editable=true",
+        "type": "String",
+        "value": "string editable=true",
+        "editable": true,
+        "binding": {
+          "type": "property",
+          "name": "string-editable-true"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.json
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.json
@@ -1,0 +1,209 @@
+[
+  {
+    "name": "Rest Template",
+    "id": "com.example.rest",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "String",
+        "value": "task-type",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "type": "String",
+        "value": "header-1-value",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "header-1-key"
+        }
+      },
+      {
+        "type": "String",
+        "value": "header-2-value",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "header-2-key"
+        }
+      },
+      {
+        "value": "input-1-source",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "input-1-target"
+        }
+      },
+      {
+        "value": "input-2-source",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "input-2-target"
+        }
+      },
+      {
+        "value": "output-1-target",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:output",
+          "source": "output-1-source"
+        }
+      },
+      {
+        "value": "output-2-target",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:output",
+          "source": "output-2-source"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Rest Template (hidden)",
+    "id": "com.example.rest-hidden",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "task-type",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Task Template",
+    "id": "my.example.template",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": [
+      {
+        "type": "String",
+        "value": "my Task",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Task Template 2",
+    "id": "my.example.dropdown",
+    "appliesTo": [
+      "bpmn:UserTask"
+    ],
+    "properties": [
+      {
+        "label": "Name",
+        "type": "Dropdown",
+        "choices": [
+          { "name": "low", "value": "low" },
+          { "name": "medium", "value": "medium" },
+          { "name": "high", "value": "high" }
+        ],
+        "value": "low",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Validated Inputs Task",
+    "id": "com.validated-inputs.Task",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": [
+      {
+        "label": "NotEmpty",
+        "description": "Must not be empty",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        },
+        "constraints": {
+          "notEmpty": true
+        }
+      },
+      {
+        "label": "MinLength",
+        "description": "Must have min length 5",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        },
+        "constraints": {
+          "minLength": 5
+        }
+      },
+      {
+        "label": "MaxLength",
+        "description": "Must have max length 5",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        },
+        "constraints": {
+          "maxLength": 5
+        }
+      },
+      {
+        "label": "Pattern (String)",
+        "description": "Must match /A+B/",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        },
+        "constraints": {
+          "pattern": "A+B"
+        }
+      },
+      {
+        "label": "Pattern (String + Message)",
+        "description": "Must be https url",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        },
+        "constraints": {
+          "pattern": {
+            "message": "Must start with https://",
+            "value": "https://.*"
+          }
+        }
+      },
+      {
+        "label": "Pattern (Integer)",
+        "description": "Must be integer",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        },
+        "constraints": {
+          "pattern": {
+            "message": "Must be positive integer",
+            "value": "\\d+"
+          }
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1,0 +1,836 @@
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  bootstrapPropertiesPanel,
+  changeInput,
+  getBpmnJS,
+  inject
+} from 'test/TestHelper';
+
+import {
+  act
+} from '@testing-library/preact';
+
+import {
+  query as domQuery,
+  queryAll as domQueryAll
+} from 'min-dom';
+
+import {
+  findExtension,
+  findInputParameter,
+  findOutputParameter,
+  findTaskHeader
+} from 'src/provider/cloud-element-templates/Helper';
+
+import coreModule from 'bpmn-js/lib/core';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import zeebeModdlePackage from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import BpmnPropertiesPanel from 'src/render';
+import elementTemplatesModule from 'src/provider/cloud-element-templates';
+
+import diagramXML from './CustomProperties.bpmn';
+import elementTemplates from './CustomProperties.json';
+
+import descriptionDiagramXML from './CustomProperties.description.bpmn';
+import descriptionElementTemplates from './CustomProperties.description.json';
+
+import editableDiagramXML from './CustomProperties.editable.bpmn';
+import editableElementTemplates from './CustomProperties.editable.json';
+
+
+describe('provider/cloud-element-templates - CustomProperties', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    container,
+    debounceInput: false,
+    elementTemplates,
+    moddleExtensions: {
+      zeebe: zeebeModdlePackage
+    },
+    modules: [
+      BpmnPropertiesPanel,
+      coreModule,
+      elementTemplatesModule,
+      modelingModule
+    ]
+  }));
+
+
+  describe('property', function() {
+
+    it('should display', async function() {
+
+      // when
+      await expectSelected('Task_1');
+
+      // then
+      const entry = findEntry('custom-entry-my.example.template-0', container);
+
+      expect(entry).to.exist;
+
+      const input = findInput('text', entry);
+
+      expect(input).to.exist;
+      expect(input.value).to.equal('My task');
+    });
+
+
+    it('should change', async function() {
+
+      // given
+      const task = await expectSelected('Task_1'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const entry = findEntry('custom-entry-my.example.template-0', container),
+            input = findInput('text', entry);
+
+      changeInput(input, 'foo');
+
+      // then
+      expect(input.value).to.equal('foo');
+      expect(businessObject.get('name')).to.equal('foo');
+    });
+
+
+    it('should change String property to empty string when erased', async function() {
+
+      // given
+      const task = await expectSelected('Task_1'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const entry = findEntry('custom-entry-my.example.template-0', container),
+            input = findInput('text', entry);
+
+      changeInput(input, '');
+
+      // then
+      expect(input.value).to.eql('');
+      expect(businessObject.get('name')).to.be.eql('');
+    });
+
+  });
+
+
+  describe('zeebe:taskDefinition:type', function() {
+
+    it('should display', async function() {
+
+      // when
+      await expectSelected('RestTask');
+
+      // then
+      const entry = findEntry('custom-entry-com.example.rest-0', container),
+            input = findInput('text', entry);
+
+      expect(entry).to.exist;
+      expect(input).to.exist;
+      expect(input.value).to.equal('task-type');
+    });
+
+
+    it('should NOT display (type=hidden)', async function() {
+
+      // when
+      await expectSelected('RestTask_hidden');
+
+      // then
+      const entry = findEntry('custom-entry-com.example.rest-hidden-0', container);
+
+      expect(entry).to.not.exist;
+    });
+
+
+    it('should change, setting zeebe:TaskDefinition#type (plain)', inject(async function() {
+
+      // given
+      const task = await expectSelected('RestTask'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const entry = findEntry('custom-entry-com.example.rest-0', container),
+            input = findInput('text', entry);
+
+      changeInput(input, 'foo@bar');
+
+      // then
+      const taskDefinition = findExtension(businessObject, 'zeebe:TaskDefinition');
+
+      expect(taskDefinition).to.exist;
+      expect(taskDefinition).to.jsonEqual({
+        $type: 'zeebe:TaskDefinition',
+        type: 'foo@bar'
+      });
+    }));
+
+
+    it('should change, creating zeebe:Input if non-existing', async function() {
+
+      // given
+      const task = await expectSelected('RestTask_noData'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const entry = findEntry('custom-entry-com.example.rest-0', container),
+            input = findInput('text', entry);
+
+      changeInput(input, 'foo@bar');
+
+      // then
+      const taskDefinition = findExtension(businessObject, 'zeebe:TaskDefinition');
+
+      // then
+      expect(taskDefinition).to.exist;
+      expect(taskDefinition).to.jsonEqual({
+        $type: 'zeebe:TaskDefinition',
+        type: 'foo@bar'
+      });
+    });
+
+  });
+
+
+  describe('zeebe:input', function() {
+
+    it('should display', async function() {
+
+      // when
+      await expectSelected('RestTask');
+
+      // then
+      const entry = findEntry('custom-entry-com.example.rest-3', container),
+            input = findInput('text', entry);
+
+      expect(entry).to.exist;
+      expect(input).to.exist;
+      expect(input.value).to.equal('input-1-source');
+    });
+
+
+    it('should change, setting zeebe:Input (plain)', inject(async function() {
+
+      // given
+      const task = await expectSelected('RestTask'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const entry = findEntry('custom-entry-com.example.rest-3', container),
+            input = findInput('text', entry);
+
+      changeInput(input, 'foo@bar');
+
+      // then
+      const ioMapping = findExtension(businessObject, 'zeebe:IoMapping'),
+            inputParameter = findInputParameter(ioMapping, { name: 'input-1-target' });
+
+      expect(inputParameter).to.exist;
+      expect(inputParameter).to.jsonEqual({
+        $type: 'zeebe:Input',
+        source: 'foo@bar',
+        target: 'input-1-target'
+      });
+    }));
+
+
+    it('should change, creating zeebe:Input if non-existing', async function() {
+
+      // given
+      const task = await expectSelected('RestTask_noData'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const entry = findEntry('custom-entry-com.example.rest-3', container),
+            input = findInput('text', entry);
+
+      changeInput(input, 'foo@bar');
+
+      // then
+      const ioMapping = findExtension(businessObject, 'zeebe:IoMapping'),
+            inputParameter = findInputParameter(ioMapping, { name: 'input-1-target' });
+
+      // then
+      expect(inputParameter).to.exist;
+      expect(inputParameter).to.jsonEqual({
+        $type: 'zeebe:Input',
+        source: 'foo@bar',
+        target: 'input-1-target'
+      });
+    });
+
+  });
+
+
+  describe('zeebe:output', function() {
+
+    it('should display', async function() {
+
+      // when
+      await expectSelected('RestTask');
+
+      // then
+      const entry = findEntry('custom-entry-com.example.rest-5', container),
+            input = findInput('text', entry);
+
+      expect(entry).to.exist;
+      expect(input).to.exist;
+      expect(input.value).to.equal('output-1-target');
+    });
+
+
+    it('should change, setting zeebe:Output (plain)', inject(async function() {
+
+      // given
+      const task = await expectSelected('RestTask'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const entry = findEntry('custom-entry-com.example.rest-5', container),
+            input = findInput('text', entry);
+
+      changeInput(input, 'foo@bar');
+
+      // then
+      const ioMapping = findExtension(businessObject, 'zeebe:IoMapping'),
+            outputParameter = findOutputParameter(ioMapping, { source: 'output-1-source' });
+
+      expect(outputParameter).to.exist;
+      expect(outputParameter).to.jsonEqual({
+        $type: 'zeebe:Output',
+        source: 'output-1-source',
+        target: 'foo@bar'
+      });
+    }));
+
+
+    it('should change, creating zeebe:Output if non-existing', async function() {
+
+      // given
+      const task = await expectSelected('RestTask_noData'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const entry = findEntry('custom-entry-com.example.rest-5', container),
+            input = findInput('text', entry);
+
+      changeInput(input, 'foo@bar');
+
+      // then
+      const ioMapping = findExtension(businessObject, 'zeebe:IoMapping'),
+            outputParameter = findOutputParameter(ioMapping, { source: 'output-1-source' });
+
+      // then
+      expect(outputParameter).to.exist;
+      expect(outputParameter).to.jsonEqual({
+        $type: 'zeebe:Output',
+        source: 'output-1-source',
+        target: 'foo@bar'
+      });
+    });
+
+  });
+
+
+  describe('zeebe:taskHeader', function() {
+
+    it('should display', async function() {
+
+      // when
+      await expectSelected('RestTask');
+
+      // then
+      const entry = findEntry('custom-entry-com.example.rest-1', container),
+            input = findInput('text', entry);
+
+      expect(entry).to.exist;
+      expect(input).to.exist;
+      expect(input.value).to.equal('header-1-value');
+    });
+
+
+    it('should change, setting zeebe:Header (plain)', inject(async function() {
+
+      // given
+      const task = await expectSelected('RestTask'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const entry = findEntry('custom-entry-com.example.rest-1', container),
+            input = findInput('text', entry);
+
+      changeInput(input, 'foo@bar');
+
+      // then
+      const taskHeaders = findExtension(businessObject, 'zeebe:TaskHeaders'),
+            header = findTaskHeader(taskHeaders, { key: 'header-1-key' });
+
+      expect(header).to.exist;
+      expect(header).to.jsonEqual({
+        $type: 'zeebe:Header',
+        key: 'header-1-key',
+        value: 'foo@bar'
+      });
+    }));
+
+
+    it('should change, creating zeebe:Header if non-existing', async function() {
+
+      // given
+      const task = await expectSelected('RestTask_noData'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const entry = findEntry('custom-entry-com.example.rest-1', container),
+            input = findInput('text', entry);
+
+      changeInput(input, 'foo@bar');
+
+      // then
+      const taskHeaders = findExtension(businessObject, 'zeebe:TaskHeaders'),
+            header = findTaskHeader(taskHeaders, { key: 'header-1-key' });
+
+      // then
+      expect(header).to.exist;
+      expect(header).to.jsonEqual({
+        $type: 'zeebe:Header',
+        key: 'header-1-key',
+        value: 'foo@bar'
+      });
+    });
+
+  });
+
+
+  describe('types', function() {
+
+    describe('dropdown', function() {
+
+      beforeEach(bootstrapPropertiesPanel(diagramXML, {
+        container,
+        debounceInput: false,
+        elementTemplates,
+        moddleExtensions: {
+          zeebe: zeebeModdlePackage
+        },
+        modules: [
+          BpmnPropertiesPanel,
+          coreModule,
+          elementTemplatesModule,
+          modelingModule
+        ]
+      }));
+
+
+      it('should display options', async function() {
+
+        // when
+        await expectSelected('DropdownTask');
+
+        // then
+        const entry = findEntry('custom-entry-my.example.dropdown-0', container),
+              options = domQueryAll('select option', entry);
+
+        expect(Array.from(options).map(({ selected, value }) => {
+          return {
+            selected,
+            value
+          };
+        })).to.eql([
+          { value: 'low', selected: true },
+          { value: 'medium', selected: false },
+          { value: 'high', selected: false }
+        ]);
+      });
+
+
+      it('should change, updating binding', async function() {
+
+        // given
+        const task = await expectSelected('DropdownTask'),
+              businessObject = getBusinessObject(task);
+
+        const entry = findEntry('custom-entry-my.example.dropdown-0', container),
+              select = findSelect(entry);
+
+        // when
+        changeInput(select, 'medium');
+
+        // then
+        expect(businessObject.get('name')).to.equal('medium');
+      });
+
+    });
+
+  });
+
+
+  describe('description', function() {
+
+    beforeEach(bootstrapPropertiesPanel(descriptionDiagramXML, {
+      container,
+      debounceInput: false,
+      elementTemplates: descriptionElementTemplates,
+      moddleExtensions: {
+        zeebe: zeebeModdlePackage
+      },
+      modules: [
+        BpmnPropertiesPanel,
+        coreModule,
+        elementTemplatesModule,
+        modelingModule
+      ]
+    }));
+
+
+    it('should display description for string property', async function() {
+
+      // when
+      await expectSelected('Task');
+
+      // then
+      const entry = findEntry('custom-entry-com.zeebe.example.description-0', container);
+
+      expect(entry.textContent).to.contain('STRING_DESCRIPTION');
+    });
+
+
+    it('should display description for textarea property', async function() {
+
+      // when
+      await expectSelected('Task');
+
+      // then
+      const entry = findEntry('custom-entry-com.zeebe.example.description-1', container);
+
+      expect(entry.textContent).to.contain('TEXT_DESCRIPTION');
+    });
+
+
+    it('should display description for boolean property', async function() {
+
+      // when
+      await expectSelected('Task');
+
+      // then
+      const entry = findEntry('custom-entry-com.zeebe.example.description-2', container);
+
+      expect(entry.textContent).to.contain('BOOLEAN_DESCRIPTION');
+    });
+
+
+    it('should display description for dropdown property', async function() {
+
+      // when
+      await expectSelected('Task');
+
+      // then
+      const entry = findEntry('custom-entry-com.zeebe.example.description-3', container);
+
+      expect(entry.textContent).to.contain('DROPDOWN_DESCRIPTION');
+    });
+
+
+    it('should display HTML descriptions', async function() {
+
+      // when
+      await expectSelected('Task');
+
+      // then
+      const entry = findEntry('custom-entry-com.zeebe.example.description-4', container);
+      const description = domQuery('.bio-properties-panel-description', entry);
+
+      expect(description).to.exist;
+      expect(description.innerHTML).to.eql(
+        '<div class="markup">' +
+          '<div xmlns="http://www.w3.org/1999/xhtml">' +
+            'By the way, you can use ' +
+            '<a href="https://freemarker.apache.org/" target="_blank" rel="noopener">freemarker templates</a> ' +
+            'here' +
+          '</div>' +
+        '</div>'
+      );
+    });
+
+
+    it('should NOT display empty descriptions', async function() {
+
+      // when
+      await expectSelected('Task');
+
+      // then
+      const entry = findEntry('custom-entry-com.zeebe.example.description-5', container);
+      const description = domQuery('.bio-properties-panel-description', entry);
+
+      expect(description).to.not.exist;
+    });
+  });
+
+
+  describe('editable', function() {
+
+    beforeEach(bootstrapPropertiesPanel(editableDiagramXML, {
+      container,
+      debounceInput: false,
+      elementTemplates: editableElementTemplates,
+      moddleExtensions: {
+        zeebe: zeebeModdlePackage
+      },
+      modules: [
+        BpmnPropertiesPanel,
+        coreModule,
+        elementTemplatesModule,
+        modelingModule
+      ]
+    }));
+
+
+    it('should NOT disable input when editable is NOT set', async function() {
+
+      // when
+      await expectSelected('Task');
+
+      // then
+      const entry = findEntry('custom-entry-com.zeebe.example.editable-4', container),
+            input = findInput('text', entry);
+
+      expect(input).not.to.have.property('disabled', true);
+    });
+
+
+    it('should NOT disable input when editable=true', async function() {
+
+      // when
+      await expectSelected('Task');
+
+      // then
+      const entry = findEntry('custom-entry-com.zeebe.example.editable-5', container),
+            input = findInput('text', entry);
+
+      expect(input).not.to.have.property('disabled', true);
+    });
+
+
+    it('should disable string input when editable=false', async function() {
+
+      // when
+      await expectSelected('Task');
+
+      // then
+      const entry = findEntry('custom-entry-com.zeebe.example.editable-0', container),
+            input = findInput('text', entry);
+
+      expect(input).to.have.property('disabled', true);
+    });
+
+
+    it('should disable textarea input when editable=false', async function() {
+
+      // when
+      await expectSelected('Task');
+
+      // then
+      const entry = findEntry('custom-entry-com.zeebe.example.editable-1', container),
+            input = findTextarea(entry);
+
+      expect(input).to.have.property('disabled', true);
+    });
+
+
+    it('should disable boolean input when editable=false', async function() {
+
+      // when
+      await expectSelected('Task');
+
+      // then
+      const entry = findEntry('custom-entry-com.zeebe.example.editable-2', container),
+            input = findInput('checkbox', entry);
+
+      expect(input).to.have.property('disabled', true);
+    });
+
+
+    it('should disable dropdown input when editable=false', async function() {
+
+      // when
+      await expectSelected('Task');
+
+      // then
+      const entry = findEntry('custom-entry-com.zeebe.example.editable-3', container),
+            input = findSelect(entry);
+
+      expect(input).to.have.property('disabled', true);
+    });
+  });
+
+
+  describe('validation', function() {
+
+    it('should validate nonEmpty', async function() {
+
+      // given
+      await expectSelected('ValidateTask');
+
+      const entry = findEntry('custom-entry-com.validated-inputs.Task-0', container),
+            input = findInput('text', entry);
+
+      // assume
+      expectError(entry, 'Must not be empty.');
+
+      // when
+      changeInput(input, 'FOO');
+
+      // then
+      expectValid(entry);
+    });
+
+
+    it('should validate minLength', async function() {
+
+      // given
+      await expectSelected('ValidateTask');
+
+      const entry = findEntry('custom-entry-com.validated-inputs.Task-1', container),
+            input = findInput('text', entry);
+
+      // assume
+      expectError(entry, 'Must have min length 5.');
+
+      // when
+      changeInput(input, 'FOOOOOOO');
+
+      // then
+      expectValid(entry);
+    });
+
+
+    it('should validate maxLength', async function() {
+
+      // given
+      await expectSelected('ValidateTask');
+
+      const entry = findEntry('custom-entry-com.validated-inputs.Task-2', container),
+            input = findInput('text', entry);
+
+      // assume
+      expectValid(entry);
+
+      // when
+      changeInput(input, 'FOOOOOOO');
+
+      // then
+      expectError(entry, 'Must have max length 5.');
+    });
+
+
+    it('should validate pattern (String)', async function() {
+
+      // given
+      await expectSelected('ValidateTask');
+
+      const entry = findEntry('custom-entry-com.validated-inputs.Task-3', container),
+            input = findInput('text', entry);
+
+      // assume
+      expectError(entry, 'Must match pattern A+B.');
+
+      // when
+      changeInput(input, 'AAAB');
+
+      // then
+      expectValid(entry);
+    });
+
+
+    it('should validate pattern (String + Message)', async function() {
+
+      // given
+      await expectSelected('ValidateTask');
+
+      const entry = findEntry('custom-entry-com.validated-inputs.Task-4', container),
+            input = findInput('text', entry);
+
+      // assume
+      expectError(entry, 'Must start with https://');
+
+      // when
+      changeInput(input, 'https://');
+
+      // then
+      expectValid(entry);
+    });
+
+
+    it('should validate pattern (Integer)', async function() {
+
+      // given
+      await expectSelected('ValidateTask');
+
+      const entry = findEntry('custom-entry-com.validated-inputs.Task-5', container),
+            input = findInput('text', entry);
+
+      // assume
+      expectError(entry, 'Must be positive integer');
+
+      // when
+      changeInput(input, '20');
+
+      // then
+      expectValid(entry);
+    });
+
+  });
+
+});
+
+
+// helpers //////////
+
+function expectSelected(id) {
+  return getBpmnJS().invoke(async function(elementRegistry, selection) {
+    const element = elementRegistry.get(id);
+
+    await act(() => {
+      selection.select(element);
+    });
+
+    return element;
+  });
+}
+
+function expectError(entry, message) {
+  const errorMessage = domQuery('.bio-properties-panel-error', entry);
+
+  const error = errorMessage && errorMessage.textContent;
+
+  expect(error).to.equal(message);
+}
+
+function expectValid(entry) {
+  expectError(entry, null);
+}
+
+function findEntry(id, container) {
+  return domQuery(`[data-entry-id='${ id }']`, container);
+}
+
+function findInput(type, container) {
+  return domQuery(`input[type='${ type }']`, container);
+}
+
+function findSelect(container) {
+  return domQuery('select', container);
+}
+
+function findTextarea(container) {
+  return domQuery('textarea', container);
+}

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.spec.js
@@ -41,6 +41,9 @@ import descriptionElementTemplates from './CustomProperties.description.json';
 import editableDiagramXML from './CustomProperties.editable.bpmn';
 import editableElementTemplates from './CustomProperties.editable.json';
 
+import defaultTypesDiagramXML from './CustomProperties.default-types.bpmn';
+import defaultTypesElementTemplates from './CustomProperties.default-types.json';
+
 
 describe('provider/cloud-element-templates - CustomProperties', function() {
 
@@ -786,6 +789,91 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       // then
       expectValid(entry);
+    });
+
+  });
+
+
+  describe('default-types', function() {
+
+    beforeEach(bootstrapPropertiesPanel(defaultTypesDiagramXML, {
+      container,
+      debounceInput: false,
+      elementTemplates: defaultTypesElementTemplates,
+      moddleExtensions: {
+        zeebe: zeebeModdlePackage
+      },
+      modules: [
+        BpmnPropertiesPanel,
+        coreModule,
+        elementTemplatesModule,
+        modelingModule
+      ]
+    }));
+
+
+    it('should display String as default - property', async function() {
+
+      // given
+      await expectSelected('RestTask');
+
+      const entry = findEntry('custom-entry-com.example.default-type-0', container),
+            input = findInput('text', entry);
+
+      // then
+      expect(input).to.exist;
+    });
+
+
+    it('should display String as default - zeebe:taskDefinition:type', async function() {
+
+      // given
+      await expectSelected('RestTask');
+
+      const entry = findEntry('custom-entry-com.example.default-type-1', container),
+            input = findInput('text', entry);
+
+      // then
+      expect(input).to.exist;
+    });
+
+
+    it('should display String as default - zeebe:taskHeader', async function() {
+
+      // given
+      await expectSelected('RestTask');
+
+      const entry = findEntry('custom-entry-com.example.default-type-2', container),
+            input = findInput('text', entry);
+
+      // then
+      expect(input).to.exist;
+    });
+
+
+    it('should display String as default - zeebe:input', async function() {
+
+      // given
+      await expectSelected('RestTask');
+
+      const entry = findEntry('custom-entry-com.example.default-type-3', container),
+            input = findInput('text', entry);
+
+      // then
+      expect(input).to.exist;
+    });
+
+
+    it('should display String as default - zeebe:output', async function() {
+
+      // given
+      await expectSelected('RestTask');
+
+      const entry = findEntry('custom-entry-com.example.default-type-4', container),
+            input = findInput('text', entry);
+
+      // then
+      expect(input).to.exist;
     });
 
   });

--- a/test/spec/provider/cloud-element-templates/util/templateUtil.spec.js
+++ b/test/spec/provider/cloud-element-templates/util/templateUtil.spec.js
@@ -1,0 +1,192 @@
+import {
+  getVersionOrDateFromTemplate,
+  removeTemplate,
+  unlinkTemplate,
+  updateTemplate
+} from 'src/provider/cloud-element-templates/util/templateUtil';
+
+import TestContainer from 'mocha-test-container-support';
+
+import { bootstrapModeler, inject } from 'test/TestHelper';
+
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import coreModule from 'bpmn-js/lib/core';
+import elementTemplatesModule from 'src/provider/cloud-element-templates';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+
+import zeebeModdlePackage from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import diagramXML from '../fixtures/template-util.bpmn';
+import templates from '../fixtures/template-util.json';
+
+
+describe('provider/cloud-element-template - templateUtil', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    container: container,
+    modules: [
+      coreModule,
+      elementTemplatesModule,
+      modelingModule,
+      {
+        propertiesPanel: [ 'value', { registerProvider() {} } ]
+      }
+    ],
+    moddleExtensions: {
+      zeebe: zeebeModdlePackage
+    },
+    elementTemplates: templates
+  }));
+
+
+  it('should unlink task template', inject(function(elementRegistry, injector) {
+
+    // given
+    const task = elementRegistry.get('Task_1');
+
+    // when
+    unlinkTemplate(task, injector);
+
+    // then
+    const taskBo = getBusinessObject(task);
+
+    expect(taskBo.modelerTemplate).not.to.exist;
+    expect(taskBo.modelerTemplateVersion).not.to.exist;
+    expect(taskBo.name).to.equal('foo');
+  }));
+
+
+  it('should remove task template', inject(function(elementRegistry, injector) {
+
+    // given
+    let task = elementRegistry.get('Task_1');
+
+    // when
+    removeTemplate(task, injector);
+
+    // then
+    task = elementRegistry.get('Task_1');
+    const taskBo = getBusinessObject(task);
+
+    expect(taskBo.modelerTemplate).not.to.exist;
+    expect(taskBo.modelerTemplateVersion).not.to.exist;
+    expect(taskBo.name).to.not.exist;
+  }));
+
+
+  it('should remove conditional event template', inject(function(elementRegistry, injector) {
+
+    // given
+    let event = elementRegistry.get('ConditionalEvent');
+
+    // when
+    removeTemplate(event, injector);
+
+    // then
+    event = elementRegistry.get('ConditionalEvent');
+    const eventBo = getBusinessObject(event);
+
+    expect(eventBo.modelerTemplate).not.to.exist;
+    expect(eventBo.modelerTemplateVersion).not.to.exist;
+    expect(eventBo.eventDefinitions).to.have.length(1);
+  }));
+
+
+  it('should update template', inject(function(elementRegistry, injector) {
+
+    // given
+    const newTemplate = templates.find(
+      template => template.id === 'foo' && template.version === 2);
+    const task = elementRegistry.get('Task_1');
+
+    // when
+    updateTemplate(task, newTemplate, injector);
+
+    // then
+    const taskBo = getBusinessObject(task);
+
+    expect(taskBo.modelerTemplate).to.eql('foo');
+    expect(taskBo.modelerTemplateVersion).to.eql(2);
+  }));
+
+
+  describe('#getVersionOrDateFromTemplate', function() {
+
+    it('should return readable date from metadata.created', function() {
+
+      // given
+      const template = { metadata: { created: 0 } };
+
+      // when
+      const date = getVersionOrDateFromTemplate(template);
+
+      // then
+      expect(date).to.eql('01.01.1970');
+    });
+
+
+    it('should return readable date from metadata.updated', function() {
+
+      // given
+      const template = { metadata: { updated: 0 } };
+
+      // when
+      const date = getVersionOrDateFromTemplate(template);
+
+      // then
+      expect(date).to.eql('01.01.1970');
+    });
+
+
+    it('should return version if metadata is not present', function() {
+
+      // given
+      const template = { version: 0 };
+
+      // when
+      const version = getVersionOrDateFromTemplate(template);
+
+      // then
+      expect(version).to.eql(0);
+    });
+
+
+    it('should return null if neither version nor metadate is present', function() {
+
+      // given
+      const template = {};
+
+      // when
+      const result = getVersionOrDateFromTemplate(template);
+
+      // then
+      expect(result).to.be.null;
+    });
+  });
+
+
+  describe('selection', function() {
+
+    it('should select task after template is removed', inject(
+      function(elementRegistry, injector, selection) {
+
+        // given
+        let task = elementRegistry.get('Task_1');
+
+        // when
+        removeTemplate(task, injector);
+
+        // then
+        task = elementRegistry.get('Task_1');
+
+        expect(selection.get()).to.deep.equal([ task ]);
+      }));
+  });
+});


### PR DESCRIPTION
Closes #540 
Depends on https://github.com/camunda-cloud/zeebe-bpmn-moddle/pull/20

What's in
- [x] add basic `cloud-element-templates` feature, based on existing C7 implementation
- [x] add commands for supported bindings
  - [x] `zeebe:taskDefinition:type`
  - [x] `zeebe:taskHeader`
  - [x] `zeebe:input`
  - [x] `zeebe:output`
- [x] add custom props for supported bindings
- [x] proper default types (e.g. `zeebe:taskDefinition:type`  => `hidden`?) ==> _to be clarified_

What's not in
- add `optional` property (cf. [#559](https://github.com/bpmn-io/bpmn-js-properties-panel/issues/559)) 
- JSON schema validation
- scopes support
- make base element templates more reusable (namespace agnostic)
  - `ElementTemplatesGroup`
  - `getTemplateId` helpers

![image](https://user-images.githubusercontent.com/9433996/150802656-57bbc6f8-b215-41bb-8ff6-90c403b56195.png)

