### PR TITLE
deps: bump `@bpmn-io/properties-panel` peer dependency to `0.12.x`

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
   "peerDependencies": {
     "bpmn-js": "8.x || 9.x",
     "diagram-js": "7.x || 8.x",
-    "@bpmn-io/properties-panel": "0.11.x"
+    "@bpmn-io/properties-panel": "0.12.x"
   }
 }


### PR DESCRIPTION
Installing the properties panel with the latest libraries will otherwise fail; we already test with the respective library.