### PR TITLE
test: incorporate logging util

### DIFF
--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -11,7 +11,8 @@ import {
   setBpmnJS,
   insertCoreStyles,
   insertBpmnStyles,
-  withPropertiesPanel
+  withPropertiesPanel,
+  enableLogging
 } from 'test/TestHelper';
 
 import {
@@ -105,6 +106,8 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
       },
       ...options
     });
+
+    enableLogging && enableLogging(modeler, !!singleStart);
 
     setBpmnJS(modeler);
 


### PR DESCRIPTION
This incorporates the verbose output logging utility shipped with recent bpmn-js releases: https://github.com/bpmn-io/bpmn-js/pull/1685.