### PR TITLE
C8 templates validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -360,11 +360,12 @@
       }
     },
     "@bpmn-io/element-templates-validator": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.4.0.tgz",
-      "integrity": "sha512-cJtmUHn/4QpkeGQ/tUBQO020Cr1x2AILYczzMioRCGRSEekR/8wSaeEFuEx5ujFNDbHSx2lLN5P2ZmHlpD1Tmg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.5.0.tgz",
+      "integrity": "sha512-v/gfuYs7AOsQUzGmWBEupFGZiylCzqapBoZrjavewnPPbDOzLvbHZ1bnYPre/7b/wdnf4ayx0bf/NCC/AEySVg==",
       "requires": {
-        "@camunda/element-templates-json-schema": "^0.6.0",
+        "@camunda/element-templates-json-schema": "^0.7.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.1.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^3.8.1"
       }
@@ -389,9 +390,14 @@
       }
     },
     "@camunda/element-templates-json-schema": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.6.0.tgz",
-      "integrity": "sha512-sfNIOKSfx/VQesCe1+m1izfIZS64NWDZq3teyMzzfJkn37u0ngwIwEXlc7Voj8Qcg2paePT8HmEgp+TJP39V3Q=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.7.0.tgz",
+      "integrity": "sha512-ylBhHzAuzQjX+ZoZTPinHCsIaMa89fqyk10sxVQjgEm63+o40KMomjKf4EM2sXwiy72vDbjeXyb3Z56a7MTETQ=="
+    },
+    "@camunda/zeebe-element-templates-json-schema": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.1.0.tgz",
+      "integrity": "sha512-E5mie+Q+/0Rk12GerNRWZP6aIWFXo4KfC++6tFJUvKt8la4ZvsPpagB7F8Oiahd56/gUqOicJ7+yPyQ85JnFgA=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@bpmn-io/element-templates-validator": "^0.4.0",
+    "@bpmn-io/element-templates-validator": "^0.5.0",
     "@bpmn-io/extract-process-variables": "^0.4.4",
     "array-move": "^3.0.1",
     "classnames": "^2.3.1",

--- a/src/index.js
+++ b/src/index.js
@@ -8,3 +8,6 @@ export { DescriptionProvider as ZeebeDescriptionProvider } from './contextProvid
 
 // hooks
 export { useService } from './hooks';
+
+// utils
+export { Validator as CloudElementTemplatesValidator } from './provider/cloud-element-templates/Validator';

--- a/src/provider/cloud-element-templates/Validator.js
+++ b/src/provider/cloud-element-templates/Validator.js
@@ -1,5 +1,19 @@
-import { Validator as BaseValidator } from '../element-templates/Validator';
+import {
+  Validator as BaseValidator,
+  filteredSchemaErrors,
+  getSchemaVersion
+} from '../element-templates/Validator';
 
+import semver from 'semver';
+
+import {
+  validateZeebe as validateAgainstSchema,
+  getZeebeSchemaPackage as getTemplateSchemaPackage,
+  getZeebeSchemaVersion as getTemplateSchemaVersion
+} from '@bpmn-io/element-templates-validator';
+
+const SUPPORTED_SCHEMA_VERSION = getTemplateSchemaVersion();
+const SUPPORTED_SCHEMA_PACKAGE = getTemplateSchemaPackage();
 
 /**
  * A Camunda Cloud element template validator.
@@ -10,8 +24,6 @@ export class Validator extends BaseValidator {
   }
 
   /**
-   * TODO(pinussilvestrus): we disable JSON schema validation for now.
-   *
    * Validate given template and return error (if any).
    *
    * @param {TemplateDescriptor} template
@@ -22,9 +34,34 @@ export class Validator extends BaseValidator {
     let err;
 
     const id = template.id,
-          version = template.version || '_';
+          version = template.version || '_',
+          schema = template.$schema,
+          schemaVersion = schema && getSchemaVersion(schema);
 
-    // (1) versioning
+    // (1) $schema attribute defined
+    if (!schema) {
+      return this._logError(
+        'missing $schema attribute.',
+        template
+      );
+    }
+
+    if (!this.isSchemaValid(schema)) {
+      return this._logError(
+        `unsupported $schema attribute <${ schema }>.`,
+        template
+      );
+    }
+
+    // (2) compatibility
+    if (schemaVersion && (semver.compare(SUPPORTED_SCHEMA_VERSION, schemaVersion) < 0)) {
+      return this._logError(
+        `unsupported element template schema version <${ schemaVersion }>. Your installation only supports up to version <${ SUPPORTED_SCHEMA_VERSION }>. Please update your installation`,
+        template
+      );
+    }
+
+    // (3) versioning
     if (this._templatesById[ id ] && this._templatesById[ id ][ version ]) {
       if (version === '_') {
         return this._logError(`template id <${ id }> already used`, template);
@@ -33,6 +70,26 @@ export class Validator extends BaseValidator {
       }
     }
 
+    // (4) JSON schema compliance
+    const validationResult = validateAgainstSchema(template);
+
+    const {
+      errors,
+      valid
+    } = validationResult;
+
+    if (!valid) {
+      err = new Error('invalid template');
+
+      filteredSchemaErrors(errors).forEach((error) => {
+        this._logError(error.message, template);
+      });
+    }
+
     return err;
+  }
+
+  isSchemaValid(schema) {
+    return schema && schema.includes(SUPPORTED_SCHEMA_PACKAGE);
   }
 }

--- a/src/provider/element-templates/Validator.js
+++ b/src/provider/element-templates/Validator.js
@@ -167,7 +167,7 @@ export class Validator {
  *
  * @return {String} for example '99.99.99'
  */
-function getSchemaVersion(schemaUri) {
+export function getSchemaVersion(schemaUri) {
   const re = /\d+\.\d+\.\d+/g;
 
   const match = schemaUri.match(re);
@@ -189,7 +189,7 @@ function getSchemaVersion(schemaUri) {
  *
  * @return {Array}
  */
-function filteredSchemaErrors(schemaErrors) {
+export function filteredSchemaErrors(schemaErrors) {
   return filter(schemaErrors, (err) => {
     const {
       dataPath,

--- a/test/spec/provider/cloud-element-templates/Validator.spec.js
+++ b/test/spec/provider/cloud-element-templates/Validator.spec.js
@@ -1,0 +1,435 @@
+import { Validator } from 'src/provider/cloud-element-templates/Validator';
+
+import { getZeebeSchemaVersion as getTemplateSchemaVersion } from '@bpmn-io/element-templates-validator';
+
+const ElementTemplateSchemaVersion = getTemplateSchemaVersion();
+
+
+describe('provider/cloud-element-templates - Validator', function() {
+
+  function errors(validator) {
+    return validator.getErrors().map(function(e) {
+      return e.message;
+    });
+  }
+
+  function valid(validator) {
+    return validator.getValidTemplates();
+  }
+
+  describe('schema version', function() {
+
+    it('should accept when template and library have the same version', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/simple-same-schema-version.json');
+
+      templateDescriptor.map(function(template) {
+        template.$schema = 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema@' +
+          ElementTemplateSchemaVersion + '/resources/schema.json';
+      });
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.be.empty;
+
+      expect(valid(templates)).to.have.length(templateDescriptor.length);
+    });
+
+
+    it('should accept when template has lower version than library', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/simple-low-schema-version.json');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.be.empty;
+
+      expect(valid(templates)).to.have.length(templateDescriptor.length);
+    });
+
+
+    it('should reject when template has higher version than library', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/simple-high-schema-version.json');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(valid(templates)).to.be.empty;
+
+      expect(errors(templates)).to.have.length(templateDescriptor.length);
+    });
+
+
+    it('should accept when template has no version', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/simple.json');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.be.empty;
+
+      expect(valid(templates)).to.have.length(templateDescriptor.length);
+    });
+
+
+    it('should accept when template has latest version', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/simple-latest-schema-version.json');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.be.empty;
+
+      expect(valid(templates)).to.have.length(templateDescriptor.length);
+    });
+
+
+    it('should accept and reject when some templates have unsupported version', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/simple-mixed-schema-version.json');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.have.length(3);
+
+      expect(valid(templates)).to.have.length(3);
+    });
+
+
+    it('should provide correct error details when rejecting', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/simple-high-schema-version.json');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.have.length(6);
+
+      expect(errors(templates)[0]).to.eql('template(id: <foo>, name: <Foo>): unsupported element template schema version <99.99.99>. Your installation only supports up to version <' + ElementTemplateSchemaVersion + '>. Please update your installation');
+    });
+
+  });
+
+
+  describe('schema attribute', function() {
+
+    it('should accept', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/simple-defined-schema.json');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.be.empty;
+
+      expect(valid(templates)).to.have.length(templateDescriptor.length);
+    });
+
+
+    it('should accept - other vendor', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/simple-other-vendor-schema.json');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.be.empty;
+
+      expect(valid(templates)).to.have.length(templateDescriptor.length);
+    });
+
+
+    it('should reject - missing $schema', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/simple-missing-schema.json');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(valid(templates)).to.be.empty;
+
+      expect(errors(templates)).to.jsonEqual([
+        'template(id: <foo>, name: <Foo>): missing $schema attribute.'
+      ]);
+    });
+
+
+    it('should reject - wrong $schema', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/simple-wrong-schema.json');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(valid(templates)).to.be.empty;
+
+      expect(errors(templates)).to.jsonEqual([
+        'template(id: <foo>, name: <Foo>): unsupported $schema attribute <https://unpkg.com/@camunda/element-templates-json-schema/resources/schema.json>.'
+      ]);
+    });
+
+  });
+
+
+  describe('content validation', function() {
+
+    it('should accept simple example templates', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/simple');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.be.empty;
+
+      expect(valid(templates)).to.have.length(templateDescriptor.length);
+    });
+
+
+    it('should accept complex example templates', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/complex');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.be.empty;
+
+      expect(valid(templates)).to.have.length(templateDescriptor.length);
+    });
+
+
+    it('should accept connectors templates', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/connectors');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.be.empty;
+
+      expect(valid(templates)).to.have.length(templateDescriptor.length);
+    });
+
+
+    it('should reject missing name', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/error-name-missing');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.contain('template(id: <invalid>, name: <undefined>): missing template name');
+
+      expect(valid(templates)).to.be.empty;
+    });
+
+
+    it('should reject missing id', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/error-id-missing');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.contain('template(id: <undefined>, name: <Invalid>): missing template id');
+
+      expect(valid(templates)).to.be.empty;
+    });
+
+
+    it('should reject missing binding', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/error-binding-missing');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.contain('template(id: <invalid>, name: <Invalid>): missing binding for property "0"');
+
+      expect(valid(templates)).to.be.empty;
+    });
+
+
+    it('should reject duplicate id', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/error-id-duplicate');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.contain('template(id: <foo>, name: <Foo 2>): template id <foo> already used');
+
+      expect(valid(templates)).to.have.length(1);
+    });
+
+
+    it('should reject duplicate id and version', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/error-id-version-duplicate');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.contain('template(id: <foo>, name: <Foo 2>): template id <foo> and version <1> already used');
+
+      expect(valid(templates)).to.have.length(1);
+    });
+
+
+    it('should reject invalid optional binding type', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/error-invalid-optional');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.contain('template(id: <invalid>, name: <Invalid>): optional is not supported for binding type "zeebe:taskHeader"; must be any of { zeebe:input, zeebe:output }');
+
+      expect(valid(templates)).to.be.empty;
+    });
+
+
+    it('should reject optional=true <-> constraints.notEmpty=true', function() {
+
+      // given
+      const templates = new Validator();
+
+      const templateDescriptor = require('./fixtures/error-optional-not-empty');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.contain('template(id: <invalid>, name: <Invalid>): optional is not allowed for truthy "notEmpty" constraint');
+
+      expect(valid(templates)).to.be.empty;
+    });
+
+
+    describe('grouping', function() {
+
+      it('should accept groups', function() {
+
+        // given
+        const templates = new Validator();
+
+        const templateDescriptor = require('./fixtures/groups');
+
+        // when
+        templates.addAll(templateDescriptor);
+
+        // then
+        expect(errors(templates)).to.be.empty;
+
+        expect(valid(templates)).to.have.length(templateDescriptor.length);
+      });
+
+
+      it('should not accept missing group id', function() {
+
+        // given
+        const templates = new Validator();
+
+        const templateDescriptor = require('./fixtures/error-groups-missing-id');
+
+        // when
+        templates.addAll(templateDescriptor);
+
+        // then
+        expect(errors(templates)).to.contain('template(id: <example.com.missingGroupId>, name: <Missing group id>): missing id for group "0"');
+
+        expect(valid(templates)).to.be.empty;
+      });
+
+    });
+
+  });
+
+});

--- a/test/spec/provider/cloud-element-templates/fixtures/complex.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/complex.json
@@ -1,5 +1,6 @@
 [
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "REST Connector",
     "id": "io.camunda.connectors.RestConnector-s1",
     "description": "A generic REST service.",
@@ -71,6 +72,7 @@
     ]
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "REST Connector (entries visible)",
     "id": "io.camunda.connectors.RestConnector-entriesVisible",
     "description": "A generic REST service.",
@@ -141,6 +143,7 @@
     ]
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "REST Connector (outdated)",
     "id": "io.camunda.connectors.RestConnector-outdated",
     "description": "A generic REST service.",
@@ -211,6 +214,7 @@
     ]
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "REST Connector (outdated)",
     "id": "io.camunda.connectors.RestConnector-outdated",
     "description": "A generic REST service.",
@@ -281,6 +285,7 @@
     ]
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "REST Connector (groups)",
     "id": "io.camunda.connectors.RestConnector-groups",
     "description": "A generic REST service.",
@@ -368,6 +373,7 @@
     ]
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "REST Connector (optional)",
     "id": "io.camunda.connectors.RestConnector-optional",
     "description": "A generic REST service.",

--- a/test/spec/provider/cloud-element-templates/fixtures/connectors.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/connectors.json
@@ -1,0 +1,189 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Email Connector",
+    "id": "io.camunda.connectors.EmailConnector-s2",
+    "description": "A Email sending task.",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "send-email",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "Hostname",
+        "description": "Specify the email server (SMTP) host name",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "HOST_NAME"
+        },
+        "constraints": {
+          "notEmpty": true
+        }
+      },
+      {
+        "label": "Port",
+        "description": "Specify the email server (SMTP) port (default=25)",
+        "type": "String",
+        "value": "= 25",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "PORT"
+        },
+        "constraints": {
+          "optional": true
+        }
+      },
+      {
+        "label": "Username",
+        "description": "Specify the user name to authenticate with",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "USER_NAME"
+        },
+        "constraints": {
+          "optional": true
+        }
+      },
+      {
+        "label": "Password",
+        "description": "Specify the password to authenticate with",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "PASSWORD"
+        },
+        "constraints": {
+          "optional": true
+        }
+      },
+      {
+        "label": "Sender",
+        "description": "Enter the FROM field",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "sender"
+        },
+        "constraints": {
+          "notEmpty": true
+        }
+      },
+      {
+        "label": "Recipient",
+        "description": "Enter the TO field",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "recipient"
+        },
+        "constraints": {
+          "notEmpty": true
+        }
+      },
+      {
+        "label": "Subject",
+        "description": "Enter the mail subject",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "subject"
+        },
+        "constraints": {
+          "notEmpty": true
+        }
+      },
+      {
+        "label": "Body",
+        "description": "Enter the email message body",
+        "type": "Text",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "message"
+        },
+        "constraints": {
+          "notEmpty": true
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "REST Connector",
+    "id": "io.camunda.connectors.RestConnector-s1",
+    "description": "A REST API invocation task.",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "http",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "REST Endpoint URL",
+        "description": "Specify the url of the REST API to talk to.",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "url"
+        },
+        "constraints": {
+          "notEmpty": true,
+          "pattern": {
+            "value": "^https?://.*",
+            "message": "Must be http(s) URL."
+          }
+        }
+      },
+      {
+        "label": "REST Method",
+        "description": "Specify the HTTP method to use.",
+        "type": "Dropdown",
+        "value": "get",
+        "choices": [
+          { "name": "GET", "value": "get" },
+          { "name": "POST", "value": "post" },
+          { "name": "PATCH", "value": "patch" },
+          { "name": "DELETE", "value": "delete" }
+        ],
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "method"
+        }
+      },
+      {
+        "label": "Request Body",
+        "description": "Data to send to the endpoint.",
+        "value": "",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "body"
+        }
+      },
+      {
+        "label": "Result Variable",
+        "description": "Name of variable to store the response data in.",
+        "value": "response",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:output",
+          "source": "= body"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/entries-visible.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/entries-visible.json
@@ -1,5 +1,6 @@
 [
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "id": "foo",
     "name":"EntriesVisible=true",
     "appliesTo": [ "bpmn:Task" ],
@@ -7,6 +8,7 @@
     "entriesVisible": true
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "id": "foo",
     "name":"EntriesVisible=false",
     "version": 1,
@@ -14,6 +16,7 @@
     "properties": []
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "id": "default",
     "name": "EntriesVisible unset",
     "isDefault": true,

--- a/test/spec/provider/cloud-element-templates/fixtures/error-binding-missing.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/error-binding-missing.json
@@ -1,0 +1,16 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "invalid",
+    "name": "Invalid",
+    "appliesTo": [
+      "bpmn:UserTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "http"
+      }
+    ]
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/error-groups-missing-id.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/error-groups-missing-id.json
@@ -1,0 +1,24 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Missing group id",
+    "id": "example.com.missingGroupId",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [],
+    "groups": [
+      {
+        "label": "Group one"
+      },
+      {
+        "id": "two",
+        "label": "Group two"
+      },
+      {
+        "id": "three",
+        "label": "Group three"
+      }
+    ]
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/error-id-duplicate.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/error-id-duplicate.json
@@ -1,0 +1,20 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "FOO 1",
+    "id": "foo",
+    "appliesTo": [
+      "bpmn:UserTask"
+    ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Foo 2",
+    "id": "foo",
+    "appliesTo": [
+      "bpmn:UserTask"
+    ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/error-id-missing.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/error-id-missing.json
@@ -1,0 +1,10 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Invalid",
+    "appliesTo": [
+      "bpmn:UserTask"
+    ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/error-id-version-duplicate.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/error-id-version-duplicate.json
@@ -1,0 +1,22 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "FOO 1",
+    "id": "foo",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:UserTask"
+    ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Foo 2",
+    "id": "foo",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:UserTask"
+    ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/error-invalid-optional.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/error-invalid-optional.json
@@ -1,0 +1,20 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Invalid",
+    "id": "invalid",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "header"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/error-name-missing.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/error-name-missing.json
@@ -1,0 +1,10 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "invalid",
+    "appliesTo": [
+      "bpmn:UserTask"
+    ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/error-optional-not-empty.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/error-optional-not-empty.json
@@ -1,0 +1,23 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Invalid",
+    "id": "invalid",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "header"
+        },
+        "constraints": {
+          "notEmpty": true
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/groups.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/groups.json
@@ -1,0 +1,70 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Grouping",
+    "id": "example.com.grouping",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "label": "input 1",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "input1"
+        }
+      },
+      {
+        "label": "input 2",
+        "group": "one",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "input2"
+        }
+      },
+      {
+        "label": "input 3",
+        "group": "one",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "input3"
+        }
+      },
+      {
+        "label": "input 4",
+        "group": "two",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "input4"
+        }
+      },
+      {
+        "label": "input 5",
+        "group": "three",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "input5"
+        }
+      }
+    ],
+    "groups": [
+      {
+        "id": "one",
+        "label": "Group one"
+      },
+      {
+        "id": "two",
+        "label": "Group two"
+      },
+      {
+        "id": "three",
+        "label": "Group three"
+      }
+    ]
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/simple-defined-schema.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/simple-defined-schema.json
@@ -1,0 +1,9 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "foo",
+    "name":"Foo",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/simple-high-schema-version.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/simple-high-schema-version.json
@@ -1,0 +1,49 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@99.99.99/resources/schema.json",
+    "id": "foo",
+    "name":"Foo",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@99.99.99/resources/schema.json",
+    "id": "foo",
+    "name":"Foo 1",
+    "version": 1,
+    "isDefault": true,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@99.99.99/resources/schema.json",
+    "id": "foo",
+    "name":"Foo 2",
+    "version": 2,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@99.99.99/resources/schema.json",
+    "id": "bar",
+    "name":"Bar 1",
+    "version": 1,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@99.99.99/resources/schema.json",
+    "id": "bar",
+    "name":"Bar 2",
+    "version": 2,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@99.99.99/resources/schema.json",
+    "id": "baz",
+    "name":"Baz",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/simple-latest-schema-version.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/simple-latest-schema-version.json
@@ -1,0 +1,49 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "foo",
+    "name":"Foo",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "foo",
+    "name":"Foo 1",
+    "version": 1,
+    "isDefault": true,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "foo",
+    "name":"Foo 2",
+    "version": 2,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "bar",
+    "name":"Bar 1",
+    "version": 1,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "bar",
+    "name":"Bar 2",
+    "version": 2,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "baz",
+    "name":"Baz",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/simple-low-schema-version.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/simple-low-schema-version.json
@@ -1,0 +1,49 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.0.1/resources/schema.json",
+    "id": "foo",
+    "name":"Foo",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.0.1/resources/schema.json",
+    "id": "foo",
+    "name":"Foo 1",
+    "version": 1,
+    "isDefault": true,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.0.1/resources/schema.json",
+    "id": "foo",
+    "name":"Foo 2",
+    "version": 2,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.0.1/resources/schema.json",
+    "id": "bar",
+    "name":"Bar 1",
+    "version": 1,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.0.1/resources/schema.json",
+    "id": "bar",
+    "name":"Bar 2",
+    "version": 2,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.0.1/resources/schema.json",
+    "id": "baz",
+    "name":"Baz",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/simple-missing-schema.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/simple-missing-schema.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "foo",
+    "name":"Foo",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/simple-mixed-schema-version.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/simple-mixed-schema-version.json
@@ -1,0 +1,49 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.0.1/resources/schema.json",
+    "id": "foo",
+    "name":"Foo",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.0.1/resources/schema.json",
+    "id": "foo",
+    "name":"Foo 1",
+    "version": 1,
+    "isDefault": true,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.0.1/resources/schema.json",
+    "id": "foo",
+    "name":"Foo 2",
+    "version": 2,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@99.99.99/resources/schema.json",
+    "id": "bar",
+    "name":"Bar 1",
+    "version": 1,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@99.99.99/resources/schema.json",
+    "id": "bar",
+    "name":"Bar 2",
+    "version": 2,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@99.99.99/resources/schema.json",
+    "id": "baz",
+    "name":"Baz",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/simple-other-vendor-schema.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/simple-other-vendor-schema.json
@@ -1,0 +1,9 @@
+[
+  {
+    "$schema": "https://cdn.jsdelivr.net/npm/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "foo",
+    "name":"Foo",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/simple-same-schema-version.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/simple-same-schema-version.json
@@ -1,0 +1,49 @@
+[
+  {
+    "$schema": "<define during runtime>",
+    "id": "foo",
+    "name":"Foo",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "<define during runtime>",
+    "id": "foo",
+    "name":"Foo 1",
+    "version": 1,
+    "isDefault": true,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "<define during runtime>",
+    "id": "foo",
+    "name":"Foo 2",
+    "version": 2,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "<define during runtime>",
+    "id": "bar",
+    "name":"Bar 1",
+    "version": 1,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "<define during runtime>",
+    "id": "bar",
+    "name":"Bar 2",
+    "version": 2,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  },
+  {
+    "$schema": "<define during runtime>",
+    "id": "baz",
+    "name":"Baz",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/simple-wrong-schema.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/simple-wrong-schema.json
@@ -1,0 +1,9 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/element-templates-json-schema/resources/schema.json",
+    "id": "foo",
+    "name":"Foo",
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/cloud-element-templates/fixtures/simple.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/simple.json
@@ -1,5 +1,6 @@
 [
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "MailTask",
     "id": "my.mail.Task",
     "appliesTo": [
@@ -18,12 +19,14 @@
     ]
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "id": "foo",
     "name":"Foo",
     "appliesTo": [ "bpmn:Task" ],
     "properties": []
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "id": "foo",
     "name":"Foo 1",
     "version": 1,
@@ -31,6 +34,7 @@
     "properties": []
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "id": "foo",
     "name":"Foo 2",
     "version": 2,
@@ -38,6 +42,7 @@
     "properties": []
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "id": "foo",
     "name":"Foo 3",
     "version": 3,
@@ -45,6 +50,7 @@
     "properties": []
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "id": "bar",
     "name":"Bar 1",
     "version": 1,
@@ -52,6 +58,7 @@
     "properties": []
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "id": "bar",
     "name":"Bar 2",
     "version": 2,
@@ -59,12 +66,14 @@
     "properties": []
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "id": "baz",
     "name":"Baz",
     "appliesTo": [ "bpmn:Task" ],
     "properties": []
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "id": "default",
     "name": "Default Template",
     "version": 1,

--- a/test/spec/provider/cloud-element-templates/fixtures/template-groups.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/template-groups.json
@@ -1,5 +1,6 @@
 [
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "REST Connector",
     "id": "io.camunda.connectors.RestConnector-s1",
     "description": "A generic REST service.",

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.default-types.json
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.default-types.json
@@ -1,5 +1,6 @@
 [
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Rest Template",
     "id": "com.example.default-types",
     "appliesTo": [

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.description.json
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.description.json
@@ -1,5 +1,6 @@
 [
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Description Task",
     "id": "com.zeebe.example.description",
     "description": "Shows description for each type of property",

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.editable.json
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.editable.json
@@ -1,5 +1,6 @@
 [
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Editable Task",
     "id": "com.zeebe.example.editable",
     "description": "Shows editable for each type of property",

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.groups.json
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.groups.json
@@ -1,5 +1,6 @@
 [
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Grouping",
     "id": "example.com.grouping",
     "appliesTo": [
@@ -75,6 +76,7 @@
     ]
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "no default",
     "id": "example.com.grouping-noDefault",
     "appliesTo": [
@@ -115,6 +117,7 @@
     ]
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "no groups",
     "id": "example.com.grouping-noGroups",
     "appliesTo": [
@@ -147,6 +150,7 @@
     ]
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "no entries",
     "id": "example.com.grouping-noEntries",
     "appliesTo": [
@@ -184,6 +188,7 @@
     ]
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "non existing",
     "id": "example.com.grouping-nonExisting",
     "appliesTo": [

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.json
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.json
@@ -1,5 +1,6 @@
 [
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Rest Template",
     "id": "com.example.rest",
     "appliesTo": [
@@ -64,6 +65,7 @@
     ]
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Rest Template (hidden)",
     "id": "com.example.rest-hidden",
     "appliesTo": [
@@ -80,6 +82,7 @@
     ]
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Task Template",
     "id": "my.example.template",
     "appliesTo": [
@@ -97,6 +100,7 @@
     ]
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Task Template 2",
     "id": "my.example.dropdown",
     "appliesTo": [
@@ -120,6 +124,7 @@
     ]
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Validated Inputs Task",
     "id": "com.validated-inputs.Task",
     "appliesTo": [
@@ -207,6 +212,7 @@
     ]
   },
   {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Rest Template (optional)",
     "id": "com.example.rest-optional",
     "appliesTo": [

--- a/test/spec/provider/element-templates/Validator.spec.js
+++ b/test/spec/provider/element-templates/Validator.spec.js
@@ -450,10 +450,10 @@ describe('provider/element-templates - Validator', function() {
 
       // then
       expect(errors(templates)).to.eql([
+        'template(id: <my.execution.listener.task>, name: <Execution Listener>): must provide choices=[] with "Dropdown" type',
         'template(id: <my.execution.listener.task>, name: <Execution Listener>): invalid property type "String" for binding type "camunda:executionListener"; must be "Hidden"',
         'template(id: <my.execution.listener.task>, name: <Execution Listener>): invalid property type "Text" for binding type "camunda:executionListener"; must be "Hidden"',
         'template(id: <my.execution.listener.task>, name: <Execution Listener>): invalid property type "Boolean" for binding type "camunda:executionListener"; must be "Hidden"',
-        'template(id: <my.execution.listener.task>, name: <Execution Listener>): must provide choices=[] with "Dropdown" type',
         'template(id: <my.execution.listener.task>, name: <Execution Listener>): invalid property type "Dropdown" for binding type "camunda:executionListener"; must be "Hidden"',
       ]);
 


### PR DESCRIPTION
Closes #561 

Implements JSON Schema validation for C8 templates.
Note that we also validate for an existing `$schema` attribute in any C8 template, that needs to reference our schema package in some way (`@camunda/zeebe-element-templates-json-schema`).

In particular it
* adds `@bpmn-io/element-templates-validator` v0.5
* adds the `$schema` attribute to existing C8 example templates
* validates C8 templates against the JSON Schema + validates the defined `$schema` attribute

----

Snapshot from the Camunda Modeler WIP integration

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/9433996/154971228-f34c88d3-639d-4247-a1a5-c374e68121d8.png">
