### PR TITLE
Explicitly bind undo/redo shortcuts to properties container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -455,6 +455,46 @@
         "diagram-js": "^8.1.2",
         "min-dash": "^3.7.0",
         "min-dom": "^3.1.3"
+      },
+      "dependencies": {
+        "diagram-js": {
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.8.0.tgz",
+          "integrity": "sha512-isDblySC/k8dOUA1yevLPa0rdXT6Zv6+S6ZFv4CUZBk4Bgtv+3MJdnL+hVzeKPVuvlYGsEM42AyXHCW+35QJQg==",
+          "dev": true,
+          "requires": {
+            "css.escape": "^1.5.1",
+            "didi": "^8.0.0",
+            "hammerjs": "^2.0.1",
+            "inherits-browser": "0.0.1",
+            "min-dash": "^3.5.2",
+            "min-dom": "^3.2.0",
+            "object-refs": "^0.3.0",
+            "path-intersection": "^2.2.1",
+            "tiny-svg": "^2.2.2"
+          },
+          "dependencies": {
+            "min-dom": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
+              "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
+              "dev": true,
+              "requires": {
+                "component-event": "^0.1.4",
+                "domify": "^1.3.1",
+                "indexof": "0.0.1",
+                "matches-selector": "^1.2.0",
+                "min-dash": "^3.8.1"
+              }
+            }
+          }
+        },
+        "didi": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.1.tgz",
+          "integrity": "sha512-7oXiXbp8DHE3FfQsVBkc2pwePo3Jy2uyGS9trAeBmfxiZAP4WV23LWokRpMmyl3hlu8OEAsyMxx19i5P6TVaJQ==",
+          "dev": true
+        }
       }
     },
     "@camunda/element-templates-json-schema": {
@@ -2408,9 +2448,9 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.6.0.tgz",
-      "integrity": "sha512-/0KKtGEiBZkXOaKh2lcBevNaObqNGPQWdJSGkM2fbRB5Q9rcahh4CVaI9auObfQnLWdxswHiJO9mhjyf+vn/7w==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.8.0.tgz",
+      "integrity": "sha512-isDblySC/k8dOUA1yevLPa0rdXT6Zv6+S6ZFv4CUZBk4Bgtv+3MJdnL+hVzeKPVuvlYGsEM42AyXHCW+35QJQg==",
       "dev": true,
       "requires": {
         "css.escape": "^1.5.1",
@@ -2425,9 +2465,9 @@
       },
       "dependencies": {
         "didi": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.0.tgz",
-          "integrity": "sha512-PwqTBaYzzfJSyxvpXPcTWF6nDdCKx2mFAU5eup1ZSb5wbaAS9a/HiKdtcAUdie/VMLHoFI50jkYZcA+bhUOugw==",
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.1.tgz",
+          "integrity": "sha512-7oXiXbp8DHE3FfQsVBkc2pwePo3Jy2uyGS9trAeBmfxiZAP4WV23LWokRpMmyl3hlu8OEAsyMxx19i5P6TVaJQ==",
           "dev": true
         },
         "min-dom": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "copy-webpack-plugin": "^9.0.0",
     "cross-env": "^7.0.3",
     "css-loader": "^5.2.6",
-    "diagram-js": "^8.6.0",
+    "diagram-js": "^8.8.0",
     "eslint": "^7.32.0",
     "eslint-plugin-bpmn-io": "^0.13.0",
     "eslint-plugin-import": "^2.23.4",

--- a/src/provider/element-templates/util/templateUtil.js
+++ b/src/provider/element-templates/util/templateUtil.js
@@ -1,5 +1,4 @@
 import { getLabel, setLabel } from 'bpmn-js/lib/features/label-editing/LabelUtil';
-import { createCategoryValue } from 'bpmn-js/lib/features/modeling/behavior/util/CategoryUtil';
 import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
 
 import { isUndefined } from 'min-dash';
@@ -111,8 +110,7 @@ function leftPad(string, length, character) {
 }
 
 function createBlankBusinessObject(element, injector) {
-  const bpmnFactory = injector.get('bpmnFactory'),
-        bpmnJs = injector.get('bpmnjs');
+  const bpmnFactory = injector.get('bpmnFactory');
 
   const bo = getBusinessObject(element),
         newBo = bpmnFactory.create(bo.$type),
@@ -123,10 +121,7 @@ function createBlankBusinessObject(element, injector) {
   }
 
   if (is(element, 'bpmn:Group')) {
-    const definitions = bpmnJs.getDefinitions();
-    const categoryValue = createCategoryValue(definitions, bpmnFactory);
-
-    newBo.categoryValueRef = categoryValue;
+    newBo.categoryValueRef = bpmnFactory.create('bpmn:CategoryValue');
   }
 
   setLabel({ businessObject: newBo }, label);

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -50,7 +50,8 @@ global.chai.use(function(chai, utils) {
 export * from 'bpmn-js/test/helper';
 
 export {
-  createCanvasEvent
+  createCanvasEvent,
+  createEvent
 } from 'bpmn-js/test/util/MockEvents';
 
 export function bootstrapPropertiesPanel(diagram, options, locals) {

--- a/test/util/KeyEvents.js
+++ b/test/util/KeyEvents.js
@@ -1,0 +1,29 @@
+import {
+  assign,
+  isString,
+  omit
+} from 'min-dash';
+
+/**
+ * Create a fake key event for testing purposes.
+ *
+ * @param {String|number} key the key or keyCode/charCode
+ * @param {Object} [attrs]
+ * @param {string} [attrs.type]
+ *
+ * @return {Event}
+ */
+export function createKeyEvent(key, attrs) {
+  if (!attrs) {
+    attrs = {};
+  }
+
+  var event = document.createEvent('Events') || new document.defaultView.CustomEvent('keyEvent');
+
+  // init and mark as bubbles / cancelable
+  event.initEvent(attrs.type || 'keydown', false, true);
+
+  var keyAttrs = isString(key) ? { key: key } : { keyCode: key, which: key };
+
+  return assign(event, keyAttrs, omit(attrs, [ 'type' ]));
+}


### PR DESCRIPTION
This follows https://github.com/bpmn-io/diagram-js/pull/662 and adds explicit handling of  undo/redo keyboard shortcuts on the properties panel to trigger diagram undo/redo.


-----

Depends on https://github.com/bpmn-io/diagram-js/pull/665 and backports (https://github.com/bpmn-io/diagram-js/pull/664, https://github.com/bpmn-io/diagram-js/pull/663)