### PR TITLE
docs: correct usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import BpmnModeler from 'bpmn-js/lib/Modeler';
 import {
   BpmnPropertiesPanelModule,
   BpmnPropertiesProviderModule,
-} from '@bpmn-io/bpmn-properties-panel';
+} from 'bpmn-js-properties-panel';
 
 const modeler = new BpmnModeler({
   container: '#canvas',


### PR DESCRIPTION
We did use the old import until now.

The one documented works at `bpmn-js-properties-panel@next`.