### PR TITLE
Be Able to Show Entry and Error through Event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -566,6 +566,14 @@
         "fastq": "^1.6.0"
       }
     },
+    "@philippfromme/moddle-helpers": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@philippfromme/moddle-helpers/-/moddle-helpers-0.4.1.tgz",
+      "integrity": "sha512-6ST9WdafFGh/vxeQP4pwFkcGcqIQJ0mtQSrXwoetTLigCXCcP4UXdXxjcIEwWKoXuexXV/2CgFS0CPENSVcwdg==",
+      "requires": {
+        "min-dash": "^3.8.1"
+      }
+    },
     "@polka/url": {
       "version": "1.0.0-next.21",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
@@ -758,6 +766,12 @@
       "requires": {
         "@testing-library/dom": "^7.16.2"
       }
+    },
+    "@testing-library/preact-hooks": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/preact-hooks/-/preact-hooks-1.1.0.tgz",
+      "integrity": "sha512-+JIor+NsOHkK3oIrwMDGKGHXTN0JJi462dBJlj4FNbGaDPTlctE6eu2ranWQirh7/FJMkWfzQCP+tk7jmY8ZrQ==",
+      "dev": true
     },
     "@types/aria-query": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "@bpmn-io/element-templates-validator": "^0.6.0",
     "@bpmn-io/extract-process-variables": "^0.4.5",
+    "@philippfromme/moddle-helpers": "^0.4.1",
     "array-move": "^3.0.1",
     "classnames": "^2.3.1",
     "ids": "^1.0.0",
@@ -68,6 +69,7 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@testing-library/preact": "^2.0.1",
+    "@testing-library/preact-hooks": "^1.1.0",
     "babel-loader": "^8.2.2",
     "bpmn-js": "9.0.3",
     "bpmn-moddle": "^7.1.2",

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,1 +1,2 @@
-export { default as useService } from './useService';
+export { useService } from './useService';
+export { useShowCallback } from './useShowCallback';

--- a/src/hooks/useService.js
+++ b/src/hooks/useService.js
@@ -4,8 +4,7 @@ import {
 
 import { BpmnPropertiesPanelContext } from '../context';
 
-
-export default function(type, strict) {
+export function useService(type, strict) {
   const {
     getService
   } = useContext(BpmnPropertiesPanelContext);

--- a/src/hooks/useShowCallback.js
+++ b/src/hooks/useShowCallback.js
@@ -1,0 +1,24 @@
+import { useCallback } from '@bpmn-io/properties-panel/preact/hooks';
+
+import { pathEquals } from '@philippfromme/moddle-helpers';
+
+import {
+  isArray,
+  isFunction
+} from 'min-dash';
+
+export function useShowCallback(businessObject, path) {
+  return useCallback((event) => {
+    if (event.id !== businessObject.get('id')) {
+      return false;
+    }
+
+    if (isArray(path)) {
+      return event.path && pathEquals(event.path, path);
+    }
+
+    if (isFunction(path)) {
+      return path(event);
+    }
+  }, [ businessObject, path ]);
+}

--- a/src/hooks/useShowCallback.js
+++ b/src/hooks/useShowCallback.js
@@ -7,18 +7,44 @@ import {
   isFunction
 } from 'min-dash';
 
-export function useShowCallback(businessObject, path) {
+/**
+ * Returns a memoized callback to be passed as `show` prop. Callback returns
+ * true if (1) ID and path match or (2) ID matches and matcher returns true.
+ *
+ * @example
+ *
+ * // using path
+ * const show = useShowCallback(businessObject, [ 'foo' ]);
+ *
+ * @example
+ *
+ * // using matcher
+ * const show = useShowCallback(businessObject, (event) => event.foo === 'bar');
+ *
+ * @param {Object} businessObject
+ * @param {string[]|Function} matcher
+ *
+ * @returns {Function}
+ */
+export function useShowCallback(businessObject, matcher) {
   return useCallback((event) => {
-    if (event.id !== businessObject.get('id')) {
+    const {
+      id,
+      path
+    } = event;
+
+    if (id !== businessObject.get('id')) {
       return false;
     }
 
-    if (isArray(path)) {
-      return event.path && pathEquals(event.path, path);
+    if (isArray(matcher)) {
+      return path && pathEquals(path, matcher);
     }
 
-    if (isFunction(path)) {
-      return path(event);
+    if (isFunction(matcher)) {
+      return !!matcher(event);
     }
-  }, [ businessObject, path ]);
+
+    return false;
+  }, [ businessObject, matcher ]);
 }

--- a/src/provider/bpmn/properties/ErrorProps.js
+++ b/src/provider/bpmn/properties/ErrorProps.js
@@ -11,10 +11,17 @@ import {
   isSelectEntryEdited,
   isTextFieldEntryEdited
 } from '@bpmn-io/properties-panel';
+
+import {
+  getPath,
+  pathConcat
+} from '@philippfromme/moddle-helpers';
+
 import ReferenceSelect from '../../../entries/ReferenceSelect';
 
 import {
-  useService
+  useService,
+  useShowCallback
 } from '../../../hooks';
 
 import {
@@ -165,6 +172,11 @@ function ErrorRef(props) {
     return options;
   };
 
+  const businessObject = getBusinessObject(element),
+        path = pathConcat(getPath(errorEventDefinition, businessObject), 'errorRef');
+
+  const show = useShowCallback(businessObject, path);
+
   return ReferenceSelect({
     element,
     id: 'errorRef',
@@ -172,7 +184,8 @@ function ErrorRef(props) {
     autoFocusEntry: 'errorName',
     getValue,
     setValue,
-    getOptions
+    getOptions,
+    show
   });
 }
 

--- a/src/provider/bpmn/properties/MessageProps.js
+++ b/src/provider/bpmn/properties/MessageProps.js
@@ -10,7 +10,8 @@ import { TextFieldEntry, isTextFieldEntryEdited, isSelectEntryEdited } from '@bp
 import ReferenceSelect from '../../../entries/ReferenceSelect';
 
 import {
-  useService
+  useService,
+  useShowCallback
 } from '../../../hooks';
 
 import {
@@ -26,6 +27,7 @@ import {
   getRoot,
   nextId
 } from '../../../utils/ElementUtil';
+import { getPath, pathConcat } from '@philippfromme/moddle-helpers';
 
 export const EMPTY_OPTION = '';
 export const CREATE_NEW_OPTION = 'create-new';
@@ -158,6 +160,11 @@ function MessageRef(props) {
     return options;
   };
 
+  const businessObject = getBusinessObject(element),
+        path = pathConcat(getPath(messageEventDefinition, businessObject), 'messageRef');
+
+  const show = useShowCallback(businessObject, path);
+
   return ReferenceSelect({
     element,
     id: 'messageRef',
@@ -165,7 +172,8 @@ function MessageRef(props) {
     autoFocusEntry: 'messageName',
     getValue,
     setValue,
-    getOptions
+    getOptions,
+    show
   });
 }
 

--- a/src/provider/zeebe/properties/BusinessRuleImplementationProps.js
+++ b/src/provider/zeebe/properties/BusinessRuleImplementationProps.js
@@ -17,7 +17,8 @@ import {
 } from '../../../utils/ElementUtil';
 
 import {
-  useService
+  useService,
+  useShowCallback
 } from '../../../hooks';
 
 import { without } from 'min-dash';
@@ -47,7 +48,8 @@ export function BusinessRuleImplementationProps(props) {
 
 function BusinessRuleImplementation(props) {
   const {
-    element
+    element,
+    id
   } = props;
 
   const commandStack = useService('commandStack');
@@ -107,13 +109,33 @@ function BusinessRuleImplementation(props) {
     return options;
   };
 
+  const businessObject = getBusinessObject(element);
+
+  const show = useShowCallback(businessObject, (event) => {
+    const {
+      error = {}
+    } = event;
+
+    const {
+      requiredExtensionElement,
+      type
+    } = error;
+
+    return type === 'extensionElementRequired'
+      && [
+        'zeebe:CalledDecision',
+        'zeebe:TaskDefinition'
+      ].includes(requiredExtensionElement);
+  });
+
   return SelectEntry({
     element,
-    id: 'businessRuleImplementation',
+    id,
     label: translate('Implementation'),
     getValue,
     setValue,
-    getOptions
+    getOptions,
+    show
   });
 }
 

--- a/src/provider/zeebe/properties/BusinessRuleImplementationProps.js
+++ b/src/provider/zeebe/properties/BusinessRuleImplementationProps.js
@@ -112,9 +112,11 @@ function BusinessRuleImplementation(props) {
   const businessObject = getBusinessObject(element);
 
   const show = useShowCallback(businessObject, (event) => {
-    const {
-      error = {}
-    } = event;
+    const { error } = event;
+
+    if (!error) {
+      return false;
+    }
 
     const {
       requiredExtensionElement,

--- a/src/provider/zeebe/properties/CalledDecisionProps.js
+++ b/src/provider/zeebe/properties/CalledDecisionProps.js
@@ -6,6 +6,11 @@ import {
 import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
+  getPath,
+  pathConcat
+} from '@philippfromme/moddle-helpers';
+
+import {
   getExtensionElementsList
 } from '../../../utils/ExtensionElementsUtil';
 
@@ -14,7 +19,8 @@ import {
 } from '../../../utils/ElementUtil';
 
 import {
-  useService
+  useService,
+  useShowCallback
 } from '../../../hooks';
 
 
@@ -43,7 +49,8 @@ export function CalledDecisionProps(props) {
 
 function DecisionID(props) {
   const {
-    element
+    element,
+    id
   } = props;
 
   const commandStack = useService('commandStack');
@@ -118,19 +125,28 @@ function DecisionID(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
+  const businessObject = getBusinessObject(element),
+        calledDecision = getCalledDecision(element);
+
+  const path = pathConcat(getPath(calledDecision, businessObject), 'decisionId');
+
+  const show = useShowCallback(businessObject, path);
+
   return TextFieldEntry({
     element,
-    id: 'decisionId',
+    id,
     label: translate('ID'),
     getValue,
     setValue,
-    debounce
+    debounce,
+    show
   });
 }
 
 function ResultVariable(props) {
   const {
-    element
+    element,
+    id
   } = props;
 
   const commandStack = useService('commandStack');
@@ -205,13 +221,21 @@ function ResultVariable(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
+  const businessObject = getBusinessObject(element),
+        calledDecision = getCalledDecision(element);
+
+  const path = pathConcat(getPath(calledDecision, businessObject), 'resultVariable');
+
+  const show = useShowCallback(businessObject, path);
+
   return TextFieldEntry({
     element,
-    id: 'resultVariable',
+    id,
     label: translate('Result variable'),
     getValue,
     setValue,
-    debounce
+    debounce,
+    show
   });
 }
 

--- a/src/provider/zeebe/properties/MessageProps.js
+++ b/src/provider/zeebe/properties/MessageProps.js
@@ -1,4 +1,5 @@
 import {
+  getBusinessObject,
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
@@ -9,7 +10,14 @@ import {
 import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
-  useService
+  getPath,
+  pathConcat,
+  pathEquals
+} from '@philippfromme/moddle-helpers';
+
+import {
+  useService,
+  useShowCallback
 } from '../../../hooks';
 
 import {
@@ -168,6 +176,17 @@ function SubscriptionCorrelationKey(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
+  const businessObject = getBusinessObject(element),
+        subscription = getSubscription(businessObject),
+        path = pathConcat(getPath(subscription, businessObject), 'correlationKey');
+
+  const show = useShowCallback(businessObject, (event) => {
+    const { error = {} } = event;
+
+    return pathEquals(event.path, path)
+      || (error.type === 'extensionElementRequired' && error.requiredExtensionElement === 'zeebe:Subscription');
+  });
+
   return TextFieldEntry({
     element,
     id: 'messageSubscriptionCorrelationKey',
@@ -175,7 +194,8 @@ function SubscriptionCorrelationKey(props) {
     feel: 'required',
     getValue,
     setValue,
-    debounce
+    debounce,
+    show
   });
 }
 

--- a/src/provider/zeebe/properties/MultiInstanceProps.js
+++ b/src/provider/zeebe/properties/MultiInstanceProps.js
@@ -5,6 +5,12 @@ import {
 import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
+  getPath,
+  pathConcat,
+  pathEquals
+} from '@philippfromme/moddle-helpers';
+
+import {
   getExtensionElementsList
 } from '../../../utils/ExtensionElementsUtil';
 
@@ -13,7 +19,8 @@ import {
 } from '../../../utils/ElementUtil';
 
 import {
-  useService
+  useService,
+  useShowCallback
 } from '../../../hooks';
 
 
@@ -73,6 +80,24 @@ function InputCollection(props) {
     return setProperty(element, 'inputCollection', value, commandStack, bpmnFactory);
   };
 
+  const businessObject = getBusinessObject(element);
+
+  const loopCharacteristics = getLoopCharacteristics(element),
+        zeebeLoopCharacteristics = getZeebeLoopCharacteristics(loopCharacteristics),
+        path = pathConcat(getPath(zeebeLoopCharacteristics, businessObject), 'inputCollection');
+
+  const show = useShowCallback(businessObject, (event) => {
+    const { error = {} } = event;
+
+    const {
+      requiredExtensionElement,
+      type
+    } = error;
+
+    return pathEquals(event.path, path)
+      || (type === 'extensionElementRequired' && requiredExtensionElement === 'zeebe:LoopCharacteristics');
+  });
+
   return TextFieldEntry({
     element,
     id: 'multiInstance-inputCollection',
@@ -80,7 +105,8 @@ function InputCollection(props) {
     feel: 'required',
     getValue,
     setValue,
-    debounce
+    debounce,
+    show
   });
 }
 
@@ -130,13 +156,22 @@ function OutputCollection(props) {
     return setProperty(element, 'outputCollection', value, commandStack, bpmnFactory);
   };
 
+  const businessObject = getBusinessObject(element);
+
+  const loopCharacteristics = getLoopCharacteristics(element),
+        zeebeLoopCharacteristics = getZeebeLoopCharacteristics(loopCharacteristics),
+        path = pathConcat(getPath(zeebeLoopCharacteristics, businessObject), 'outputCollection');
+
+  const show = useShowCallback(businessObject, path);
+
   return TextFieldEntry({
     element,
     id: 'multiInstance-outputCollection',
     label: translate('Output collection'),
     getValue,
     setValue,
-    debounce
+    debounce,
+    show
   });
 }
 
@@ -158,6 +193,14 @@ function OutputElement(props) {
     return setProperty(element, 'outputElement', value, commandStack, bpmnFactory);
   };
 
+  const businessObject = getBusinessObject(element);
+
+  const loopCharacteristics = getLoopCharacteristics(element),
+        zeebeLoopCharacteristics = getZeebeLoopCharacteristics(loopCharacteristics),
+        path = pathConcat(getPath(zeebeLoopCharacteristics, businessObject), 'outputElement');
+
+  const show = useShowCallback(businessObject, path);
+
   return TextFieldEntry({
     element,
     id: 'multiInstance-outputElement',
@@ -165,7 +208,8 @@ function OutputElement(props) {
     feel: 'required',
     getValue,
     setValue,
-    debounce
+    debounce,
+    show
   });
 }
 

--- a/src/provider/zeebe/properties/TaskDefinitionProps.js
+++ b/src/provider/zeebe/properties/TaskDefinitionProps.js
@@ -5,6 +5,12 @@ import {
 import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
+  getPath,
+  pathConcat,
+  pathEquals
+} from '@philippfromme/moddle-helpers';
+
+import {
   getExtensionElementsList
 } from '../../../utils/ExtensionElementsUtil';
 
@@ -13,7 +19,8 @@ import {
 } from '../../../utils/ElementUtil';
 
 import {
-  useService
+  useService,
+  useShowCallback
 } from '../../../hooks';
 
 import {
@@ -46,7 +53,8 @@ export function TaskDefinitionProps(props) {
 
 function TaskDefinitionType(props) {
   const {
-    element
+    element,
+    id
   } = props;
 
   const commandStack = useService('commandStack');
@@ -121,20 +129,39 @@ function TaskDefinitionType(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
+  const businessObject = getBusinessObject(element),
+        taskDefinition = getTaskDefinition(businessObject);
+
+  const path = pathConcat(getPath(taskDefinition, businessObject), 'type');
+
+  const show = useShowCallback(businessObject, (event) => {
+    const { error = {} } = event;
+
+    const {
+      type,
+      requiredExtensionElement
+    } = error;
+
+    return pathEquals(event.path, path)
+      || (type === 'extensionElementRequired' && requiredExtensionElement === 'zeebe:TaskDefinition');
+  });
+
   return TextFieldEntry({
     element,
-    id: 'taskDefinitionType',
+    id,
     label: translate('Type'),
     feel: 'optional',
     getValue,
     setValue,
-    debounce
+    debounce,
+    show
   });
 }
 
 function TaskDefinitionRetries(props) {
   const {
-    element
+    element,
+    id
   } = props;
 
   const commandStack = useService('commandStack');
@@ -208,14 +235,22 @@ function TaskDefinitionRetries(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
+  const businessObject = getBusinessObject(element),
+        taskDefinition = getTaskDefinition(businessObject);
+
+  const path = pathConcat(getPath(taskDefinition, businessObject), 'retries');
+
+  const show = useShowCallback(businessObject, path);
+
   return TextFieldEntry({
     element,
-    id: 'taskDefinitionRetries',
+    id,
     label: translate('Retries'),
     feel: 'optional',
     getValue,
     setValue,
-    debounce
+    debounce,
+    show
   });
 }
 

--- a/src/render/BpmnPropertiesPanel.js
+++ b/src/render/BpmnPropertiesPanel.js
@@ -190,7 +190,8 @@ export default function BpmnPropertiesPanel(props) {
       layoutConfig={ layoutConfig }
       layoutChanged={ onLayoutChanged }
       descriptionConfig={ descriptionConfig }
-      descriptionLoaded={ onDescriptionLoaded } />
+      descriptionLoaded={ onDescriptionLoaded }
+      eventBus={ eventBus } />
   </BpmnPropertiesPanelContext.Provider>;
 }
 

--- a/test/spec/hooks/useShowCallback.spec.js
+++ b/test/spec/hooks/useShowCallback.spec.js
@@ -1,0 +1,212 @@
+import { act } from 'preact/test-utils';
+
+import { renderHook } from '@testing-library/preact-hooks';
+
+import { useShowCallback } from 'src/hooks';
+
+import { pathEquals } from '@philippfromme/moddle-helpers';
+
+
+describe('hooks/useShowEntryEvent', function() {
+
+  it('should return callback', function() {
+
+    // given
+    let show;
+
+    // when
+    renderHook(() => {
+      show = useShowCallback();
+    });
+
+    // then
+    expect(show).to.exist;
+  });
+
+
+  it('should return memoized callback', function() {
+
+    // given
+    const businessObject = { id: 'foo' },
+          path = [ 'bar' ];
+
+    let show;
+
+    const { rerender } = renderHook(({ businessObject, path }) => {
+      show = useShowCallback(businessObject, path);
+    }, {
+      initialProps: {
+        businessObject,
+        path
+      }
+    });
+
+    const oldShow = show;
+
+    // when
+    rerender();
+
+    // then
+    expect(show).to.equal(oldShow);
+  });
+
+
+  it('should not return memoized callback', function() {
+
+    // given
+    const businessObject = { id: 'foo' },
+          path = [ 'bar' ];
+
+    let show;
+
+    const { rerender } = renderHook(({ businessObject, path }) => {
+      show = useShowCallback(businessObject, path);
+    }, {
+      initialProps: {
+        businessObject,
+        path
+      }
+    });
+
+    const oldShow = show;
+
+    // when
+    act(() => rerender({
+      businessObject: { id: 'bar' },
+      path
+    }));
+
+    // then
+    expect(show).not.to.equal(oldShow);
+  });
+
+
+  describe('callback', function() {
+
+    it('should return true (path=string[])', function() {
+
+      // given
+      const businessObject = {
+              get: () => 'foo'
+            },
+            path = [ 'bar' ];
+
+      let show;
+
+      renderHook(() => {
+        show = useShowCallback(businessObject, path);
+      });
+
+      // when
+      const result = show({
+        id: 'foo',
+        path: [ 'bar' ]
+      });
+
+      // then
+      expect(result).to.be.true;
+    });
+
+
+    it('should return true (path=Function)', function() {
+
+      // given
+      const businessObject = {
+              get: () => 'foo'
+            },
+            path = ({ path }) => pathEquals(path, [ 'bar' ]);
+
+      let show;
+
+      renderHook(() => {
+        show = useShowCallback(businessObject, path);
+      });
+
+      // when
+      const result = show({
+        id: 'foo',
+        path: [ 'bar' ]
+      });
+
+      // then
+      expect(result).to.be.true;
+    });
+
+
+    it('should return false (id)', function() {
+
+      // given
+      const businessObject = {
+              get: () => 'foo'
+            },
+            path = [ 'bar' ];
+
+      let show;
+
+      renderHook(() => {
+        show = useShowCallback(businessObject, path);
+      });
+
+      // when
+      const result = show({
+        id: 'bar',
+        path: [ 'bar' ]
+      });
+
+      // then
+      expect(result).to.be.false;
+    });
+
+
+    it('should return false (path=string[])', function() {
+
+      // given
+      const businessObject = {
+              get: () => 'foo'
+            },
+            path = [ 'bar' ];
+
+      let show;
+
+      renderHook(() => {
+        show = useShowCallback(businessObject, path);
+      });
+
+      // when
+      const result = show({
+        id: 'foo',
+        path: [ 'baz' ]
+      });
+
+      // then
+      expect(result).to.be.false;
+    });
+
+
+    it('should return false (path=Function)', function() {
+
+      // given
+      const businessObject = {
+              get: () => 'foo'
+            },
+            path = ({ path }) => pathEquals(path, [ 'baz' ]);
+
+      let show;
+
+      renderHook(() => {
+        show = useShowCallback(businessObject, path);
+      });
+
+      // when
+      const result = show({
+        id: 'foo',
+        path: [ 'bar' ]
+      });
+
+      // then
+      expect(result).to.be.false;
+    });
+
+  });
+
+});

--- a/test/spec/provider/bpmn/ErrorProps.spec.js
+++ b/test/spec/provider/bpmn/ErrorProps.spec.js
@@ -259,6 +259,38 @@ describe('provider/bpmn - ErrorProps', function() {
 
     });
 
+
+    describe('show error', function() {
+
+      it('should show error (no error ref)', inject(async function(elementRegistry, eventBus, selection) {
+
+        // given
+        const boundaryEvent = elementRegistry.get('ErrorEvent_empty');
+
+        // when
+        await act(() => {
+          selection.select(boundaryEvent);
+
+          eventBus.fire('propertiesPanel.showError', {
+            id: 'ErrorEvent_empty',
+            message: 'foo',
+            path: [ 'eventDefinitions', 0, 'errorRef' ]
+          });
+        });
+
+        // then
+        const error = document.querySelector('.bio-properties-panel-error');
+
+        expect(error).to.exist;
+        expect(error.textContent).to.equal('foo');
+
+        const entry = error.closest('.bio-properties-panel-entry');
+
+        expect(entry.dataset.entryId).to.equal('errorRef');
+      }));
+
+    });
+
   });
 
 

--- a/test/spec/provider/bpmn/MessageProps.spec.js
+++ b/test/spec/provider/bpmn/MessageProps.spec.js
@@ -259,6 +259,38 @@ describe('provider/bpmn - MessageProps', function() {
 
     });
 
+
+    describe('show error', function() {
+
+      it('should show error (no message ref)', inject(async function(elementRegistry, eventBus, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('MessageEvent_1');
+
+        // when
+        await act(() => {
+          selection.select(startEvent);
+
+          eventBus.fire('propertiesPanel.showError', {
+            id: 'MessageEvent_1',
+            message: 'foo',
+            path: [ 'eventDefinitions', 0, 'messageRef' ]
+          });
+        });
+
+        // then
+        const error = document.querySelector('.bio-properties-panel-error');
+
+        expect(error).to.exist;
+        expect(error.textContent).to.equal('foo');
+
+        const entry = error.closest('.bio-properties-panel-entry');
+
+        expect(entry.dataset.entryId).to.equal('messageRef');
+      }));
+
+    });
+
   });
 
 
@@ -405,6 +437,38 @@ describe('provider/bpmn - MessageProps', function() {
         expect(messageRefSelect.value).to.eql(originalValue);
       })
     );
+
+
+    describe('show error', function() {
+
+      it('should show error (no message ref)', inject(async function(elementRegistry, eventBus, selection) {
+
+        // given
+        const boundaryEvent = elementRegistry.get('ReceiveTask_empty');
+
+        // when
+        await act(() => {
+          selection.select(boundaryEvent);
+
+          eventBus.fire('propertiesPanel.showError', {
+            id: 'ReceiveTask_empty',
+            message: 'foo',
+            path: [ 'messageRef' ]
+          });
+        });
+
+        // then
+        const error = document.querySelector('.bio-properties-panel-error');
+
+        expect(error).to.exist;
+        expect(error.textContent).to.equal('foo');
+
+        const entry = error.closest('.bio-properties-panel-entry');
+
+        expect(entry.dataset.entryId).to.equal('messageRef');
+      }));
+
+    });
 
   });
 

--- a/test/spec/provider/zeebe/BusinessRuleImplementationProps.spec.js
+++ b/test/spec/provider/zeebe/BusinessRuleImplementationProps.spec.js
@@ -252,6 +252,41 @@ describe('provider/zeebe - TargetProps', function() {
       expect(implementation.value).to.eql('dmn');
     }));
 
+
+    describe('show error', function() {
+
+      it('should show error', inject(async function(elementRegistry, eventBus, selection) {
+
+        // given
+        const businessRuleTask = elementRegistry.get('BusinessRuleTask_1');
+
+        // when
+        await act(() => {
+          selection.select(businessRuleTask);
+
+          eventBus.fire('propertiesPanel.showError', {
+            id: 'BusinessRuleTask_1',
+            message: 'foo',
+            error: {
+              type: 'extensionElementRequired',
+              requiredExtensionElement: 'zeebe:CalledDecision'
+            }
+          });
+        });
+
+        // then
+        const error = document.querySelector('.bio-properties-panel-error');
+
+        expect(error).to.exist;
+        expect(error.textContent).to.equal('foo');
+
+        const entry = error.closest('.bio-properties-panel-entry');
+
+        expect(entry.dataset.entryId).to.equal('businessRuleImplementation');
+      }));
+
+    });
+
   });
 
 });

--- a/test/spec/provider/zeebe/CalledDecisionProps.spec.js
+++ b/test/spec/provider/zeebe/CalledDecisionProps.spec.js
@@ -150,6 +150,38 @@ describe('provider/zeebe - TargetProps', function() {
         })
       );
 
+
+      describe('show error', function() {
+
+        it('should show error', inject(async function(elementRegistry, eventBus, selection) {
+
+          // given
+          const businessRuleTask = elementRegistry.get('BusinessRuleTask_1');
+
+          // when
+          await act(() => {
+            selection.select(businessRuleTask);
+
+            eventBus.fire('propertiesPanel.showError', {
+              id: 'BusinessRuleTask_1',
+              message: 'foo',
+              path: [ 'extensionElements', 'values', 0, 'decisionId' ]
+            });
+          });
+
+          // then
+          const error = document.querySelector('.bio-properties-panel-error');
+
+          expect(error).to.exist;
+          expect(error.textContent).to.equal('foo');
+
+          const entry = error.closest('.bio-properties-panel-entry');
+
+          expect(entry.dataset.entryId).to.equal('decisionId');
+        }));
+
+      });
+
     });
 
 
@@ -240,6 +272,38 @@ describe('provider/zeebe - TargetProps', function() {
           expect(resultVariableInput.value).to.eql(originalValue);
         })
       );
+
+
+      describe('show error', function() {
+
+        it('should show error', inject(async function(elementRegistry, eventBus, selection) {
+
+          // given
+          const businessRuleTask = elementRegistry.get('BusinessRuleTask_1');
+
+          // when
+          await act(() => {
+            selection.select(businessRuleTask);
+
+            eventBus.fire('propertiesPanel.showError', {
+              id: 'BusinessRuleTask_1',
+              message: 'foo',
+              path: [ 'extensionElements', 'values', 0, 'resultVariable' ]
+            });
+          });
+
+          // then
+          const error = document.querySelector('.bio-properties-panel-error');
+
+          expect(error).to.exist;
+          expect(error.textContent).to.equal('foo');
+
+          const entry = error.closest('.bio-properties-panel-entry');
+
+          expect(entry.dataset.entryId).to.equal('resultVariable');
+        }));
+
+      });
 
     });
 

--- a/test/spec/provider/zeebe/MessageProps.bpmn
+++ b/test/spec/provider/zeebe/MessageProps.bpmn
@@ -25,6 +25,7 @@
     <bpmn:intermediateCatchEvent id="IntermediateEvent_empty">
       <bpmn:messageEventDefinition id="MessageEventDefinition_02zap1w" />
     </bpmn:intermediateCatchEvent>
+    <bpmn:receiveTask id="ReceiveTask_noCorrelationKey" messageRef="Message_noCorrelationKey" />
   </bpmn:process>
   <bpmn:message id="Message_1" name="Message_1">
     <bpmn:extensionElements>
@@ -45,6 +46,11 @@
     <bpmn:extensionElements />
   </bpmn:message>
   <bpmn:message id="Message_empty" name="Message_empty" />
+  <bpmn:message id="Message_noCorrelationKey" name="Message_noCorrelationKey">
+    <bpmn:extensionElements>
+      <zeebe:subscription />
+    </bpmn:extensionElements>
+  </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_17fhhp5">
       <bpmndi:BPMNShape id="Event_0og0a7w_di" bpmnElement="IntermediateEvent_1">
@@ -52,6 +58,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0eexx4v" bpmnElement="IntermediateEvent_empty">
         <dc:Bounds x="317" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_01jx65q_di" bpmnElement="ReceiveTask_noCorrelationKey">
+        <dc:Bounds x="520" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1ufkvg9_di" bpmnElement="EventSubProcess_1" isExpanded="true">
         <dc:Bounds x="160" y="220" width="350" height="200" />

--- a/test/spec/provider/zeebe/MessageProps.spec.js
+++ b/test/spec/provider/zeebe/MessageProps.spec.js
@@ -510,6 +510,69 @@ describe('provider/zeebe - MessageProps', function() {
       expect(documentationLink.title).to.equal('Receive task documentation');
     }));
 
+
+    describe('show error', function() {
+
+      it('should show error (no extension element)', inject(async function(elementRegistry, eventBus, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('StartEvent_noSubscription');
+
+        // when
+        await act(() => {
+          selection.select(startEvent);
+
+          eventBus.fire('propertiesPanel.showError', {
+            id: 'StartEvent_noSubscription',
+            message: 'foo',
+            error: {
+              type: 'extensionElementRequired',
+              requiredExtensionElement: 'zeebe:Subscription'
+            }
+          });
+        });
+
+        // then
+        const error = document.querySelector('.bio-properties-panel-error');
+
+        expect(error).to.exist;
+        expect(error.textContent).to.equal('foo');
+
+        const entry = error.closest('.bio-properties-panel-entry');
+
+        expect(entry.dataset.entryId).to.equal('messageSubscriptionCorrelationKey');
+      }));
+
+
+      it('should show error (no correlation key)', inject(async function(elementRegistry, eventBus, selection) {
+
+        // given
+        const receiveTask = elementRegistry.get('ReceiveTask_noCorrelationKey');
+
+        // when
+        await act(() => {
+          selection.select(receiveTask);
+
+          eventBus.fire('propertiesPanel.showError', {
+            id: 'ReceiveTask_noCorrelationKey',
+            message: 'foo',
+            path: [ 'rootElements', 6, 'extensionElements', 'values', 0, 'correlationKey' ]
+          });
+        });
+
+        // then
+        const error = document.querySelector('.bio-properties-panel-error');
+
+        expect(error).to.exist;
+        expect(error.textContent).to.equal('foo');
+
+        const entry = error.closest('.bio-properties-panel-entry');
+
+        expect(entry.dataset.entryId).to.equal('messageSubscriptionCorrelationKey');
+      }));
+
+    });
+
   });
 
 });

--- a/test/spec/provider/zeebe/MultiInstanceProps.bpmn
+++ b/test/spec/provider/zeebe/MultiInstanceProps.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_0l1dxrj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_0l1dxrj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0-alpha.1">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:serviceTask id="ServiceTask_1" name="task">
       <bpmn:multiInstanceLoopCharacteristics>
@@ -20,6 +20,13 @@
       <bpmn:multiInstanceLoopCharacteristics isSequential="true" />
     </bpmn:serviceTask>
     <bpmn:serviceTask id="Activity_empty" name="empty" />
+    <bpmn:serviceTask id="ServiceTask_noInputCollection" name="no input collection">
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputElement="foo" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -32,11 +39,15 @@
       <bpmndi:BPMNShape id="Activity_0xr5kjj_di" bpmnElement="ServiceTask_noExtensionElements">
         <dc:Bounds x="230" y="440" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_completion_empty_di" bpmnElement="ServiceTask_noCompletionCondition">
+        <dc:Bounds x="560" y="290" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0r3tspp_di" bpmnElement="Activity_empty">
         <dc:Bounds x="460" y="140" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_completion_empty_di" bpmnElement="ServiceTask_noCompletionCondition">
-        <dc:Bounds x="560" y="290" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_0jrkkkk_di" bpmnElement="ServiceTask_noInputCollection">
+        <dc:Bounds x="560" y="440" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/zeebe/MultiInstanceProps.spec.js
+++ b/test/spec/provider/zeebe/MultiInstanceProps.spec.js
@@ -191,6 +191,69 @@ describe('provider/zeebe - MultiInstanceProps', function() {
       })
     );
 
+
+    describe('show error', function() {
+
+      it('should show error (no extension element)', inject(async function(elementRegistry, eventBus, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_noZeebeLoops');
+
+        // when
+        await act(() => {
+          selection.select(serviceTask);
+
+          eventBus.fire('propertiesPanel.showError', {
+            id: 'ServiceTask_noZeebeLoops',
+            message: 'foo',
+            error: {
+              type: 'extensionElementRequired',
+              requiredExtensionElement: 'zeebe:LoopCharacteristics'
+            }
+          });
+        });
+
+        // then
+        const error = document.querySelector('.bio-properties-panel-error');
+
+        expect(error).to.exist;
+        expect(error.textContent).to.equal('foo');
+
+        const entry = error.closest('.bio-properties-panel-entry');
+
+        expect(entry.dataset.entryId).to.equal('multiInstance-inputCollection');
+      }));
+
+
+      it('should show error (no input collection)', inject(async function(elementRegistry, eventBus, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_noInputCollection');
+
+        // when
+        await act(() => {
+          selection.select(serviceTask);
+
+          eventBus.fire('propertiesPanel.showError', {
+            id: 'ServiceTask_noInputCollection',
+            message: 'foo',
+            path: [ 'loopCharacteristics', 'extensionElements', 'values', 0, 'inputCollection' ]
+          });
+        });
+
+        // then
+        const error = document.querySelector('.bio-properties-panel-error');
+
+        expect(error).to.exist;
+        expect(error.textContent).to.equal('foo');
+
+        const entry = error.closest('.bio-properties-panel-entry');
+
+        expect(entry.dataset.entryId).to.equal('multiInstance-inputCollection');
+      }));
+
+    });
+
   });
 
 
@@ -451,6 +514,38 @@ describe('provider/zeebe - MultiInstanceProps', function() {
       })
     );
 
+
+    describe('show error', function() {
+
+      it('should show error (no output collection)', inject(async function(elementRegistry, eventBus, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_noInputCollection');
+
+        // when
+        await act(() => {
+          selection.select(serviceTask);
+
+          eventBus.fire('propertiesPanel.showError', {
+            id: 'ServiceTask_noInputCollection',
+            message: 'foo',
+            path: [ 'loopCharacteristics', 'extensionElements', 'values', 0, 'outputCollection' ]
+          });
+        });
+
+        // then
+        const error = document.querySelector('.bio-properties-panel-error');
+
+        expect(error).to.exist;
+        expect(error.textContent).to.equal('foo');
+
+        const entry = error.closest('.bio-properties-panel-entry');
+
+        expect(entry.dataset.entryId).to.equal('multiInstance-outputCollection');
+      }));
+
+    });
+
   });
 
 
@@ -580,6 +675,38 @@ describe('provider/zeebe - MultiInstanceProps', function() {
         expect(getZeebeLoopCharacteristics(serviceTask).get('outputElement')).to.eql('newValue');
       })
     );
+
+
+    describe('show error', function() {
+
+      it('should show error (no output element)', inject(async function(elementRegistry, eventBus, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_noInputCollection');
+
+        // when
+        await act(() => {
+          selection.select(serviceTask);
+
+          eventBus.fire('propertiesPanel.showError', {
+            id: 'ServiceTask_noInputCollection',
+            message: 'foo',
+            path: [ 'loopCharacteristics', 'extensionElements', 'values', 0, 'outputElement' ]
+          });
+        });
+
+        // then
+        const error = document.querySelector('.bio-properties-panel-error');
+
+        expect(error).to.exist;
+        expect(error.textContent).to.equal('foo');
+
+        const entry = error.closest('.bio-properties-panel-entry');
+
+        expect(entry.dataset.entryId).to.equal('multiInstance-outputElement');
+      }));
+
+    });
 
   });
 

--- a/test/spec/provider/zeebe/TargetProps.bpmn
+++ b/test/spec/provider/zeebe/TargetProps.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0oevfuo" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0oevfuo" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0-alpha.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
   <bpmn:process id="Process_04htq1t" isExecutable="true">
     <bpmn:callActivity id="CallActivity_1" name="CallActivity_1">
       <bpmn:extensionElements>
@@ -18,6 +18,11 @@
         </zeebe:ioMapping>
       </bpmn:extensionElements>
     </bpmn:callActivity>
+    <bpmn:callActivity id="CallActivity_4" name="CallActivity_4">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_04htq1t">
@@ -32,6 +37,10 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0s74y25_di" bpmnElement="CallActivity_3">
         <dc:Bounds x="160" y="440" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1dhj0c5_di" bpmnElement="CallActivity_4">
+        <dc:Bounds x="160" y="560" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/zeebe/TargetProps.spec.js
+++ b/test/spec/provider/zeebe/TargetProps.spec.js
@@ -222,6 +222,69 @@ describe('provider/zeebe - TargetProps', function() {
       })
     );
 
+
+    describe('show error', function() {
+
+      it('should show error (no extension element)', inject(async function(elementRegistry, eventBus, selection) {
+
+        // given
+        const businessRuleTask = elementRegistry.get('CallActivity_2');
+
+        // when
+        await act(() => {
+          selection.select(businessRuleTask);
+
+          eventBus.fire('propertiesPanel.showError', {
+            id: 'CallActivity_2',
+            message: 'foo',
+            error: {
+              type: 'extensionElementRequired',
+              requiredExtensionElement: 'zeebe:CalledElement'
+            }
+          });
+        });
+
+        // then
+        const error = document.querySelector('.bio-properties-panel-error');
+
+        expect(error).to.exist;
+        expect(error.textContent).to.equal('foo');
+
+        const entry = error.closest('.bio-properties-panel-entry');
+
+        expect(entry.dataset.entryId).to.equal('targetProcessId');
+      }));
+
+
+      it('should show error (no process ID)', inject(async function(elementRegistry, eventBus, selection) {
+
+        // given
+        const businessRuleTask = elementRegistry.get('CallActivity_4');
+
+        // when
+        await act(() => {
+          selection.select(businessRuleTask);
+
+          eventBus.fire('propertiesPanel.showError', {
+            id: 'CallActivity_4',
+            message: 'foo',
+            path: [ 'extensionElements', 'values', 0, 'processId' ]
+          });
+        });
+
+        // then
+        const error = document.querySelector('.bio-properties-panel-error');
+
+        expect(error).to.exist;
+        expect(error.textContent).to.equal('foo');
+
+        const entry = error.closest('.bio-properties-panel-entry');
+
+        expect(entry.dataset.entryId).to.equal('targetProcessId');
+      }));
+
+    });
+
   });
 
 });

--- a/test/spec/provider/zeebe/TaskDefinitionProps.bpmn
+++ b/test/spec/provider/zeebe/TaskDefinitionProps.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_0k89tne" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_0k89tne" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0-alpha.1">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:serviceTask id="ServiceTask_1" name="service task">
       <bpmn:extensionElements>
@@ -19,6 +19,16 @@
     </bpmn:businessRuleTask>
     <bpmn:scriptTask id="ScriptTask_1" name="ScriptTask_1" />
     <bpmn:sendTask id="SendTask_1" name="SendTask_1" />
+    <bpmn:serviceTask id="ServiceTask_noTaskDefinitionType" name="service task no task definition type">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition retries="foo" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_noTaskDefinitionRetries" name="service task no task definition retries">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -45,6 +55,14 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0sypdy6_di" bpmnElement="SendTask_1">
         <dc:Bounds x="660" y="390" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ik5i2e_di" bpmnElement="ServiceTask_noTaskDefinitionType">
+        <dc:Bounds x="160" y="360" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1pgh9t4" bpmnElement="ServiceTask_noTaskDefinitionRetries">
+        <dc:Bounds x="160" y="470" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/zeebe/TaskDefinitionProps.spec.js
+++ b/test/spec/provider/zeebe/TaskDefinitionProps.spec.js
@@ -294,6 +294,69 @@ describe('provider/zeebe - TaskDefinitionProps', function() {
       expect(documentationLink.title).to.equal('Send task documentation');
     }));
 
+
+    describe('show error', function() {
+
+      it('should show error (no extension element)', inject(async function(elementRegistry, eventBus, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_empty');
+
+        // when
+        await act(() => {
+          selection.select(serviceTask);
+
+          eventBus.fire('propertiesPanel.showError', {
+            id: 'ServiceTask_empty',
+            message: 'foo',
+            error: {
+              type: 'extensionElementRequired',
+              requiredExtensionElement: 'zeebe:TaskDefinition'
+            }
+          });
+        });
+
+        // then
+        const error = document.querySelector('.bio-properties-panel-error');
+
+        expect(error).to.exist;
+        expect(error.textContent).to.equal('foo');
+
+        const entry = error.closest('.bio-properties-panel-entry');
+
+        expect(entry.dataset.entryId).to.equal('taskDefinitionType');
+      }));
+
+
+      it('should show error (no type)', inject(async function(elementRegistry, eventBus, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_noTaskDefinitionType');
+
+        // when
+        await act(() => {
+          selection.select(serviceTask);
+
+          eventBus.fire('propertiesPanel.showError', {
+            id: 'ServiceTask_noTaskDefinitionType',
+            message: 'foo',
+            path: [ 'extensionElements', 'values', 0, 'type' ]
+          });
+        });
+
+        // then
+        const error = document.querySelector('.bio-properties-panel-error');
+
+        expect(error).to.exist;
+        expect(error.textContent).to.equal('foo');
+
+        const entry = error.closest('.bio-properties-panel-entry');
+
+        expect(entry.dataset.entryId).to.equal('taskDefinitionType');
+      }));
+
+    });
+
   });
 
 
@@ -419,6 +482,38 @@ describe('provider/zeebe - TaskDefinitionProps', function() {
         expect(getTaskDefinition(serviceTask).get('retries')).to.eql('newValue');
       })
     );
+
+
+    describe('show error', function() {
+
+      it('should show error (no retries)', inject(async function(elementRegistry, eventBus, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_noTaskDefinitionRetries');
+
+        // when
+        await act(() => {
+          selection.select(serviceTask);
+
+          eventBus.fire('propertiesPanel.showError', {
+            id: 'ServiceTask_noTaskDefinitionRetries',
+            message: 'foo',
+            path: [ 'extensionElements', 'values', 0, 'retries' ]
+          });
+        });
+
+        // then
+        const error = document.querySelector('.bio-properties-panel-error');
+
+        expect(error).to.exist;
+        expect(error.textContent).to.equal('foo');
+
+        const entry = error.closest('.bio-properties-panel-entry');
+
+        expect(entry.dataset.entryId).to.equal('taskDefinitionRetries');
+      }));
+
+    });
 
   });
 


### PR DESCRIPTION
Adds `show` callbacks to all entries that can be shown through events. A `useShowCallback` hook is introduced to simplify things.

List of errors: https://docs.google.com/spreadsheets/d/1AbFn2lXWPywmM1OaP7pVZUaAG0CglYv-2th2dbl5_k4/edit#gid=0

---

Requires https://github.com/bpmn-io/properties-panel/pull/142