### PR TITLE
deps: mark properties-panel@0.11 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,6 @@
   "peerDependencies": {
     "bpmn-js": "8.x || 9.x",
     "diagram-js": "7.x || 8.x",
-    "@bpmn-io/properties-panel": "0.10.x"
+    "@bpmn-io/properties-panel": "0.11.x"
   }
 }


### PR DESCRIPTION
Without it, we would get warnings on `npm install`

```sh
npm WARN bpmn-js-properties-panel@1.0.0-alpha.4 requires a peer of @bpmn-io/properties-panel@0.10.x but none is installed. You must install peer dependencies yourself.
```
