### PR TITLE
feat: add `ElementTemplates#applyTemplate` API

### DIFF
--- a/src/provider/cloud-element-templates/ElementTemplates.js
+++ b/src/provider/cloud-element-templates/ElementTemplates.js
@@ -12,6 +12,7 @@ export default class ElementTemplates extends DefaultElementTemplates {
   constructor(templateElementFactory, commandStack) {
     super(commandStack);
 
+    this._commandStack = commandStack;
     this._templateElementFactory = templateElementFactory;
   }
 

--- a/src/provider/cloud-element-templates/ElementTemplates.js
+++ b/src/provider/cloud-element-templates/ElementTemplates.js
@@ -9,9 +9,9 @@ import { default as DefaultElementTemplates } from '../element-templates/Element
  * Registry for element templates.
  */
 export default class ElementTemplates extends DefaultElementTemplates {
-  constructor(templateElementFactory) {
-    super();
-    this._templates = {};
+  constructor(templateElementFactory, commandStack) {
+    super(commandStack);
+
     this._templateElementFactory = templateElementFactory;
   }
 
@@ -39,6 +39,26 @@ export default class ElementTemplates extends DefaultElementTemplates {
     return element;
   }
 
+  /**
+   * Apply element template to a given element.
+   *
+   * @param {djs.model.Base} element
+   * @param {ElementTemplate} newTemplate
+   *
+   * @return {djs.model.Base} the updated element
+   */
+  applyTemplate(element, newTemplate) {
+
+    const oldTemplate = this.get(element);
+
+    this._commandStack.execute('propertiesPanel.zeebe.changeTemplate', {
+      element: element,
+      newTemplate,
+      oldTemplate
+    });
+
+    return element;
+  }
 }
 
-ElementTemplates.$inject = [ 'templateElementFactory' ];
+ElementTemplates.$inject = [ 'templateElementFactory', 'commandStack' ];

--- a/src/provider/cloud-element-templates/util/templateUtil.js
+++ b/src/provider/cloud-element-templates/util/templateUtil.js
@@ -13,14 +13,7 @@ export function unlinkTemplate(element, injector) {
 }
 
 export function updateTemplate(element, newTemplate, injector) {
-  const commandStack = injector.get('commandStack'),
-        elementTemplates = injector.get('elementTemplates');
+  const elementTemplates = injector.get('elementTemplates');
 
-  const oldTemplate = elementTemplates.get(element);
-
-  commandStack.execute('propertiesPanel.zeebe.changeTemplate', {
-    element: element,
-    newTemplate,
-    oldTemplate
-  });
+  return elementTemplates.applyTemplate(element, newTemplate);
 }

--- a/src/provider/element-templates/ElementTemplates.js
+++ b/src/provider/element-templates/ElementTemplates.js
@@ -17,7 +17,9 @@ import { isAny } from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
  * Registry for element templates.
  */
 export default class ElementTemplates {
-  constructor() {
+  constructor(commandStack) {
+    this._commandStack = commandStack;
+
     this._templates = {};
   }
 
@@ -109,4 +111,27 @@ export default class ElementTemplates {
   _getTemplateVersion(element) {
     return getTemplateVersion(element);
   }
+
+  /**
+   * Apply element template to a given element.
+   *
+   * @param {djs.model.Base} element
+   * @param {ElementTemplate} newTemplate
+   *
+   * @return {djs.model.Base} the updated element
+   */
+  applyTemplate(element, newTemplate) {
+
+    const oldTemplate = this.get(element);
+
+    this._commandStack.execute('propertiesPanel.camunda.changeTemplate', {
+      element: element,
+      newTemplate,
+      oldTemplate
+    });
+
+    return element;
+  }
 }
+
+ElementTemplates.$inject = [ 'commandStack' ];

--- a/src/provider/element-templates/util/templateUtil.js
+++ b/src/provider/element-templates/util/templateUtil.js
@@ -30,16 +30,9 @@ export function removeTemplate(element, injector) {
 }
 
 export function updateTemplate(element, newTemplate, injector) {
-  const commandStack = injector.get('commandStack'),
-        elementTemplates = injector.get('elementTemplates');
+  const elementTemplates = injector.get('elementTemplates');
 
-  const oldTemplate = elementTemplates.get(element);
-
-  commandStack.execute('propertiesPanel.camunda.changeTemplate', {
-    element: element,
-    newTemplate,
-    oldTemplate
-  });
+  return elementTemplates.applyTemplate(element, newTemplate);
 }
 
 export function getVersionOrDateFromTemplate(template) {

--- a/test/spec/provider/cloud-element-templates/ElementTemplates.spec.js
+++ b/test/spec/provider/cloud-element-templates/ElementTemplates.spec.js
@@ -1,6 +1,10 @@
 import TestContainer from 'mocha-test-container-support';
 
 import {
+  isAny
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import {
   bootstrapModeler,
   createCanvasEvent as canvasEvent,
   inject
@@ -188,6 +192,31 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
         expect(element.parent).to.eql(processElement);
       })
     );
+
+  });
+
+
+  describe('applyTemplate', function() {
+
+    it('should set template on element', inject(function(elementRegistry, elementTemplates) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      const template = elementTemplates.getAll().find(
+        t => isAny(task, t.appliesTo)
+      );
+
+      // assume
+      expect(template).to.exist;
+
+      // when
+      const updatedTask = elementTemplates.applyTemplate(task, template);
+
+      // then
+      expect(updatedTask).to.exist;
+      expect(elementTemplates.get(updatedTask)).to.equal(template);
+    }));
 
   });
 

--- a/test/spec/provider/element-templates/ElementTemplates.spec.js
+++ b/test/spec/provider/element-templates/ElementTemplates.spec.js
@@ -1,5 +1,9 @@
 import TestContainer from 'mocha-test-container-support';
 
+import {
+  isAny
+} from 'bpmn-js/lib/util/ModelUtil';
+
 import { bootstrapModeler, inject } from 'test/TestHelper';
 
 import coreModule from 'bpmn-js/lib/core';
@@ -193,6 +197,31 @@ describe('provider/element-templates - ElementTemplates', function() {
 
       // then
       expect(elementTemplates.get(falsyVersionTemplate[0].id, 0)).to.exist;
+    }));
+
+  });
+
+
+  describe('applyTemplate', function() {
+
+    it('should set template on element', inject(function(elementRegistry, elementTemplates) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      const template = elementTemplates.getAll().find(
+        t => isAny(task, t.appliesTo)
+      );
+
+      // assume
+      expect(template).to.exist;
+
+      // when
+      const updatedTask = elementTemplates.applyTemplate(task, template);
+
+      // then
+      expect(updatedTask).to.exist;
+      expect(elementTemplates.get(updatedTask)).to.equal(template);
     }));
 
   });


### PR DESCRIPTION
This allows us to use the `elementTemplate` service to apply templates without caring about the implementation details, i.e. if it is a Platform or Cloud template.

Mid-term this will also support our "element templates everywhere" spirit (cf. [`bpmn-io/bpmn-js-connectors-extension#apply-template-usage`](https://github.com/bpmn-io/bpmn-js-connectors-extension/compare/apply-template-usage)).

---

Related to https://github.com/bpmn-io/element-template-chooser/issues/2#issuecomment-1067806835.

Required by https://github.com/bpmn-io/element-template-chooser/issues/2