### PR TITLE
Spike: A11y tests tabbing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6319,6 +6319,12 @@
         "util.promisify": "~1.0.0"
       }
     },
+    "tabbable": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==",
+      "dev": true
+    },
     "table": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
     "sirv-cli": "^1.0.12",
+    "tabbable": "^5.3.3",
     "webpack": "^5.38.1",
     "zeebe-bpmn-moddle": "^0.12.1"
   },

--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -13,6 +13,8 @@ import {
   insertBpmnStyles
 } from 'test/TestHelper';
 
+import { tabbable } from 'tabbable';
+
 import {
   query as domQuery,
   domify
@@ -737,11 +739,9 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
 
   describe('a11y', function() {
 
-    it('should have no violations', async function() {
+    beforeEach(async function() {
 
-      // given
-
-      // (0) this test needs some time
+      // (0) these tests need some time
       this.timeout(5000);
 
       const diagramXml = require('test/fixtures/a11y.bpmn').default;
@@ -800,9 +800,77 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
         inputMapHeader.click();
         entryHeader.click();
       });
+    });
+
+    it('should have no violations', async function() {
+      await expectNoViolations(propertiesContainer);
+    });
+
+
+    it('should retrieve tab order properly', async function() {
+
+      // given
+      const expectedTabOrderSelectors = [
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-arrow',
+        'input#bio-properties-panel-name.bio-properties-panel-input',
+        'input#bio-properties-panel-id.bio-properties-panel-input',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-arrow',
+        'textarea#bio-properties-panel-documentation.bio-properties-panel-input',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-arrow',
+        'select#bio-properties-panel-implementationType.bio-properties-panel-input',
+        'input#bio-properties-panel-connectorId.bio-properties-panel-input',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-arrow',
+        'input#bio-properties-panel-asynchronousContinuationBefore.bio-properties-panel-input',
+        'input#bio-properties-panel-asynchronousContinuationAfter.bio-properties-panel-input',
+        'input#bio-properties-panel-exclusive.bio-properties-panel-input',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-arrow',
+        'input#bio-properties-panel-retryTimeCycle.bio-properties-panel-input',
+        'input#bio-properties-panel-jobPriority.bio-properties-panel-input',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-add-entry',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'input#bio-properties-panel-ServiceTask_1-inputParameter-0-name.bio-properties-panel-input',
+        'select#bio-properties-panel-ServiceTask_1-inputParameter-0-type.bio-properties-panel-input',
+        'button.bio-properties-panel-add-entry',
+        'button.bio-properties-panel-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-add-entry',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-add-entry',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-add-entry',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-add-entry',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-add-entry',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-add-entry',
+        'button.bio-properties-panel-group-header-button.bio-properties-panel-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow',
+        'button.bio-properties-panel-arrow.bio-properties-panel-collapsible-entry-arrow'
+      ];
 
       // when
-      await expectNoViolations(propertiesContainer);
+      const tabOrder = tabbable(propertiesContainer);
+
+      // then
+      expect(toElements(expectedTabOrderSelectors)).to.eql(tabOrder);
+
     });
 
   });
@@ -818,4 +886,8 @@ function getGroup(container, id) {
 
 function getHeaderName(container) {
   return domQuery('.bio-properties-panel-header-label', container).innerText;
+}
+
+function toElements(selectors) {
+  return selectors.map(s => domQuery(s));
 }


### PR DESCRIPTION
Pushing some experiments on an automated [tabbing test](https://pressbooks.library.ryerson.ca/pwaa/chapter/tab-key-navigation-test/). 

Idea: simulate what the browser would do when clicking the TAB key like crazy and verify focus management works as expected in the properties panel. I ended up using [`tabbable`](https://github.com/focus-trap/tabbable) for this as it provides calculating the tab order (and other stuff) out of the box.

Builds on top of: https://github.com/bpmn-io/bpmn-js-properties-panel/pull/702.

----

Disclaimer: I'm not really convinced that tabbing is something that should be automated, but rather a manual activity, as it should also contain some visual validation. Still, I wanted to try out what's possible. I will talk about this in one of the next weeklies and I am happy to close this one afterward. 


