### PR TITLE
Add `documentationRef` to properties panel header

### DIFF
--- a/src/render/PanelHeaderProvider.js
+++ b/src/render/PanelHeaderProvider.js
@@ -68,6 +68,16 @@ export function getConcreteType(element) {
 
 export const PanelHeaderProvider = {
 
+  getDocumentationRef: (element) => {
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const elementTemplates = useService('elementTemplates', false);
+
+    if (elementTemplates) {
+      return getTemplateDocumentation(element, elementTemplates);
+    }
+  },
+
   getElementLabel: (element) => {
     if (is(element, 'bpmn:Process')) {
       return getBusinessObject(element).name;
@@ -164,4 +174,10 @@ function isPlane(element) {
 function getTemplate(element, elementTemplates) {
   const templateId = elementTemplates._getTemplateId(element);
   return templateId && elementTemplates.get(templateId);
+}
+
+function getTemplateDocumentation(element, elementTemplates) {
+  const template = getTemplate(element, elementTemplates);
+
+  return template && template.documentationRef;
 }

--- a/test/spec/PanelHeaderProvider.spec.js
+++ b/test/spec/PanelHeaderProvider.spec.js
@@ -670,6 +670,84 @@ describe('<PanelHeaderProvider>', function() {
 
   });
 
+
+  describe('#getDocumentationRef', function() {
+
+    it('should NOT get documentationRef - no element templates', function() {
+
+      // given
+      const element = createElement('bpmn:Task', {
+        name: 'foo'
+      });
+
+      // when
+      const result = createHeader({ container, element });
+
+      const documentationNode = domQuery('.bio-properties-panel-header-link', result.container);
+
+      // then
+      expect(documentationNode).to.not.exist;
+    });
+
+
+    it('should NOT get documentationRef - no value', function() {
+
+      // given
+      const element = createElement('bpmn:Task', {
+        name: 'foo'
+      });
+
+      const elementTemplates = {
+        get: () => { return { id: 'foo' }; },
+        getTemplateId: () => true
+      };
+
+      const context = {
+        getService: () => {
+          return new ElementTemplates(elementTemplates);
+        }
+      };
+
+      // when
+      const result = createHeader({ container, element, context });
+
+      const documentationNode = domQuery('.bio-properties-panel-header-link', result.container);
+
+      // then
+      expect(documentationNode).to.not.exist;
+    });
+
+
+    it('should get element template documentationRef', function() {
+
+      // given
+      const element = createElement('bpmn:Task', {
+        name: 'foo'
+      });
+
+      const elementTemplates = {
+        get: () => { return { id: 'foo', documentationRef: 'https://example.com/' }; },
+        getTemplateId: () => true
+      };
+
+      const context = {
+        getService: () => {
+          return new ElementTemplates(elementTemplates);
+        }
+      };
+
+      // when
+      const result = createHeader({ container, element, context });
+
+      const documentationNode = domQuery('.bio-properties-panel-header-link', result.container);
+
+      // then
+      expect(documentationNode).to.exist;
+      expect(documentationNode.href).to.eql('https://example.com/');
+    });
+
+  });
+
 });
 
 

--- a/test/spec/provider/cloud-element-templates/fixtures/complex.bpmn
+++ b/test/spec/provider/cloud-element-templates/fixtures/complex.bpmn
@@ -54,6 +54,7 @@
       </bpmn:extensionElements>
     </bpmn:serviceTask>
     <bpmn:serviceTask id="Activity_1k5y89v" name="feel" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-feel" />
+    <bpmn:serviceTask id="Activity_1ftabot" name="documentationRef" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-documentationRef" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0vvlc66">
@@ -91,6 +92,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0dk5at4" bpmnElement="Activity_1k5y89v">
         <dc:Bounds x="270" y="470" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ftabot_di" bpmnElement="Activity_1ftabot">
+        <dc:Bounds x="270" y="580" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/cloud-element-templates/fixtures/complex.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/complex.json
@@ -525,5 +525,24 @@
         "feel": "required"
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "REST Connector (with Docs)",
+    "id": "io.camunda.connectors.RestConnector-documentationRef",
+    "description": "A generic REST service.",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "documentationRef": "https://docs.camunda.io",
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "http",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/provider/element-templates/fixtures/complex.bpmn
+++ b/test/spec/provider/element-templates/fixtures/complex.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1-entries-visible">
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1-entries-visible">
   <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:task id="Activity_07u0i6l" name="AsyncAwesomeTask" camunda:modelerTemplate="my.awesome.Task" camunda:modelerTemplateVersion="2" camunda:asyncBefore="true">
       <bpmn:outgoing>Flow_08c5khp</bpmn:outgoing>
@@ -109,7 +109,7 @@
       <bpmn:outgoing>Flow_10mgmi5</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_10mgmi5" sourceRef="Activity_01vr3dd" targetRef="Activity_0hf8j3r" />
-    <bpmn:callActivity id="Activity_0hf8j3r" name="Caller" camunda:modelerTemplate="my.Caller" calledElement="calledProcess">
+    <bpmn:callActivity id="Activity_0hf8j3r" name="Caller" calledElement="calledProcess" camunda:modelerTemplate="my.Caller">
       <bpmn:extensionElements>
         <camunda:in source="var_local" target="var_called_source" />
         <camunda:out source="var_local_source" target="var_called" />
@@ -134,7 +134,7 @@
       <bpmn:incoming>Flow_0s9gmd7</bpmn:incoming>
       <bpmn:outgoing>Flow_14l7z7l</bpmn:outgoing>
     </bpmn:task>
-    <bpmn:sequenceFlow id="Flow_14l7z7l" name="YEY YEA!" camunda:modelerTemplate="e.com.merce.FastPath" sourceRef="Activity_0pgqx99" targetRef="Activity_0538n0s">
+    <bpmn:sequenceFlow id="Flow_14l7z7l" name="YEY YEA!" sourceRef="Activity_0pgqx99" targetRef="Activity_0538n0s" camunda:modelerTemplate="e.com.merce.FastPath">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ customer.vip }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:task id="Activity_0t66hf8" name="ValidatedInputsTask" camunda:modelerTemplate="com.validated-inputs.Task">
@@ -178,6 +178,7 @@
         </camunda:inputOutput>
       </bpmn:extensionElements>
     </bpmn:task>
+    <bpmn:task id="Activity_1us5ywh" name="documentationRef" camunda:modelerTemplate="com.camunda.example.DocumentationRef" />
   </bpmn:process>
   <bpmn:error id="Error_error-1_xyz" name="error-name" errorCode="my-code" camunda:errorMessage="foo" />
   <bpmn:error id="Error_error-1_20b3oqr" name="error-name" errorCode="my-code" camunda:errorMessage="error-message" />
@@ -284,6 +285,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1r9ysfw_di" bpmnElement="Activity_1r9ysfw">
         <dc:Bounds x="930" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1us5ywh_di" bpmnElement="Activity_1us5ywh">
+        <dc:Bounds x="930" y="210" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/element-templates/fixtures/complex.json
+++ b/test/spec/provider/element-templates/fixtures/complex.json
@@ -710,5 +710,15 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/element-templates-json-schema/resources/schema.json",
+    "name": "Documentation Reference",
+    "id": "com.camunda.example.DocumentationRef",
+    "documentationRef": "https://docs.camunda.io",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": []
   }
 ]


### PR DESCRIPTION
Closes #614
Closes #616

Script to test this out
> npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel#616-documentation-header -c "npm run start:cloud-templates"

<img width="535" alt="image" src="https://user-images.githubusercontent.com/9433996/160626906-9dd8af82-d8fc-4dce-a7fc-ccdbc70d0660.png">
