### PR TITLE
feat(DescriptionProvider): add user and multi-instance task links

### DIFF
--- a/src/contextProvider/zeebe/DescriptionProvider.js
+++ b/src/contextProvider/zeebe/DescriptionProvider.js
@@ -10,6 +10,16 @@ import {
 
 const DescriptionProvider = {
 
+  assignmentDefinitionAssignee: (element) => {
+    const translate = useService('translate');
+
+    return (
+      <a href="https://docs.camunda.io/docs/components/modeler/bpmn/user-tasks/#assignments" target="_blank" rel="noopener" title={ translate('User task documentation') }>
+        { translate('How to configure a user task') }
+      </a>
+    );
+  },
+
   conditionExpression: (element) => {
     const translate = useService('translate');
 
@@ -94,6 +104,16 @@ const DescriptionProvider = {
         </a>
       );
     }
+  },
+
+  'multiInstance-inputCollection': (element) => {
+    const translate = useService('translate');
+
+    return (
+      <a href="https://docs.camunda.io/docs/components/modeler/bpmn/multi-instance/#defining-the-collection-to-iterate-over" target="_blank" rel="noopener" title={ translate('Multi instance documentation') }>
+        { translate('How to configure a multi instance task') }
+      </a>
+    );
   },
 
   errorCode: (element) => {

--- a/src/contextProvider/zeebe/DescriptionProvider.js
+++ b/src/contextProvider/zeebe/DescriptionProvider.js
@@ -30,6 +30,16 @@ const DescriptionProvider = {
     );
   },
 
+  formType: (element) => {
+    const translate = useService('translate');
+
+    return (
+      <a href="https://docs.camunda.io/docs/components/modeler/bpmn/user-tasks/#user-task-forms" target="_blank" rel="noopener" title={ translate('User task form documentation') }>
+        { translate('How to link a form') }
+      </a>
+    );
+  },
+
   messageSubscriptionCorrelationKey: (element) => {
     const translate = useService('translate');
 
@@ -104,6 +114,14 @@ const DescriptionProvider = {
         </a>
       );
     }
+
+    if (is(element, 'bpmn:ThrowEvent')) {
+      return (
+        <a href="https://docs.camunda.io/docs/components/modeler/bpmn/message-events/#message-throw-events" target="_blank" rel="noopener" title={ translate('Message throw event documentation') }>
+          { translate('How to configure a message throw event') }
+        </a>
+      );
+    }
   },
 
   'multiInstance-inputCollection': (element) => {
@@ -111,7 +129,7 @@ const DescriptionProvider = {
 
     return (
       <a href="https://docs.camunda.io/docs/components/modeler/bpmn/multi-instance/#defining-the-collection-to-iterate-over" target="_blank" rel="noopener" title={ translate('Multi instance documentation') }>
-        { translate('How to configure a multi instance task') }
+        { translate('How to configure a multi instance activity') }
       </a>
     );
   },


### PR DESCRIPTION
Add doc links for Multi-Instance and Assignment Groups:

![image](https://user-images.githubusercontent.com/21984219/158599094-a7ce1289-815c-4326-a15b-9dd6055af04c.png)


closes #600
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
