### PR TITLE
test(templates): add template chooser to C7 templates test

### DIFF
--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -204,6 +204,7 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
           CamundaModdleExtension,
           BpmnPropertiesPanel,
           BpmnPropertiesProvider,
+          ElementTemplateChooserModule,
           ElementTemplatesPropertiesProvider
         ],
         moddleExtensions: {


### PR DESCRIPTION
It just makes sense to have it for C7 templates as well.

![image](https://user-images.githubusercontent.com/9433996/163949500-124594e6-94ed-4a36-8905-0491db06b3d3.png)

