### PR TITLE
feat(element-templates): open custom groups

### DIFF
--- a/src/provider/cloud-element-templates/properties/CustomProperties.js
+++ b/src/provider/cloud-element-templates/properties/CustomProperties.js
@@ -122,7 +122,8 @@ function addCustomGroup(groups, props) {
     id,
     label,
     component: Group,
-    entries: []
+    entries: [],
+    shouldOpen: true
   };
 
   properties.forEach((property, index) => {

--- a/src/provider/element-templates/properties/CustomProperties.js
+++ b/src/provider/element-templates/properties/CustomProperties.js
@@ -161,7 +161,8 @@ function addCustomGroup(groups, props) {
     id,
     label,
     component: Group,
-    entries: []
+    entries: [],
+    shouldOpen: true
   };
 
   properties.forEach((property, index) => {

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.spec.js
@@ -16,6 +16,7 @@ import {
 } from 'min-dash';
 
 import {
+  classes as domClasses,
   query as domQuery,
   queryAll as domQueryAll
 } from 'min-dom';
@@ -1043,6 +1044,27 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
     });
 
 
+    it('should open custom groups', async function() {
+
+      // given
+      await expectSelected('ServiceTask_1');
+
+      // when
+      var customGroups = [
+        getGroupById('ElementTemplates__CustomProperties-headers', container),
+        getGroupById('ElementTemplates__CustomProperties-payload', container),
+        getGroupById('ElementTemplates__CustomProperties-mapping', container),
+        getGroupById('ElementTemplates__CustomProperties', container)
+      ];
+
+      // then
+      customGroups.forEach(function(group) {
+        expectGroupOpen(group, true);
+      });
+
+    });
+
+
     it('should display in defined properties order', async function() {
 
       // given
@@ -1088,6 +1110,22 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         'ElementTemplates__Template',
         'ElementTemplates__CustomProperties'
       ]);
+    });
+
+
+    it('should open default group', async function() {
+
+      // given
+      await expectSelected('ServiceTask_noGroups');
+
+      // when
+      var tempalteGroup = getGroupById('ElementTemplates__Template', container);
+      var customPropertiesGroup = getGroupById('ElementTemplates__CustomProperties', container);
+
+
+      // then
+      expectGroupOpen(tempalteGroup, false);
+      expectGroupOpen(customPropertiesGroup, true);
     });
 
 
@@ -1265,6 +1303,13 @@ function expectError(entry, message) {
   expect(error).to.equal(message);
 }
 
+function expectGroupOpen(group, open) {
+
+  const entries = domQuery('.bio-properties-panel-group-entries', group);
+
+  expect(domClasses(entries).contains('open')).to.eql(open);
+}
+
 function expectValid(entry) {
   expectError(entry, null);
 }
@@ -1283,6 +1328,15 @@ function getGroupIds(container) {
 function getGroup(entry) {
   const parent = entry.closest('[data-group-id]');
   return parent && withoutPrefix(parent.dataset.groupId);
+}
+
+function getGroupById(id, container) {
+  const group = domQuery(
+    `[data-group-id=group-${id}]`,
+    container
+  );
+
+  return group;
 }
 
 function withoutPrefix(groupId) {

--- a/test/spec/provider/element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/provider/element-templates/properties/CustomProperties.spec.js
@@ -16,6 +16,7 @@ import {
 } from 'min-dash';
 
 import {
+  classes as domClasses,
   query as domQuery,
   queryAll as domQueryAll
 } from 'min-dom';
@@ -1762,6 +1763,27 @@ describe('provider/element-templates - CustomProperties', function() {
     });
 
 
+    it('should open defined groups', async function() {
+
+      // given
+      await expectSelected('ServiceTask_1');
+
+      // when
+      var customGroups = [
+        getGroupById('ElementTemplates__CustomProperties-one', container),
+        getGroupById('ElementTemplates__CustomProperties-two', container),
+        getGroupById('ElementTemplates__CustomProperties-three', container),
+        getGroupById('ElementTemplates__CustomProperties', container)
+      ];
+
+      // then
+      customGroups.forEach(function(group) {
+        expectGroupOpen(group, true);
+      });
+
+    });
+
+
     it('should display in defined properties order', async function() {
 
       // given
@@ -1807,6 +1829,22 @@ describe('provider/element-templates - CustomProperties', function() {
         'ElementTemplates__Template',
         'ElementTemplates__CustomProperties'
       ]);
+    });
+
+
+    it('should open default group', async function() {
+
+      // given
+      await expectSelected('ServiceTask_noGroups');
+
+      // when
+      var tempalteGroup = getGroupById('ElementTemplates__Template', container);
+      var customPropertiesGroup = getGroupById('ElementTemplates__CustomProperties', container);
+
+
+      // then
+      expectGroupOpen(tempalteGroup, false);
+      expectGroupOpen(customPropertiesGroup, true);
     });
 
 
@@ -1896,6 +1934,13 @@ function expectValid(entry) {
   expectError(entry, null);
 }
 
+function expectGroupOpen(group, open) {
+
+  const entries = domQuery('.bio-properties-panel-group-entries', group);
+
+  expect(domClasses(entries).contains('open')).to.eql(open);
+}
+
 function findEntry(id, container) {
   return domQuery(`[data-entry-id='${ id }']`, container);
 }
@@ -1910,6 +1955,15 @@ function findSelect(container) {
 
 function findTextarea(container) {
   return domQuery('textarea', container);
+}
+
+function getGroupById(id, container) {
+  const group = domQuery(
+    `[data-group-id=group-${id}]`,
+    container
+  );
+
+  return group;
 }
 
 function getGroupIds(container) {


### PR DESCRIPTION

![Recording 2022-03-29 at 16 38 45](https://user-images.githubusercontent.com/21984219/160637120-3423c3b1-78e2-4c14-9b8d-2a33e18c9a6c.gif)


Try it out with `npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel#618-element-template-sections -c 'npm run start:cloud-templates'`

closes #618 

Applying a `entriesVisible` template can open other groups. This is a bug that was present before, I created https://github.com/bpmn-io/bpmn-js-properties-panel/issues/620 to track it 

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
