### PR TITLE
feat(render): display template icons in header

### DIFF
--- a/src/render/PanelHeaderProvider.js
+++ b/src/render/PanelHeaderProvider.js
@@ -69,9 +69,7 @@ export function getConcreteType(element) {
 export const PanelHeaderProvider = {
 
   getDocumentationRef: (element) => {
-
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const elementTemplates = useService('elementTemplates', false);
+    const elementTemplates = getTemplatesService();
 
     if (elementTemplates) {
       return getTemplateDocumentation(element, elementTemplates);
@@ -89,13 +87,21 @@ export const PanelHeaderProvider = {
   getElementIcon: (element) => {
     const concreteType = getConcreteType(element);
 
+    const elementTemplates = getTemplatesService();
+
+    if (elementTemplates) {
+      const template = getTemplate(element, elementTemplates);
+
+      if (template && template.icon) {
+        return () => <img class="bio-properties-panel-header-template-icon" width="32" height="32" src={ template.icon.contents } />;
+      }
+    }
+
     return iconsByType[ concreteType ];
   },
 
   getTypeLabel: (element) => {
-
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const elementTemplates = useService('elementTemplates', false);
+    const elementTemplates = getTemplatesService();
 
     if (elementTemplates) {
       const template = getTemplate(element, elementTemplates);
@@ -169,6 +175,12 @@ function isPlane(element) {
   const di = element && (element.di || getBusinessObject(element).di);
 
   return is(di, 'bpmndi:BPMNPlane');
+}
+
+function getTemplatesService() {
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return useService('elementTemplates', false);
 }
 
 function getTemplate(element, elementTemplates) {

--- a/test/spec/PanelHeaderProvider.spec.js
+++ b/test/spec/PanelHeaderProvider.spec.js
@@ -182,6 +182,125 @@ describe('<PanelHeaderProvider>', function() {
   });
 
 
+  describe('#getElementIcon', function() {
+
+    it('should get icon - no element templates', function() {
+
+      // given
+      const element = createElement('bpmn:Task');
+
+      // when
+      const result = createHeader({ container, element });
+
+      const iconNode = domQuery('.bio-properties-panel-header-icon', result.container);
+      const templateIconNode = domQuery('.bio-properties-panel-header-template-icon', iconNode);
+
+      // then
+      expect(iconNode).to.exist;
+      expect(templateIconNode).to.not.exist;
+    });
+
+
+    it('should get icon - no template icon', function() {
+
+      // given
+      const element = createElement('bpmn:Task');
+
+      const elementTemplates = {
+        get: () => { return { id: 'foo' }; },
+        getTemplateId: () => 'foo'
+      };
+
+      const context = {
+        getService: () => {
+          return new ElementTemplates(elementTemplates);
+        }
+      };
+
+      // when
+      const result = createHeader({ container, element, context });
+
+      const iconNode = domQuery('.bio-properties-panel-header-icon', result.container);
+      const templateIconNode = domQuery('.bio-properties-panel-header-template-icon', iconNode);
+
+      // then
+      expect(iconNode).to.exist;
+      expect(templateIconNode).to.not.exist;
+    });
+
+
+    it('should get template icon - data URI', function() {
+
+      // given
+      const element = createElement('bpmn:Task');
+
+      const template = {
+        id: 'foo',
+        icon: {
+          contents: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='100' width='100'%3E%3Ccircle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red' /%3E%3C/svg%3E"
+        }
+      };
+
+      const elementTemplates = {
+        get: () => { return template; },
+        getTemplateId: () => 'foo'
+      };
+
+      const context = {
+        getService: () => {
+          return new ElementTemplates(elementTemplates);
+        }
+      };
+
+      // when
+      const result = createHeader({ container, element, context });
+
+      const iconNode = domQuery('.bio-properties-panel-header-icon', result.container);
+      const templateIconNode = domQuery('.bio-properties-panel-header-template-icon', iconNode);
+
+      // then
+      expect(templateIconNode).to.exist;
+      expect(templateIconNode.src).to.eql(template.icon.contents);
+    });
+
+
+    it('should get template icon - https URI', function() {
+
+      // given
+      const element = createElement('bpmn:Task');
+
+      const template = {
+        id: 'foo',
+        icon: {
+          contents: 'https://camunda.com/wp-content/uploads/2020/05/logo-camunda-black.svg'
+        }
+      };
+
+      const elementTemplates = {
+        get: () => { return template; },
+        getTemplateId: () => 'foo'
+      };
+
+      const context = {
+        getService: () => {
+          return new ElementTemplates(elementTemplates);
+        }
+      };
+
+      // when
+      const result = createHeader({ container, element, context });
+
+      const iconNode = domQuery('.bio-properties-panel-header-icon', result.container);
+      const templateIconNode = domQuery('.bio-properties-panel-header-template-icon', iconNode);
+
+      // then
+      expect(templateIconNode).to.exist;
+      expect(templateIconNode.src).to.eql(template.icon.contents);
+    });
+
+  });
+
+
   describe('#getTypeLabel', function() {
 
     it('should get element type - no element templates', function() {


### PR DESCRIPTION
Closes #635
Depends on #641 (to work end-to-end)
