### PR TITLE
Do not use `inherits`

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -70,7 +70,13 @@ function pgl(plugins = []) {
       ]
     }),
     json(),
-    resolve(),
+    resolve({
+      mainFields: [
+        'browser',
+        'module',
+        'main'
+      ]
+    }),
     commonjs()
   ];
 }

--- a/src/provider/cloud-element-templates/ReplaceBehavior.js
+++ b/src/provider/cloud-element-templates/ReplaceBehavior.js
@@ -1,5 +1,3 @@
-import inherits from 'inherits';
-
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
 import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
@@ -10,43 +8,43 @@ import { unlinkTemplate } from './util/templateUtil';
  * the list of elements the template applies to and unlinks
  * it if not.
  */
-export default function ReplaceBehavior(elementTemplates, injector) {
-  injector.invoke(CommandInterceptor, this);
+export default class ReplaceBehavior extends CommandInterceptor {
+  constructor(elementTemplates, injector) {
+    super(injector.get('eventBus'));
 
-  this.postExecuted('shape.replace', function(e) {
-    var context = e.context,
-        oldShape = context.oldShape,
-        oldBo = getBusinessObject(oldShape),
-        newShape = context.newShape,
-        newBo = getBusinessObject(newShape);
+    this.postExecuted('shape.replace', function(e) {
+      var context = e.context,
+          oldShape = context.oldShape,
+          oldBo = getBusinessObject(oldShape),
+          newShape = context.newShape,
+          newBo = getBusinessObject(newShape);
 
-    if (!oldBo.modelerTemplate) {
-      return;
-    }
+      if (!oldBo.modelerTemplate) {
+        return;
+      }
 
-    const template = newBo.modelerTemplate;
-    const version = newBo.modelerTemplateVersion;
+      const template = newBo.modelerTemplate;
+      const version = newBo.modelerTemplateVersion;
 
-    const elementTemplate = elementTemplates.get(template, version);
+      const elementTemplate = elementTemplates.get(template, version);
 
-    if (!elementTemplate) {
-      unlinkTemplate(newShape, injector);
-      return;
-    }
+      if (!elementTemplate) {
+        unlinkTemplate(newShape, injector);
+        return;
+      }
 
-    const { appliesTo } = elementTemplate;
+      const { appliesTo } = elementTemplate;
 
-    const allowed = appliesTo.reduce((allowed, type) => {
-      return allowed || is(newBo, type);
-    }, false);
+      const allowed = appliesTo.reduce((allowed, type) => {
+        return allowed || is(newBo, type);
+      }, false);
 
-    if (!allowed) {
-      unlinkTemplate(newShape, injector);
-    }
-  });
+      if (!allowed) {
+        unlinkTemplate(newShape, injector);
+      }
+    });
+  }
 }
-
-inherits(ReplaceBehavior, CommandInterceptor);
 
 ReplaceBehavior.$inject = [
   'elementTemplates',

--- a/src/provider/element-templates/ReplaceBehavior.js
+++ b/src/provider/element-templates/ReplaceBehavior.js
@@ -1,5 +1,3 @@
-import inherits from 'inherits';
-
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
 import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
@@ -10,43 +8,43 @@ import { unlinkTemplate } from './util/templateUtil';
  * the list of elements the template applies to and unlinks
  * it if not.
  */
-export default function ReplaceBehavior(elementTemplates, injector) {
-  injector.invoke(CommandInterceptor, this);
+export default class ReplaceBehavior extends CommandInterceptor {
+  constructor(elementTemplates, injector) {
+    super(injector.get('eventBus'));
 
-  this.postExecuted('shape.replace', function(e) {
-    var context = e.context,
-        oldShape = context.oldShape,
-        oldBo = getBusinessObject(oldShape),
-        newShape = context.newShape,
-        newBo = getBusinessObject(newShape);
+    this.postExecuted('shape.replace', function(e) {
+      var context = e.context,
+          oldShape = context.oldShape,
+          oldBo = getBusinessObject(oldShape),
+          newShape = context.newShape,
+          newBo = getBusinessObject(newShape);
 
-    if (!oldBo.modelerTemplate) {
-      return;
-    }
+      if (!oldBo.modelerTemplate) {
+        return;
+      }
 
-    const template = newBo.modelerTemplate;
-    const version = newBo.modelerTemplateVersion;
+      const template = newBo.modelerTemplate;
+      const version = newBo.modelerTemplateVersion;
 
-    const elementTemplate = elementTemplates.get(template, version);
+      const elementTemplate = elementTemplates.get(template, version);
 
-    if (!elementTemplate) {
-      unlinkTemplate(newShape, injector);
-      return;
-    }
+      if (!elementTemplate) {
+        unlinkTemplate(newShape, injector);
+        return;
+      }
 
-    const { appliesTo } = elementTemplate;
+      const { appliesTo } = elementTemplate;
 
-    const allowed = appliesTo.reduce((allowed, type) => {
-      return allowed || is(newBo, type);
-    }, false);
+      const allowed = appliesTo.reduce((allowed, type) => {
+        return allowed || is(newBo, type);
+      }, false);
 
-    if (!allowed) {
-      unlinkTemplate(newShape, injector);
-    }
-  });
+      if (!allowed) {
+        unlinkTemplate(newShape, injector);
+      }
+    });
+  }
 }
-
-inherits(ReplaceBehavior, CommandInterceptor);
 
 ReplaceBehavior.$inject = [
   'elementTemplates',


### PR DESCRIPTION
Usage of `inherits` was introduced without installing https://www.npmjs.com/package/inherits dependency. Thus, the Node.js internal `inherits` was used which is not being polyfilled when bundling. Instead of installing the dependency the usage of `inherits` can be avoided altogether.