### PR TITLE
style: object fit on template icons

### DIFF
--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -10,6 +10,10 @@
   --select-template-information-text-color: var(--color-grey-225-10-55);
 }
 
+.bio-properties-panel-header-template-icon {
+  object-fit: contain;
+}
+
 .bio-properties-panel-templates-group .bio-properties-panel-group-header-button:not(.bio-properties-panel-arrow) {
   padding-right: 6px;
   padding-left: 9px;


### PR DESCRIPTION
Little follow up of https://github.com/bpmn-io/bpmn-js-properties-panel/pull/650#issuecomment-1087381293


<img width="303" alt="image" src="https://user-images.githubusercontent.com/9433996/161532720-84954ae3-2e3b-4f36-b072-1a8403afdf8f.png">
