### PR TITLE
chore: adjust show callbacks and tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1714,6 +1714,57 @@
         "moddle-xml": "^9.0.5"
       }
     },
+    "bpmnlint": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-7.8.0.tgz",
+      "integrity": "sha512-hzmDB/yMzv90bRYkey6lvJ5fyqSCBPdIMRLBzWSvqpH/XvSasaRo3Gibp1oX3dJg1JyHeZw4EnJZdhP55CzGWQ==",
+      "dev": true,
+      "requires": {
+        "@philippfromme/moddle-helpers": "^0.1.0",
+        "ansi-colors": "^4.1.1",
+        "bpmn-moddle": "^7.1.2",
+        "bpmnlint-utils": "^1.0.2",
+        "cli-table": "^0.3.9",
+        "color-support": "^1.1.3",
+        "min-dash": "^3.8.0",
+        "mri": "^1.2.0",
+        "pluralize": "^7.0.0",
+        "tiny-glob": "^0.2.9"
+      },
+      "dependencies": {
+        "@philippfromme/moddle-helpers": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/@philippfromme/moddle-helpers/-/moddle-helpers-0.1.0.tgz",
+          "integrity": "sha512-eKnrt2mCtcYFhweNr20mOWSG0431BPPFnhYJEQd+D2/5ssWPaHVEEgD3YnUOmbg1gdRQdVe2rrxcdEvvPugB/A==",
+          "dev": true
+        }
+      }
+    },
+    "bpmnlint-plugin-camunda-compat": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.8.0.tgz",
+      "integrity": "sha512-t5Vh8XCSbpBrS+wW+R3sEa6uluGqh6F5ozY66DAultly7vu/mp1a7iNhdfkvpqUO4zfSezOjfhd8Z7G/dQfwdg==",
+      "dev": true,
+      "requires": {
+        "@philippfromme/moddle-helpers": "^0.1.0",
+        "bpmnlint-utils": "^1.0.2",
+        "min-dash": "^3.8.0"
+      },
+      "dependencies": {
+        "@philippfromme/moddle-helpers": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/@philippfromme/moddle-helpers/-/moddle-helpers-0.1.0.tgz",
+          "integrity": "sha512-eKnrt2mCtcYFhweNr20mOWSG0431BPPFnhYJEQd+D2/5ssWPaHVEEgD3YnUOmbg1gdRQdVe2rrxcdEvvPugB/A==",
+          "dev": true
+        }
+      }
+    },
+    "bpmnlint-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bpmnlint-utils/-/bpmnlint-utils-1.0.2.tgz",
+      "integrity": "sha512-+ti0VICOpgYpQgzpF0mwXqDX4NhrQCc2YKy28VjPu7v9sXpdpWEylP+iBw6WlheJFRcXoZh2q/QRLb5DMB3naQ==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1908,6 +1959,15 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
       "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
+    "cli-table": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "dev": true,
+      "requires": {
+        "colors": "1.0.3"
+      }
+    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -1957,10 +2017,22 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
     "colorette": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
       "dev": true
     },
     "commander": {
@@ -3429,6 +3501,12 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true
+    },
     "globby": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
@@ -3442,6 +3520,12 @@
         "merge2": "^1.3.0",
         "slash": "^3.0.0"
       }
+    },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.8",
@@ -5246,6 +5330,12 @@
         "find-up": "^4.0.0"
       }
     },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
     "postcss": {
       "version": "8.4.4",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.4.tgz",
@@ -6418,6 +6508,16 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "requires": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
     },
     "tiny-svg": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "babel-loader": "^8.2.2",
     "bpmn-js": "9.2.2",
     "bpmn-moddle": "^7.1.2",
+    "bpmnlint": "^7.8.0",
+    "bpmnlint-plugin-camunda-compat": "^0.8.0",
     "camunda-bpmn-js-behaviors": "^0.1.0",
     "camunda-bpmn-moddle": "^6.1.2",
     "chai": "^4.3.4",

--- a/src/provider/zeebe/properties/BusinessRuleImplementationProps.js
+++ b/src/provider/zeebe/properties/BusinessRuleImplementationProps.js
@@ -21,7 +21,7 @@ import {
   useShowCallback
 } from '../../../hooks';
 
-import { without } from 'min-dash';
+import { isArray, without } from 'min-dash';
 
 export const DMN_IMPLEMENTATION_OPTION = 'dmn',
       JOB_WORKER_IMPLEMENTATION_OPTION = 'jobWorker',
@@ -124,10 +124,8 @@ function BusinessRuleImplementation(props) {
     } = error;
 
     return type === 'extensionElementRequired'
-      && [
-        'zeebe:CalledDecision',
-        'zeebe:TaskDefinition'
-      ].includes(requiredExtensionElement);
+      && isArray(requiredExtensionElement)
+      && (requiredExtensionElement.includes('zeebe:CalledDecision') || requiredExtensionElement.includes('zeebe:TaskDefinition'));
   });
 
   return SelectEntry({

--- a/test/spec/provider/bpmn/ErrorProps.bpmn
+++ b/test/spec/provider/bpmn/ErrorProps.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0evowaa" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0evowaa" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
   <bpmn:process id="Process_0nlx8t6" isExecutable="true">
     <bpmn:task id="Task_1" />
     <bpmn:boundaryEvent id="ErrorEvent_empty" attachedToRef="Task_1">
@@ -11,6 +11,9 @@
       </bpmn:startEvent>
     </bpmn:subProcess>
     <bpmn:startEvent id="StartEvent_1" />
+    <bpmn:boundaryEvent id="ErrorEvent_no_error_code" attachedToRef="Task_1">
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0wxe9th" errorRef="Error_2" />
+    </bpmn:boundaryEvent>
   </bpmn:process>
   <bpmn:error id="Error_1" name="Error_1" errorCode="500" />
   <bpmn:error id="Error_3" name="Error_3" />
@@ -20,17 +23,20 @@
       <bpmndi:BPMNShape id="Activity_0m22viw_di" bpmnElement="Task_1">
         <dc:Bounds x="530" y="340" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0mlb230_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="242" y="82" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0nnog6x_di" bpmnElement="EventSubProcess_1" isExpanded="true">
         <dc:Bounds x="120" y="290" width="350" height="200" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1f72hoo_di" bpmnElement="ErrorEvent_1">
         <dc:Bounds x="160" y="372" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0mlb230_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="242" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1276rgr_di" bpmnElement="ErrorEvent_empty">
         <dc:Bounds x="552" y="402" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1bbtcen_di" bpmnElement="ErrorEvent_no_error_code">
+        <dc:Bounds x="612" y="402" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/bpmn/ErrorProps.spec.js
+++ b/test/spec/provider/bpmn/ErrorProps.spec.js
@@ -29,6 +29,8 @@ import {
   getError
 } from 'src/provider/bpmn/utils/EventDefinitionUtil';
 
+import { getLintError } from '../zeebe/lint-helper';
+
 import diagramXML from './ErrorProps.bpmn';
 
 
@@ -267,22 +269,22 @@ describe('provider/bpmn - ErrorProps', function() {
         // given
         const boundaryEvent = elementRegistry.get('ErrorEvent_empty');
 
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/error-reference');
+
+        const report = await getLintError(boundaryEvent, rule);
+
         // when
         await act(() => {
           selection.select(boundaryEvent);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'ErrorEvent_empty',
-            message: 'foo',
-            path: [ 'eventDefinitions', 0, 'errorRef' ]
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <bpmn:ErrorEventDefinition> must have property <errorRef>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 
@@ -481,24 +483,24 @@ describe('provider/bpmn - ErrorProps', function() {
       it('should show error (no error code)', inject(async function(elementRegistry, eventBus, selection) {
 
         // given
-        const boundaryEvent = elementRegistry.get('ErrorEvent_1');
+        const boundaryEvent = elementRegistry.get('ErrorEvent_no_error_code');
+
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/error-reference');
+
+        const report = await getLintError(boundaryEvent, rule);
 
         // when
         await act(() => {
           selection.select(boundaryEvent);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'ErrorEvent_1',
-            message: 'foo',
-            path: [ 'rootElements', 1, 'errorCode' ]
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <bpmn:Error> must have property <errorCode>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 

--- a/test/spec/provider/bpmn/MessageProps.bpmn
+++ b/test/spec/provider/bpmn/MessageProps.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0fsqrcy" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0fsqrcy" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
   <bpmn:process id="Process_03uklzr" isExecutable="true">
     <bpmn:startEvent id="MessageEvent_1">
       <bpmn:messageEventDefinition id="MessageEventDefinition_1x1jfqx" messageRef="Message_1" />
@@ -11,10 +11,15 @@
     <bpmn:startEvent id="StartEvent_1" />
     <bpmn:receiveTask id="ReceiveTask_1" messageRef="Message_1" />
     <bpmn:receiveTask id="ReceiveTask_empty" />
+    <bpmn:startEvent id="MessageEvent_2">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1u8gaw5" messageRef="Message_0pkdjnu" />
+    </bpmn:startEvent>
+    <bpmn:receiveTask id="ReceiveTask_2" messageRef="Message_0pkdjnu" />
   </bpmn:process>
   <bpmn:message id="Message_1" name="Message_1" />
   <bpmn:message id="Message_3" name="Message_3" />
   <bpmn:message id="Message_2" name="Message_2" />
+  <bpmn:message id="Message_0pkdjnu" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_03uklzr">
       <bpmndi:BPMNShape id="Event_03h9537_di" bpmnElement="MessageEvent_1">
@@ -31,6 +36,12 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_00gxxlu_di" bpmnElement="ReceiveTask_empty">
         <dc:Bounds x="540" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_135ei5b_di" bpmnElement="MessageEvent_2">
+        <dc:Bounds x="222" y="322" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_06qbras_di" bpmnElement="ReceiveTask_2">
+        <dc:Bounds x="690" y="240" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0hk64mx_di" bpmnElement="MessageEvent_empty">
         <dc:Bounds x="332" y="182" width="36" height="36" />

--- a/test/spec/provider/bpmn/MessageProps.spec.js
+++ b/test/spec/provider/bpmn/MessageProps.spec.js
@@ -29,6 +29,8 @@ import {
   getMessage
 } from 'src/provider/bpmn/utils/EventDefinitionUtil';
 
+import { getLintError } from '../zeebe/lint-helper';
+
 import diagramXML from './MessageProps.bpmn';
 
 
@@ -108,6 +110,7 @@ describe('provider/bpmn - MessageProps', function() {
       expect(asOptionNamesList(messageRefSelect)).to.eql([
         '<none>',
         'Create new ...',
+        '',
         'Message_1',
         'Message_2',
         'Message_3'
@@ -265,24 +268,24 @@ describe('provider/bpmn - MessageProps', function() {
       it('should show error (no message ref)', inject(async function(elementRegistry, eventBus, selection) {
 
         // given
-        const startEvent = elementRegistry.get('MessageEvent_1');
+        const startEvent = elementRegistry.get('MessageEvent_empty');
+
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/message-reference');
+
+        const report = await getLintError(startEvent, rule);
 
         // when
         await act(() => {
           selection.select(startEvent);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'MessageEvent_1',
-            message: 'foo',
-            path: [ 'eventDefinitions', 0, 'messageRef' ]
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <bpmn:MessageEventDefinition> must have property <messageRef>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 
@@ -348,6 +351,7 @@ describe('provider/bpmn - MessageProps', function() {
       expect(asOptionNamesList(messageRefSelect)).to.eql([
         '<none>',
         'Create new ...',
+        '',
         'Message_1',
         'Message_2',
         'Message_3'
@@ -446,22 +450,22 @@ describe('provider/bpmn - MessageProps', function() {
         // given
         const receiveTask = elementRegistry.get('ReceiveTask_empty');
 
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/message-reference');
+
+        const report = await getLintError(receiveTask, rule);
+
         // when
         await act(() => {
           selection.select(receiveTask);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'ReceiveTask_empty',
-            message: 'foo',
-            path: [ 'messageRef' ]
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <bpmn:ReceiveTask> must have property <messageRef>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 
@@ -578,24 +582,24 @@ describe('provider/bpmn - MessageProps', function() {
       it('should show error (no message name)', inject(async function(elementRegistry, eventBus, selection) {
 
         // given
-        const startEvent = elementRegistry.get('MessageEvent_1');
+        const startEvent = elementRegistry.get('MessageEvent_2');
+
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/message-reference');
+
+        const report = await getLintError(startEvent, rule);
 
         // when
         await act(() => {
           selection.select(startEvent);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'MessageEvent_1',
-            message: 'foo',
-            path: [ 'rootElements', 1, 'name' ]
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <bpmn:Message> must have property <name>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 
@@ -692,24 +696,24 @@ describe('provider/bpmn - MessageProps', function() {
       it('should show error (no message name)', inject(async function(elementRegistry, eventBus, selection) {
 
         // given
-        const receiveTask = elementRegistry.get('ReceiveTask_1');
+        const receiveTask = elementRegistry.get('ReceiveTask_2');
+
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/message-reference');
+
+        const report = await getLintError(receiveTask, rule);
 
         // when
         await act(() => {
           selection.select(receiveTask);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'ReceiveTask_1',
-            message: 'foo',
-            path: [ 'rootElements', 1, 'name' ]
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <bpmn:Message> must have property <name>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 

--- a/test/spec/provider/zeebe/CalledDecisionProps.bpmn
+++ b/test/spec/provider/zeebe/CalledDecisionProps.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_16ejc8c" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_16ejc8c" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
   <bpmn:process id="Process_0mgn9vm" isExecutable="true">
     <bpmn:task id="Task_1" name="Task_1" />
     <bpmn:businessRuleTask id="BusinessRuleTask_1" name="BusinessRuleTask_1">
@@ -8,6 +8,16 @@
       </bpmn:extensionElements>
     </bpmn:businessRuleTask>
     <bpmn:businessRuleTask id="BusinessRuleTask_2" name="BusinessRuleTask_2" />
+    <bpmn:businessRuleTask id="BusinessRuleTask_3" name="BusinessRuleTask_3">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision resultVariable="foo" />
+      </bpmn:extensionElements>
+    </bpmn:businessRuleTask>
+    <bpmn:businessRuleTask id="BusinessRuleTask_4" name="BusinessRuleTask_4">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision decisionId="foo" />
+      </bpmn:extensionElements>
+    </bpmn:businessRuleTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0mgn9vm">
@@ -19,6 +29,14 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0h1wnsx_di" bpmnElement="BusinessRuleTask_2">
         <dc:Bounds x="480" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0bac1ns_di" bpmnElement="BusinessRuleTask_3">
+        <dc:Bounds x="640" y="120" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1m1b8o7_di" bpmnElement="BusinessRuleTask_4">
+        <dc:Bounds x="800" y="120" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/zeebe/CalledDecisionProps.spec.js
+++ b/test/spec/provider/zeebe/CalledDecisionProps.spec.js
@@ -30,6 +30,8 @@ import ZeebePropertiesProvider from 'src/provider/zeebe';
 
 import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
 
+import { getLintError } from './lint-helper';
+
 import diagramXML from './CalledDecisionProps.bpmn';
 
 
@@ -153,27 +155,29 @@ describe('provider/zeebe - TargetProps', function() {
 
       describe('show error', function() {
 
-        it('should show error', inject(async function(elementRegistry, eventBus, selection) {
+        it('should show error (no decision ID)', inject(async function(elementRegistry, eventBus, selection) {
 
           // given
-          const businessRuleTask = elementRegistry.get('BusinessRuleTask_1');
+          const businessRuleTask = elementRegistry.get('BusinessRuleTask_3');
+
+          const rule = require('bpmnlint-plugin-camunda-compat/rules/called-decision-or-task-definition');
+
+          const { camundaCloud13: config } = require('bpmnlint-plugin-camunda-compat/rules/called-decision-or-task-definition/config');
+
+          const report = await getLintError(businessRuleTask, rule, config);
 
           // when
           await act(() => {
             selection.select(businessRuleTask);
 
-            eventBus.fire('propertiesPanel.showError', {
-              id: 'BusinessRuleTask_1',
-              message: 'foo',
-              path: [ 'extensionElements', 'values', 0, 'decisionId' ]
-            });
+            eventBus.fire('propertiesPanel.showError', report);
           });
 
           // then
           const error = document.querySelector('.bio-properties-panel-error');
 
           expect(error).to.exist;
-          expect(error.textContent).to.equal('foo');
+          expect(error.textContent).to.equal('Element of type <zeebe:CalledDecision> must have property <decisionId>');
 
           const entry = error.closest('.bio-properties-panel-entry');
 
@@ -276,27 +280,29 @@ describe('provider/zeebe - TargetProps', function() {
 
       describe('show error', function() {
 
-        it('should show error', inject(async function(elementRegistry, eventBus, selection) {
+        it('should show error (no result variable)', inject(async function(elementRegistry, eventBus, selection) {
 
           // given
-          const businessRuleTask = elementRegistry.get('BusinessRuleTask_1');
+          const businessRuleTask = elementRegistry.get('BusinessRuleTask_4');
+
+          const rule = require('bpmnlint-plugin-camunda-compat/rules/called-decision-or-task-definition');
+
+          const { camundaCloud13: config } = require('bpmnlint-plugin-camunda-compat/rules/called-decision-or-task-definition/config');
+
+          const report = await getLintError(businessRuleTask, rule, config);
 
           // when
           await act(() => {
             selection.select(businessRuleTask);
 
-            eventBus.fire('propertiesPanel.showError', {
-              id: 'BusinessRuleTask_1',
-              message: 'foo',
-              path: [ 'extensionElements', 'values', 0, 'resultVariable' ]
-            });
+            eventBus.fire('propertiesPanel.showError', report);
           });
 
           // then
           const error = document.querySelector('.bio-properties-panel-error');
 
           expect(error).to.exist;
-          expect(error.textContent).to.equal('foo');
+          expect(error.textContent).to.equal('Element of type <zeebe:CalledDecision> must have property <resultVariable>');
 
           const entry = error.closest('.bio-properties-panel-entry');
 

--- a/test/spec/provider/zeebe/MessageProps.bpmn
+++ b/test/spec/provider/zeebe/MessageProps.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0upqbpl" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0-alpha.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0upqbpl" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
   <bpmn:process id="Process_17fhhp5" isExecutable="true">
     <bpmn:subProcess id="EventSubProcess_1" triggeredByEvent="true">
       <bpmn:startEvent id="StartEvent_1" isInterrupting="false">
@@ -26,6 +26,12 @@
       <bpmn:messageEventDefinition id="MessageEventDefinition_02zap1w" />
     </bpmn:intermediateCatchEvent>
     <bpmn:receiveTask id="ReceiveTask_noCorrelationKey" messageRef="Message_noCorrelationKey" />
+    <bpmn:startEvent id="MessageEvent_no_message_name">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1i0ywl3" messageRef="Message_086fgbs" />
+    </bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateEvent_no_message_name">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0gcos7s" messageRef="Message_086fgbs" />
+    </bpmn:intermediateCatchEvent>
   </bpmn:process>
   <bpmn:message id="Message_1" name="Message_1">
     <bpmn:extensionElements>
@@ -51,16 +57,14 @@
       <zeebe:subscription />
     </bpmn:extensionElements>
   </bpmn:message>
+  <bpmn:message id="Message_086fgbs" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_17fhhp5">
-      <bpmndi:BPMNShape id="Event_0og0a7w_di" bpmnElement="IntermediateEvent_1">
-        <dc:Bounds x="242" y="472" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1gnxknd_di" bpmnElement="MessageEvent_no_message_name">
+        <dc:Bounds x="242" y="162" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0eexx4v" bpmnElement="IntermediateEvent_empty">
-        <dc:Bounds x="317" y="472" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_01jx65q_di" bpmnElement="ReceiveTask_noCorrelationKey">
-        <dc:Bounds x="520" y="80" width="100" height="80" />
+      <bpmndi:BPMNShape id="Event_0f79uf9_di" bpmnElement="IntermediateEvent_no_message_name">
+        <dc:Bounds x="392" y="472" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1ufkvg9_di" bpmnElement="EventSubProcess_1" isExpanded="true">
         <dc:Bounds x="160" y="220" width="350" height="200" />
@@ -82,6 +86,15 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_08h08b4" bpmnElement="MessageEvent_empty">
         <dc:Bounds x="112" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0og0a7w_di" bpmnElement="IntermediateEvent_1">
+        <dc:Bounds x="242" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0eexx4v" bpmnElement="IntermediateEvent_empty">
+        <dc:Bounds x="317" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_01jx65q_di" bpmnElement="ReceiveTask_noCorrelationKey">
+        <dc:Bounds x="520" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/zeebe/MessageProps.spec.js
+++ b/test/spec/provider/zeebe/MessageProps.spec.js
@@ -36,6 +36,8 @@ import {
   getMessage
 } from 'src/provider/bpmn/utils/EventDefinitionUtil';
 
+import { getLintError } from './lint-helper';
+
 import diagramXML from './MessageProps.bpmn';
 
 
@@ -190,24 +192,24 @@ describe('provider/zeebe - MessageProps', function() {
       it('should show error (no message name)', inject(async function(elementRegistry, eventBus, selection) {
 
         // given
-        const startEvent = elementRegistry.get('StartEvent_1');
+        const startEvent = elementRegistry.get('MessageEvent_no_message_name');
+
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/message-reference');
+
+        const report = await getLintError(startEvent, rule);
 
         // when
         await act(() => {
           selection.select(startEvent);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'StartEvent_1',
-            message: 'foo',
-            path: [ 'rootElements', 1, 'name' ]
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <bpmn:Message> must have property <name>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 
@@ -339,24 +341,24 @@ describe('provider/zeebe - MessageProps', function() {
       it('should show error (no message name)', inject(async function(elementRegistry, eventBus, selection) {
 
         // given
-        const receiveTask = elementRegistry.get('IntermediateEvent_1');
+        const receiveTask = elementRegistry.get('IntermediateEvent_no_message_name');
+
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/message-reference');
+
+        const report = await getLintError(receiveTask, rule);
 
         // when
         await act(() => {
           selection.select(receiveTask);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'IntermediateEvent_1',
-            message: 'foo',
-            path: [ 'rootElements', 3, 'name' ]
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <bpmn:Message> must have property <name>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 
@@ -582,25 +584,22 @@ describe('provider/zeebe - MessageProps', function() {
         // given
         const startEvent = elementRegistry.get('StartEvent_noSubscription');
 
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/subscription');
+
+        const report = await getLintError(startEvent, rule);
+
         // when
         await act(() => {
           selection.select(startEvent);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'StartEvent_noSubscription',
-            message: 'foo',
-            error: {
-              type: 'extensionElementRequired',
-              requiredExtensionElement: 'zeebe:Subscription'
-            }
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <bpmn:Message> must have extension element of type <zeebe:Subscription>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 
@@ -613,22 +612,22 @@ describe('provider/zeebe - MessageProps', function() {
         // given
         const receiveTask = elementRegistry.get('ReceiveTask_noCorrelationKey');
 
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/subscription');
+
+        const report = await getLintError(receiveTask, rule);
+
         // when
         await act(() => {
           selection.select(receiveTask);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'ReceiveTask_noCorrelationKey',
-            message: 'foo',
-            path: [ 'rootElements', 6, 'extensionElements', 'values', 0, 'correlationKey' ]
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <zeebe:Subscription> must have property <correlationKey>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 

--- a/test/spec/provider/zeebe/MultiInstanceProps.bpmn
+++ b/test/spec/provider/zeebe/MultiInstanceProps.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_0l1dxrj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0-alpha.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_0l1dxrj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:serviceTask id="ServiceTask_1" name="task">
       <bpmn:multiInstanceLoopCharacteristics>
@@ -27,6 +27,20 @@
         </bpmn:extensionElements>
       </bpmn:multiInstanceLoopCharacteristics>
     </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_noOutputElement" name="no output element">
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="bar" outputCollection="foo" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_noOutputCollection" name="no output collection">
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="bar" outputElement="foo" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -47,6 +61,14 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0jrkkkk_di" bpmnElement="ServiceTask_noInputCollection">
         <dc:Bounds x="560" y="440" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0uj0htj_di" bpmnElement="ServiceTask_noOutputElement">
+        <dc:Bounds x="680" y="440" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_17couom" bpmnElement="ServiceTask_noOutputCollection">
+        <dc:Bounds x="800" y="440" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/spec/provider/zeebe/MultiInstanceProps.spec.js
+++ b/test/spec/provider/zeebe/MultiInstanceProps.spec.js
@@ -33,6 +33,8 @@ import {
   getExtensionElementsList
 } from 'src/utils/ExtensionElementsUtil';
 
+import { getLintError } from './lint-helper';
+
 import diagramXML from './MultiInstanceProps.bpmn';
 
 
@@ -199,25 +201,22 @@ describe('provider/zeebe - MultiInstanceProps', function() {
         // given
         const serviceTask = elementRegistry.get('ServiceTask_noZeebeLoops');
 
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/loop-characteristics');
+
+        const report = await getLintError(serviceTask, rule);
+
         // when
         await act(() => {
           selection.select(serviceTask);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'ServiceTask_noZeebeLoops',
-            message: 'foo',
-            error: {
-              type: 'extensionElementRequired',
-              requiredExtensionElement: 'zeebe:LoopCharacteristics'
-            }
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <bpmn:MultiInstanceLoopCharacteristics> must have extension element of type <zeebe:LoopCharacteristics>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 
@@ -230,22 +229,22 @@ describe('provider/zeebe - MultiInstanceProps', function() {
         // given
         const serviceTask = elementRegistry.get('ServiceTask_noInputCollection');
 
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/loop-characteristics');
+
+        const report = await getLintError(serviceTask, rule);
+
         // when
         await act(() => {
           selection.select(serviceTask);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'ServiceTask_noInputCollection',
-            message: 'foo',
-            path: [ 'loopCharacteristics', 'extensionElements', 'values', 0, 'inputCollection' ]
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <zeebe:LoopCharacteristics> must have property <inputCollection>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 
@@ -520,24 +519,24 @@ describe('provider/zeebe - MultiInstanceProps', function() {
       it('should show error (no output collection)', inject(async function(elementRegistry, eventBus, selection) {
 
         // given
-        const serviceTask = elementRegistry.get('ServiceTask_noInputCollection');
+        const serviceTask = elementRegistry.get('ServiceTask_noOutputCollection');
+
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/loop-characteristics');
+
+        const report = await getLintError(serviceTask, rule);
 
         // when
         await act(() => {
           selection.select(serviceTask);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'ServiceTask_noInputCollection',
-            message: 'foo',
-            path: [ 'loopCharacteristics', 'extensionElements', 'values', 0, 'outputCollection' ]
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <zeebe:LoopCharacteristics> must have property <outputCollection> if it has property <outputElement>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 
@@ -682,24 +681,24 @@ describe('provider/zeebe - MultiInstanceProps', function() {
       it('should show error (no output element)', inject(async function(elementRegistry, eventBus, selection) {
 
         // given
-        const serviceTask = elementRegistry.get('ServiceTask_noInputCollection');
+        const serviceTask = elementRegistry.get('ServiceTask_noOutputElement');
+
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/loop-characteristics');
+
+        const report = await getLintError(serviceTask, rule);
 
         // when
         await act(() => {
           selection.select(serviceTask);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'ServiceTask_noInputCollection',
-            message: 'foo',
-            path: [ 'loopCharacteristics', 'extensionElements', 'values', 0, 'outputElement' ]
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <zeebe:LoopCharacteristics> must have property <outputElement> if it has property <outputCollection>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 

--- a/test/spec/provider/zeebe/TargetProps.spec.js
+++ b/test/spec/provider/zeebe/TargetProps.spec.js
@@ -35,6 +35,8 @@ import ZeebePropertiesProvider from 'src/provider/zeebe';
 
 import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
 
+import { getLintError } from './lint-helper';
+
 import diagramXML from './TargetProps.bpmn';
 
 
@@ -228,27 +230,24 @@ describe('provider/zeebe - TargetProps', function() {
       it('should show error (no extension element)', inject(async function(elementRegistry, eventBus, selection) {
 
         // given
-        const businessRuleTask = elementRegistry.get('CallActivity_2');
+        const callActivity = elementRegistry.get('CallActivity_2');
+
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/called-element');
+
+        const report = await getLintError(callActivity, rule);
 
         // when
         await act(() => {
-          selection.select(businessRuleTask);
+          selection.select(callActivity);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'CallActivity_2',
-            message: 'foo',
-            error: {
-              type: 'extensionElementRequired',
-              requiredExtensionElement: 'zeebe:CalledElement'
-            }
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <bpmn:CallActivity> must have extension element of type <zeebe:CalledElement>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 
@@ -259,24 +258,24 @@ describe('provider/zeebe - TargetProps', function() {
       it('should show error (no process ID)', inject(async function(elementRegistry, eventBus, selection) {
 
         // given
-        const businessRuleTask = elementRegistry.get('CallActivity_4');
+        const callActivity = elementRegistry.get('CallActivity_4');
+
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/called-element');
+
+        const report = await getLintError(callActivity, rule);
 
         // when
         await act(() => {
-          selection.select(businessRuleTask);
+          selection.select(callActivity);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'CallActivity_4',
-            message: 'foo',
-            path: [ 'extensionElements', 'values', 0, 'processId' ]
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <zeebe:CalledElement> must have property <processId>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 

--- a/test/spec/provider/zeebe/TaskDefinitionProps.spec.js
+++ b/test/spec/provider/zeebe/TaskDefinitionProps.spec.js
@@ -34,6 +34,8 @@ import {
   getExtensionElementsList
 } from 'src/utils/ExtensionElementsUtil';
 
+import { getLintError } from './lint-helper';
+
 import diagramXML from './TaskDefinitionProps.bpmn';
 
 
@@ -302,25 +304,24 @@ describe('provider/zeebe - TaskDefinitionProps', function() {
         // given
         const serviceTask = elementRegistry.get('ServiceTask_empty');
 
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/called-decision-or-task-definition');
+
+        const { camundaCloud10: config } = require('bpmnlint-plugin-camunda-compat/rules/called-decision-or-task-definition/config');
+
+        const report = await getLintError(serviceTask, rule, config);
+
         // when
         await act(() => {
           selection.select(serviceTask);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'ServiceTask_empty',
-            message: 'foo',
-            error: {
-              type: 'extensionElementRequired',
-              requiredExtensionElement: 'zeebe:TaskDefinition'
-            }
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <bpmn:ServiceTask> must have extension element of type <zeebe:TaskDefinition>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 
@@ -333,22 +334,24 @@ describe('provider/zeebe - TaskDefinitionProps', function() {
         // given
         const serviceTask = elementRegistry.get('ServiceTask_noTaskDefinitionType');
 
+        const rule = require('bpmnlint-plugin-camunda-compat/rules/called-decision-or-task-definition');
+
+        const { camundaCloud10: config } = require('bpmnlint-plugin-camunda-compat/rules/called-decision-or-task-definition/config');
+
+        const report = await getLintError(serviceTask, rule, config);
+
         // when
         await act(() => {
           selection.select(serviceTask);
 
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'ServiceTask_noTaskDefinitionType',
-            message: 'foo',
-            path: [ 'extensionElements', 'values', 0, 'type' ]
-          });
+          eventBus.fire('propertiesPanel.showError', report);
         });
 
         // then
         const error = document.querySelector('.bio-properties-panel-error');
 
         expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
+        expect(error.textContent).to.equal('Element of type <zeebe:TaskDefinition> must have property <type>');
 
         const entry = error.closest('.bio-properties-panel-entry');
 
@@ -482,38 +485,6 @@ describe('provider/zeebe - TaskDefinitionProps', function() {
         expect(getTaskDefinition(serviceTask).get('retries')).to.eql('newValue');
       })
     );
-
-
-    describe('show error', function() {
-
-      it('should show error (no retries)', inject(async function(elementRegistry, eventBus, selection) {
-
-        // given
-        const serviceTask = elementRegistry.get('ServiceTask_noTaskDefinitionRetries');
-
-        // when
-        await act(() => {
-          selection.select(serviceTask);
-
-          eventBus.fire('propertiesPanel.showError', {
-            id: 'ServiceTask_noTaskDefinitionRetries',
-            message: 'foo',
-            path: [ 'extensionElements', 'values', 0, 'retries' ]
-          });
-        });
-
-        // then
-        const error = document.querySelector('.bio-properties-panel-error');
-
-        expect(error).to.exist;
-        expect(error.textContent).to.equal('foo');
-
-        const entry = error.closest('.bio-properties-panel-entry');
-
-        expect(entry.dataset.entryId).to.equal('taskDefinitionRetries');
-      }));
-
-    });
 
   });
 

--- a/test/spec/provider/zeebe/lint-helper.js
+++ b/test/spec/provider/zeebe/lint-helper.js
@@ -1,0 +1,55 @@
+import Linter from 'bpmnlint/lib/linter';
+
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+async function lintNode(node, rule, config = {}) {
+  node = getBusinessObject(node);
+
+  const linter = new Linter({
+    resolver: {
+      resolveRule: () => Promise.resolve(rule)
+    }
+  });
+
+  return linter.lint(node, {
+    rules: { 'ruleName': [ 2, config ] }
+  });
+}
+
+/**
+ * Lint node with given rule and configuration expecting one report.
+ *
+ * @param {Object} node
+ * @param {Function} rule
+ * @param {Object} [config]
+ *
+ * @returns {Object}
+ */
+export async function getLintError(node, rule, config = {}) {
+  const { ruleName } = await lintNode(node, rule, config);
+
+  // assume
+  expect(ruleName).to.exist;
+  expect(ruleName).to.have.length(1);
+
+  return ruleName[ 0 ];
+}
+
+/**
+ * Lint node with given rule and configuration expecting one or more reports.
+ *
+ * @param {Object} node
+ * @param {Function} rule
+ * @param {Object} [config]
+ *
+ * @returns {Object}
+ */
+export async function getLintErrors(node, rule, config = {}) {
+  const { ruleName } = await lintNode(node, rule, config);
+
+  // assume
+  expect(ruleName).to.exist;
+  expect(ruleName).to.have.lengthOf.greaterThanOrEqual(1);
+
+  return ruleName;
+}


### PR DESCRIPTION
* adjust callbacks to changes in [bpmnlint-plugin-camunda-compat@0.8.0](https://github.com/camunda/bpmnlint-plugin-camunda-compat/blob/main/CHANGELOG.md#080)
* do not mock lint errors

In the future, I'd like to remove all functionality tightly coupled to linting from the properties panel for architecture reasons. The mapping of lint error to the properties panel should be done outside of the properties panel, probably in `@camunda/linting`. It would also mean that changes in linting are decoupled from the properties panel.

---

Follow-up to https://github.com/camunda/bpmnlint-plugin-camunda-compat/issues/28
Related to https://github.com/bpmn-io/internal-docs/issues/517