### PR TITLE
Semver compare

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4350,6 +4350,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -5690,9 +5691,15 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "serialize-javascript": {
       "version": "6.0.0",
@@ -6607,7 +6614,8 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "min-dash": "^3.8.1",
     "min-dom": "^3.1.3",
     "preact-markup": "^2.1.1",
-    "semver": "^7.3.5"
+    "semver-compare": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   ],
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
+  "umd:main": "dist/bpmn-js-properties-panel.umd.js",
   "author": {
     "name": "Nico Rehwaldt",
     "url": "https://github.com/nikku"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,6 +17,18 @@ export default [
     output: [
       {
         sourcemap: true,
+        format: 'umd',
+        file: pkg['umd:main'],
+        name: 'BpmnJSPropertiesPanel'
+      }
+    ],
+    plugins: pgl()
+  },
+  {
+    input: 'src/index.js',
+    output: [
+      {
+        sourcemap: true,
         format: 'commonjs',
         file: pkg.main
       },
@@ -27,36 +39,41 @@ export default [
       }
     ],
     external: externalDependencies(),
-    plugins: [
-      alias({
-        entries: [
-          { find: 'react', replacement: '@bpmn-io/properties-panel/preact/compat' },
-          { find: 'preact', replacement: '@bpmn-io/properties-panel/preact' }
-        ]
-      }),
-      reactSvg(),
-      babel({
-        babelHelpers: 'bundled',
-        plugins: [
-          [ '@babel/plugin-transform-react-jsx', {
-            'importSource': '@bpmn-io/properties-panel/preact',
-            'runtime': 'automatic'
-          } ]
-        ]
-      }),
+    plugins: pgl([
       copy({
         targets: [
           { src: 'node_modules/@bpmn-io/properties-panel/assets/**/*.css', dest: 'dist/assets' },
           { src: 'assets/*.css', dest: 'dist/assets' }
         ]
-      }),
-      json(),
-      resolve(),
-      commonjs()
-    ]
+      })
+    ])
   }
 ];
 
+function pgl(plugins = []) {
+  return [
+    ...plugins,
+    alias({
+      entries: [
+        { find: 'react', replacement: '@bpmn-io/properties-panel/preact/compat' },
+        { find: 'preact', replacement: '@bpmn-io/properties-panel/preact' }
+      ]
+    }),
+    reactSvg(),
+    babel({
+      babelHelpers: 'bundled',
+      plugins: [
+        [ '@babel/plugin-transform-react-jsx', {
+          'importSource': '@bpmn-io/properties-panel/preact',
+          'runtime': 'automatic'
+        } ]
+      ]
+    }),
+    json(),
+    resolve(),
+    commonjs()
+  ];
+}
 
 function externalDependencies() {
   return id => {

--- a/src/provider/cloud-element-templates/Validator.js
+++ b/src/provider/cloud-element-templates/Validator.js
@@ -4,7 +4,7 @@ import {
   getSchemaVersion
 } from '../element-templates/Validator';
 
-import semver from 'semver';
+import semverCompare from 'semver-compare';
 
 import {
   validateZeebe as validateAgainstSchema,
@@ -54,7 +54,7 @@ export class Validator extends BaseValidator {
     }
 
     // (2) compatibility
-    if (schemaVersion && (semver.compare(SUPPORTED_SCHEMA_VERSION, schemaVersion) < 0)) {
+    if (schemaVersion && (semverCompare(SUPPORTED_SCHEMA_VERSION, schemaVersion) < 0)) {
       return this._logError(
         `unsupported element template schema version <${ schemaVersion }>. Your installation only supports up to version <${ SUPPORTED_SCHEMA_VERSION }>. Please update your installation`,
         template

--- a/src/provider/element-templates/Validator.js
+++ b/src/provider/element-templates/Validator.js
@@ -4,7 +4,7 @@ import {
   isString
 } from 'min-dash';
 
-import semver from 'semver';
+import semverCompare from 'semver-compare';
 
 import {
   validate as validateAgainstSchema,
@@ -85,7 +85,7 @@ export class Validator {
           schemaVersion = template.$schema && getSchemaVersion(template.$schema);
 
     // (1) compatibility
-    if (schemaVersion && (semver.compare(SUPPORTED_SCHEMA_VERSION, schemaVersion) < 0)) {
+    if (schemaVersion && (semverCompare(SUPPORTED_SCHEMA_VERSION, schemaVersion) < 0)) {
       return this._logError(
         `unsupported element template schema version <${ schemaVersion }>. Your installation only supports up to version <${ SUPPORTED_SCHEMA_VERSION }>. Please update your installation`,
         template


### PR DESCRIPTION
Semver does not properly bundle with rollup as it contains cyclic dependencies:

![image](https://user-images.githubusercontent.com/58601/159558268-9389c796-7cb5-4068-ae2d-c8a74c0e49ff.png)

This PR replaces semver with semver-compare. Also shaves off 9kB (minified) of the bundled distribution.