### PR TITLE
Optional `zeebe:input` and `zeebe:output`

### DIFF
--- a/src/provider/cloud-element-templates/CreateHelper.js
+++ b/src/provider/cloud-element-templates/CreateHelper.js
@@ -74,3 +74,20 @@ export function createTaskDefinitionWithType(value, bpmnFactory) {
     type: value
   });
 }
+
+/**
+ * Retrieves whether an element should be updated for a given property.
+ *
+ * That matches once
+ * a) the property value is not empty, or
+ * b) the property is not optional
+ *
+ * @param {String} value
+ * @param {Object} property
+ * @returns {Boolean}
+ */
+export function shouldUpdate(value, property) {
+  const { optional } = property;
+
+  return value || !optional;
+}

--- a/test/spec/provider/cloud-element-templates/cmd/task-template-optional.json
+++ b/test/spec/provider/cloud-element-templates/cmd/task-template-optional.json
@@ -1,0 +1,44 @@
+{
+  "name": "Task Template (optional)",
+  "version": 1,
+  "id": "task-template-optional",
+  "appliesTo": [
+    "bpmn:ServiceTask"
+  ],
+  "properties": [
+    {
+      "value": "input-1-source",
+      "type": "String",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:input",
+        "name": "input-1-target"
+      }
+    },
+    {
+      "type": "String",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:input",
+        "name": "input-2-target"
+      }
+    },
+    {
+      "value": "output-1-target",
+      "type": "String",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:output",
+        "source": "output-1-source"
+      }
+    },
+    {
+      "type": "String",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:output",
+        "source": "output-2-source"
+      }
+    }
+  ]
+}

--- a/test/spec/provider/cloud-element-templates/fixtures/complex.bpmn
+++ b/test/spec/provider/cloud-element-templates/fixtures/complex.bpmn
@@ -40,6 +40,19 @@
     <bpmn:serviceTask id="Activity_1x04xy0" name="outdated" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-outdated" zeebe:modelerTemplateVersion="1" />
     <bpmn:serviceTask id="Activity_166ntf9" name="missing template" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-missingTemplate" />
     <bpmn:serviceTask id="Activity_1iof33f" name="groups" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-groups" />
+    <bpmn:serviceTask id="Activity_042oqko" name="optional" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-optional">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="http" />
+        <zeebe:taskHeaders>
+          <zeebe:header key="method" value="get" />
+          <zeebe:header key="url" />
+        </zeebe:taskHeaders>
+        <zeebe:ioMapping>
+          <zeebe:input source="= invoiceDetails" target="body" />
+          <zeebe:output source="= body" target="response" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0vvlc66">
@@ -71,6 +84,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1iof33f_di" bpmnElement="Activity_1iof33f">
         <dc:Bounds x="550" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_042oqko_di" bpmnElement="Activity_042oqko">
+        <dc:Bounds x="410" y="360" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/cloud-element-templates/fixtures/complex.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/complex.json
@@ -51,6 +51,7 @@
         "description": "Data to send to the endpoint.",
         "value": "",
         "type": "String",
+        "optional": true,
         "binding": {
           "type": "zeebe:input",
           "name": "body"
@@ -61,6 +62,7 @@
         "description": "Name of variable to store the response data in.",
         "value": "response",
         "type": "String",
+        "optional": true,
         "binding": {
           "type": "zeebe:output",
           "source": "= body"
@@ -362,6 +364,77 @@
       {
         "id": "mapping",
         "label": "Response mapping"
+      }
+    ]
+  },
+  {
+    "name": "REST Connector (optional)",
+    "id": "io.camunda.connectors.RestConnector-optional",
+    "description": "A generic REST service.",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "http",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "REST Endpoint URL",
+        "description": "Specify the url of the REST API to talk to.",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "url"
+        },
+        "constraints": {
+          "notEmpty": true,
+          "pattern": {
+            "value": "^https?://.*",
+            "message": "Must be http(s) URL."
+          }
+        }
+      },
+      {
+        "label": "REST Method",
+        "description": "Specify the HTTP method to use.",
+        "type": "Dropdown",
+        "value": "get",
+        "choices": [
+          { "name": "GET", "value": "get" },
+          { "name": "POST", "value": "post" },
+          { "name": "PATCH", "value": "patch" },
+          { "name": "DELETE", "value": "delete" }
+        ],
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "method"
+        }
+      },
+      {
+        "label": "Request Body",
+        "description": "Data to send to the endpoint.",
+        "value": "",
+        "optional": true,
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "body"
+        }
+      },
+      {
+        "label": "Result Variable",
+        "description": "Name of variable to store the response data in.",
+        "value": "response",
+        "optional": true,
+        "type": "String",
+        "binding": {
+          "type": "zeebe:output",
+          "source": "= body"
+        }
       }
     ]
   }

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.bpmn
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.bpmn
@@ -22,6 +22,16 @@
         <zeebe:taskDefinition type="task-type" />
       </bpmn:extensionElements>
     </bpmn:serviceTask>
+    <bpmn:serviceTask id="RestTask_optional" name="optional" zeebe:modelerTemplate="com.example.rest-optional">
+       <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="input-1-source" target="input-1-target" />
+          <zeebe:input source="input-2-source" target="input-2-target" />
+          <zeebe:output source="output-1-source" target="output-1-target" />
+          <zeebe:output source="output-2-source" target="output-2-target" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -42,6 +52,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0sz43pp_di" bpmnElement="RestTask_hidden">
         <dc:Bounds x="470" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="RestTask_optional_di" bpmnElement="RestTask_optional">
+        <dc:Bounds x="470" y="200" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.json
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.json
@@ -205,5 +205,64 @@
         }
       }
     ]
+  },
+  {
+    "name": "Rest Template (optional)",
+    "id": "com.example.rest-optional",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "value": "input-1-source",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "input-1-target"
+        }
+      },
+      {
+        "value": "input-2-source",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "input-2-target"
+        }
+      },
+      {
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "input-3-target"
+        }
+      },
+      {
+        "value": "output-1-target",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:output",
+          "source": "output-1-source"
+        }
+      },
+      {
+        "value": "output-2-target",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:output",
+          "source": "output-2-source"
+        }
+      },
+      {
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:output",
+          "source": "output-3-source"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.spec.js
@@ -228,6 +228,21 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
     });
 
 
+    it('should display empty (optional)', async function() {
+
+      // when
+      await expectSelected('RestTask_optional');
+
+      // then
+      const entry = findEntry('custom-entry-com.example.rest-optional-2', container),
+            input = findInput('text', entry);
+
+      expect(entry).to.exist;
+      expect(input).to.exist;
+      expect(input.value).to.equal('');
+    });
+
+
     it('should change, setting zeebe:Input (plain)', inject(async function() {
 
       // given
@@ -278,6 +293,51 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
     });
 
+
+    it('should keep input (non optional)', inject(async function() {
+
+      // given
+      const task = await expectSelected('RestTask_optional'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const entry = findEntry('custom-entry-com.example.rest-optional-0', container),
+            input = findInput('text', entry);
+
+      changeInput(input, '');
+
+      // then
+      const ioMapping = findExtension(businessObject, 'zeebe:IoMapping'),
+            inputParameter = findInputParameter(ioMapping, { name: 'input-1-target' });
+
+      expect(inputParameter).to.exist;
+      expect(inputParameter).to.jsonEqual({
+        $type: 'zeebe:Input',
+        source: undefined,
+        target: 'input-1-target'
+      });
+    }));
+
+
+    it('should not keep input (optional)', inject(async function() {
+
+      // given
+      const task = await expectSelected('RestTask_optional'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const entry = findEntry('custom-entry-com.example.rest-optional-1', container),
+            input = findInput('text', entry);
+
+      changeInput(input, '');
+
+      // then
+      const ioMapping = findExtension(businessObject, 'zeebe:IoMapping'),
+            inputParameter = findInputParameter(ioMapping, { name: 'input-2-target' });
+
+      expect(inputParameter).to.not.exist;
+    }));
+
   });
 
 
@@ -295,6 +355,21 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(entry).to.exist;
       expect(input).to.exist;
       expect(input.value).to.equal('output-1-target');
+    });
+
+
+    it('should display empty (optional)', async function() {
+
+      // when
+      await expectSelected('RestTask_optional');
+
+      // then
+      const entry = findEntry('custom-entry-com.example.rest-optional-5', container),
+            input = findInput('text', entry);
+
+      expect(entry).to.exist;
+      expect(input).to.exist;
+      expect(input.value).to.equal('');
     });
 
 
@@ -347,6 +422,51 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         target: 'foo@bar'
       });
     });
+
+
+    it('should keep output (non optional)', inject(async function() {
+
+      // given
+      const task = await expectSelected('RestTask_optional'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const entry = findEntry('custom-entry-com.example.rest-optional-3', container),
+            input = findInput('text', entry);
+
+      changeInput(input, '');
+
+      // then
+      const ioMapping = findExtension(businessObject, 'zeebe:IoMapping'),
+            outputParameter = findOutputParameter(ioMapping, { source: 'output-1-source' });
+
+      expect(outputParameter).to.exist;
+      expect(outputParameter).to.jsonEqual({
+        $type: 'zeebe:Output',
+        source: 'output-1-source',
+        target: undefined
+      });
+    }));
+
+
+    it('should NOT keep output (optional)', inject(async function() {
+
+      // given
+      const task = await expectSelected('RestTask_optional'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const entry = findEntry('custom-entry-com.example.rest-optional-4', container),
+            input = findInput('text', entry);
+
+      changeInput(input, '');
+
+      // then
+      const ioMapping = findExtension(businessObject, 'zeebe:IoMapping'),
+            outputParameter = findOutputParameter(ioMapping, { source: 'output-2-source' });
+
+      expect(outputParameter).to.not.exist;
+    }));
 
   });
 


### PR DESCRIPTION
Closes #559 

Script to try it out

```sh
npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel#559-optional-inputs-outputs -c "npm run start:cloud-templates"
```

![Kapture 2022-02-01 at 16 03 57](https://user-images.githubusercontent.com/9433996/151993619-3e6f2880-c856-455e-958f-277928053ab3.gif)

