### PR TITLE
fix: focus form field enum value on create

### DIFF
--- a/src/provider/camunda-platform/properties/FormField.js
+++ b/src/provider/camunda-platform/properties/FormField.js
@@ -361,7 +361,7 @@ function ValueList(props) {
 
   return <ListEntry
     element={ element }
-    autoFocusEntry={ true }
+    autoFocusEntry={ `[data-entry-id="${id}-value-${values.length - 1}"] input` }
     id={ id }
     label={ translate('Values') }
     items={ values }


### PR DESCRIPTION
Closes #589

![electron_T2Yl7jVbKt](https://user-images.githubusercontent.com/17801113/168770336-3de019ce-7ebc-47aa-a4b8-0b6e6c370efd.gif)

