### PR TITLE
chore: ensure we use <browser> deps, if provided

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -70,7 +70,13 @@ function pgl(plugins = []) {
       ]
     }),
     json(),
-    resolve(),
+    resolve({
+      mainFields: [
+        'browser',
+        'module',
+        'main'
+      ]
+    }),
     commonjs()
   ];
 }


### PR DESCRIPTION
The latest release is broken due to us using inherits (that uses Node shim per default): [https://github.com/bpmn-io/bpmn-js-properties-panel/compare/v1.0.0-alpha.8...v1.0.0-alpha.9#diff-8656a2b322b6384fe4e47[…]e4056bcc4915b2d6b34d7e630R1](https://github.com/bpmn-io/bpmn-js-properties-panel/compare/v1.0.0-alpha.8...v1.0.0-alpha.9#diff-8656a2b322b6384fe4e47cfa32ed42103d62f39e4056bcc4915b2d6b34d7e630R1).

The solution to this is to tell rollup to not use the node shim, but use inherits browser version: https://github.com/bpmn-io/bpmn-js/blob/develop/rollup.config.js#L100.