### PR TITLE
feat(render): display template name in header

### DIFF
--- a/src/render/PanelHeaderProvider.js
+++ b/src/render/PanelHeaderProvider.js
@@ -13,6 +13,10 @@ import {
   isInterrupting
 } from 'bpmn-js/lib/util/DiUtil';
 
+import {
+  useService
+} from '../hooks';
+
 import iconsByType from '../icons';
 
 export function getConcreteType(element) {
@@ -79,6 +83,18 @@ export const PanelHeaderProvider = {
   },
 
   getTypeLabel: (element) => {
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const elementTemplates = useService('elementTemplates', false);
+
+    if (elementTemplates) {
+      const template = getTemplate(element, elementTemplates);
+
+      if (template && template.name) {
+        return template.name;
+      }
+    }
+
     const concreteType = getConcreteType(element);
 
     return concreteType
@@ -137,12 +153,15 @@ function isConditionalFlow(element) {
   return businessObject.conditionExpression && is(sourceBusinessObject, 'bpmn:Activity');
 }
 
-
-// helpers //////////
 function isPlane(element) {
 
   // Backwards compatibility for bpmn-js<8
   const di = element && (element.di || getBusinessObject(element).di);
 
   return is(di, 'bpmndi:BPMNPlane');
+}
+
+function getTemplate(element, elementTemplates) {
+  const templateId = elementTemplates._getTemplateId(element);
+  return templateId && elementTemplates.get(templateId);
 }


### PR DESCRIPTION
Closes #610

Displays the element template name as element type in the properties panel header.

![image](https://user-images.githubusercontent.com/9433996/160145685-32e2b760-d4c3-40e5-82ca-32d4e1c1745e.png)

Script to try it out
```sh
npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel#610-template-name-header -c "npm run start:cloud-templates"
```
