### PR TITLE
deps: update to `@bpmn-io/extract-process-variables@v0.4.5`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -371,11 +371,11 @@
       }
     },
     "@bpmn-io/extract-process-variables": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.4.4.tgz",
-      "integrity": "sha512-iStnEVSEtOlZoE3ADMImdwhOhxUjXFdwWsCmmJQlyWH5ISmdRvai0Cxuw0spQEYySgIwFsUB0h+ScOCdW6yEBQ==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.4.5.tgz",
+      "integrity": "sha512-LtHx5b9xqS8avRLrq/uTlKhWzMeV3bWQKIdDic2bdo5n9roitX13GRb01u2S0hSsKDWEhXQtydFYN2b6G7bqfw==",
       "requires": {
-        "min-dash": "^3.5.2"
+        "min-dash": "^3.8.1"
       }
     },
     "@bpmn-io/properties-panel": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "license": "MIT",
   "dependencies": {
     "@bpmn-io/element-templates-validator": "^0.6.0",
-    "@bpmn-io/extract-process-variables": "^0.4.4",
+    "@bpmn-io/extract-process-variables": "^0.4.5",
     "array-move": "^3.0.1",
     "classnames": "^2.3.1",
     "ids": "^1.0.0",


### PR DESCRIPTION
Follow up of https://github.com/bpmn-io/extract-process-variables/issues/17

This also removes the annoying missing peer-deps warnings. 