### PR TITLE
chore(ElementTemplatesGroup): correct select title

### DIFF
--- a/src/provider/element-templates/components/ElementTemplatesGroup.js
+++ b/src/provider/element-templates/components/ElementTemplatesGroup.js
@@ -133,7 +133,7 @@ function SelectEntryTemplate({ element }) {
 
   return (
     <HeaderButton
-      title="SelectEntry a template"
+      title="Select a template"
       class="bio-properties-panel-select-template-button"
       onClick={ selectTemplate }
     >


### PR DESCRIPTION
Just a minor fix I stumbled upon using templates in the Camunda Modeler:

<img width="146" alt="image" src="https://user-images.githubusercontent.com/9433996/155150049-d56aafd3-fce7-46ec-91e7-dc7020564089.png">

Probably introduced during a find&replace. 
