### PR TITLE
test(a11y): add basic test scenario

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1334,6 +1334,12 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
+    "axe-core": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
+      "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==",
+      "dev": true
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@testing-library/preact": "^2.0.1",
     "@testing-library/preact-hooks": "^1.1.0",
+    "axe-core": "^4.4.2",
     "babel-loader": "^8.2.2",
     "bpmn-js": "9.2.2",
     "bpmn-moddle": "^7.1.2",

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -15,6 +15,18 @@ import semver from 'semver';
 
 import Modeler from 'bpmn-js/lib/Modeler';
 
+import axe from 'axe-core';
+
+/**
+ * https://www.deque.com/axe/core-documentation/api-documentation/#axe-core-tags
+ */
+const DEFAULT_AXE_RULES = [
+  'best-practice',
+  'wcag2a',
+  'wcag2aa',
+  'cat.semantics'
+];
+
 let PROPERTIES_PANEL_CONTAINER;
 
 global.chai.use(function(chai, utils) {
@@ -166,4 +178,19 @@ function propertiesPanelSatisfies(versionRange) {
   const version = require('@bpmn-io/properties-panel/package.json').version;
 
   return semver.satisfies(version, versionRange, { includePrerelease: true });
+}
+
+export async function expectNoViolations(node, options = {}) {
+  const {
+    rules,
+    ...rest
+  } = options;
+
+  const results = await axe.run(node, {
+    runOnly: rules || DEFAULT_AXE_RULES,
+    ...rest
+  });
+
+  expect(results.passes).to.be.not.empty;
+  expect(results.violations).to.be.empty;
 }

--- a/test/fixtures/a11y.bpmn
+++ b/test/fixtures/a11y.bpmn
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_14uq8gy" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0-nightly.20211212" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.16.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0gfnv2r</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0gfnv2r" sourceRef="StartEvent_1" targetRef="ServiceTask_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_1414k8u</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1414k8u" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
+    <bpmn:serviceTask id="ServiceTask_1" camunda:asyncBefore="true">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="Input_1">
+            <camunda:map>
+              <camunda:entry key="Entry_1">value</camunda:entry>
+              <camunda:entry key="Entry_2">value</camunda:entry>
+              <camunda:entry key="Entry_3">value</camunda:entry>
+            </camunda:map>
+          </camunda:inputParameter>
+          <camunda:inputParameter name="Input_2" />
+          <camunda:inputParameter name="Input_3" />
+          <camunda:outputParameter name="Output_1" />
+          <camunda:outputParameter name="Output_2" />
+          <camunda:outputParameter name="Output_3" />
+        </camunda:inputOutput>
+        <camunda:connector>
+          <camunda:inputOutput>
+            <camunda:inputParameter name="ConnectorInput_1" />
+            <camunda:inputParameter name="ConnectorInput_2" />
+            <camunda:outputParameter name="ConnectorOutput_1" />
+            <camunda:outputParameter name="ConnectorOutput_1" />
+          </camunda:inputOutput>
+          <camunda:connectorId>Connector_1</camunda:connectorId>
+        </camunda:connector>
+        <camunda:executionListener class="class" event="start">
+          <camunda:field name="FieldInjection_1">
+            <camunda:string>value</camunda:string>
+          </camunda:field>
+        </camunda:executionListener>
+        <camunda:properties>
+          <camunda:property name="Extension_1" value="value" />
+          <camunda:property name="Extension_2" value="value" />
+        </camunda:properties>
+        <camunda:field name="Fieldinjection_1">
+          <camunda:string>value</camunda:string>
+        </camunda:field>
+        <camunda:field name="FieldInjection_2">
+          <camunda:string>value</camunda:string>
+        </camunda:field>
+        <camunda:field name="FieldInjection_3">
+          <camunda:string>value</camunda:string>
+        </camunda:field>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0gfnv2r</bpmn:incoming>
+      <bpmn:outgoing>Flow_1414k8u</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNEdge id="Flow_1414k8u_di" bpmnElement="Flow_1414k8u">
+        <di:waypoint x="380" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0gfnv2r_di" bpmnElement="Flow_0gfnv2r">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="280" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1he262n_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1w9gxp0_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="280" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -7,6 +7,7 @@ import {
 
 import {
   clearBpmnJS,
+  expectNoViolations,
   setBpmnJS,
   insertCoreStyles,
   insertBpmnStyles
@@ -79,7 +80,8 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
       moddleExtensions = {
         zeebe: ZeebeModdle
       },
-      description = {}
+      description = {},
+      layout = {}
     } = options;
 
     clearBpmnJS();
@@ -93,7 +95,8 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
       moddleExtensions,
       propertiesPanel: {
         parent: propertiesContainer,
-        description
+        description,
+        layout
       },
       ...options
     });
@@ -727,6 +730,79 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
       // then
       // fire events
       expect(spy).to.have.been.calledTwice;
+    });
+
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+
+      // (0) this test needs some time
+      this.timeout(5000);
+
+      const diagramXml = require('test/fixtures/a11y.bpmn').default;
+
+      // (1) ensure fully opened properties panel
+      let modeler;
+      await act(async () => {
+        const result = await createModeler(
+          diagramXml,
+          {
+            additionalModules: [
+              CamundaModdleExtension,
+              BpmnPropertiesPanel,
+              BpmnPropertiesProvider,
+              CamundaPropertiesProvider
+            ],
+            moddleExtensions: {
+              camunda: CamundaModdle
+            },
+            layout: {
+              groups: {
+                'general': { open: true },
+                'documentation': { open: true },
+                'multiInstance': { open: true },
+                'CamundaPlatform__Implementation': { open: true },
+                'CamundaPlatform__AsynchronousContinuations': { open: true },
+                'CamundaPlatform__JobExecution': { open: true },
+                'CamundaPlatform__Input': { open: true },
+                'CamundaPlatform__Output': { open: true },
+                'CamundaPlatform__ConnectorInput': { open: true },
+                'CamundaPlatform__ConnectorOutput': { open: true },
+                'CamundaPlatform__ExecutionListener': { open: true },
+                'CamundaPlatform__ExtensionProperties': { open: true },
+                'CamundaPlatform__FieldInjection': { open: true }
+              }
+            }
+          }
+        );
+        modeler = result.modeler;
+      });
+
+      const selection = modeler.get('selection');
+      const elementRegistry = modeler.get('elementRegistry');
+
+      await act(() => selection.select(elementRegistry.get('ServiceTask_1')));
+
+      // (2) open nested lists
+      const input1 = domQuery('[data-entry-id="ServiceTask_1-inputParameter-0"]', propertiesContainer);
+      const inputHeader = domQuery('.bio-properties-panel-collapsible-entry-header', input1);
+      const inputMapHeader = domQuery('.bio-properties-panel-list-entry-header', input1);
+      const entry = domQuery('[data-entry-id="ServiceTask_1-inputParameter-0-mapEntry-0"]', input1);
+      const entryHeader = domQuery('.bio-properties-panel-collapsible-entry-header', entry);
+
+      await act(() => {
+        inputHeader.click();
+        inputMapHeader.click();
+        entryHeader.click();
+      });
+
+      // when
+      await expectNoViolations(propertiesContainer);
     });
 
   });


### PR DESCRIPTION
Adds a basic integration test to validate against a defines a11y ruleset ([via axe](https://github.com/dequelabs/axe-core)). I simply added the same rule definitions as we use [for the component tests](https://github.com/bpmn-io/properties-panel/pull/132) in `@bpmn-io/properties-panel`.

Disclaimer: this does not guarantee an accessible properties panel, but at least make sure we continuously track basic a11y issues in a more advanced example (groups are open, nested lists are open). 

----

Slack time work. I will talk about this in one of the next weeklies.
