### PR TITLE
fix: ensure `elementTemplates.createElement` supports latest features

### DIFF
--- a/src/provider/cloud-element-templates/create/TemplateElementFactory.js
+++ b/src/provider/cloud-element-templates/create/TemplateElementFactory.js
@@ -11,6 +11,7 @@ import TaskDefinitionTypeBindingProvider from './TaskDefinitionTypeBindingProvid
 import InputBindingProvider from './InputBindingProvider';
 import OutputBindingProvider from './OutputBindingProvider';
 import TaskHeaderBindingProvider from './TaskHeaderBindingProvider';
+import ZeebePropertiesProvider from './ZeebePropertiesProvider';
 
 import {
   EXTENSION_BINDING_TYPES,
@@ -18,7 +19,8 @@ import {
   ZEEBE_TASK_DEFINITION_TYPE_TYPE,
   ZEBBE_INPUT_TYPE,
   ZEEBE_OUTPUT_TYPE,
-  ZEEBE_TASK_HEADER_TYPE
+  ZEEBE_TASK_HEADER_TYPE,
+  ZEBBE_PROPERTY_TYPE
 } from '../util/bindingTypes';
 
 export default class TemplateElementFactory {
@@ -31,6 +33,7 @@ export default class TemplateElementFactory {
     this._providers = {
       [PROPERTY_TYPE]: PropertyBindingProvider,
       [ZEEBE_TASK_DEFINITION_TYPE_TYPE]: TaskDefinitionTypeBindingProvider,
+      [ZEBBE_PROPERTY_TYPE]: ZeebePropertiesProvider,
       [ZEBBE_INPUT_TYPE]: InputBindingProvider,
       [ZEEBE_OUTPUT_TYPE]: OutputBindingProvider,
       [ZEEBE_TASK_HEADER_TYPE]: TaskHeaderBindingProvider

--- a/src/provider/cloud-element-templates/create/TemplateElementFactory.js
+++ b/src/provider/cloud-element-templates/create/TemplateElementFactory.js
@@ -23,6 +23,8 @@ import {
   ZEBBE_PROPERTY_TYPE
 } from '../util/bindingTypes';
 
+import { applyConditions } from '../Condition';
+
 export default class TemplateElementFactory {
 
   constructor(bpmnFactory, elementFactory, moddle) {
@@ -50,8 +52,7 @@ export default class TemplateElementFactory {
 
     const {
       appliesTo,
-      elementType,
-      properties
+      elementType
     } = template;
 
     const elementFactory = this._elementFactory;
@@ -84,6 +85,8 @@ export default class TemplateElementFactory {
     if (hasIcon(template)) {
       this._setModelerTemplateIcon(element, template);
     }
+
+    const { properties } = applyConditions(element, template);
 
     // (5) apply properties
     properties.forEach(function(property) {

--- a/src/provider/cloud-element-templates/create/ZeebePropertiesProvider.js
+++ b/src/provider/cloud-element-templates/create/ZeebePropertiesProvider.js
@@ -1,0 +1,30 @@
+import {
+  createZeebeProperty,
+  ensureExtension,
+  shouldUpdate
+} from '../CreateHelper';
+
+
+export default class ZeebePropertiesProvider {
+  static create(element, options) {
+    const {
+      property,
+      bpmnFactory
+    } = options;
+
+    const {
+      binding,
+      value
+    } = property;
+
+    const zeebeProperties = ensureExtension(element, 'zeebe:Properties', bpmnFactory);
+
+    if (!shouldUpdate(value, property)) {
+      return;
+    }
+
+    const zeebeProperty = createZeebeProperty(binding, value, bpmnFactory);
+    zeebeProperty.$parent = zeebeProperties;
+    zeebeProperties.get('properties').push(zeebeProperty);
+  }
+}

--- a/src/provider/cloud-element-templates/util/bindingTypes.js
+++ b/src/provider/cloud-element-templates/util/bindingTypes.js
@@ -1,5 +1,6 @@
 export const PROPERTY_TYPE = 'property';
 
+export const ZEBBE_PROPERTY_TYPE = 'zeebe:property';
 export const ZEBBE_INPUT_TYPE = 'zeebe:input';
 export const ZEEBE_OUTPUT_TYPE = 'zeebe:output';
 export const ZEEBE_PROPERTY_TYPE = 'zeebe:property';

--- a/test/spec/provider/cloud-element-templates/ElementTemplates.spec.js
+++ b/test/spec/provider/cloud-element-templates/ElementTemplates.spec.js
@@ -314,6 +314,34 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
     }));
 
 
+    it('should not create conditional properties', inject(function(elementTemplates) {
+
+      // given
+      const template = require('./fixtures/condition.json');
+
+      // when
+      const element = elementTemplates.createElement(template);
+
+      const businessObject = getBusinessObject(element);
+
+      // then
+      // expect properties
+      expect(businessObject.get('customProperty')).to.be.undefined;
+
+      // expect ioMapping
+      const ioMapping = findExtension(businessObject, 'zeebe:IoMapping');
+      expect(ioMapping).to.be.undefined;
+
+      // expect taskHeaders
+      const taskHeaders = findExtension(businessObject, 'zeebe:TaskHeaders');
+      expect(taskHeaders).to.be.undefined;
+
+      // expect taskDefinition
+      const taskDefinition = findExtension(businessObject, 'zeebe:TaskDefinition');
+      expect(taskDefinition).to.be.undefined;
+    }));
+
+
     it('should throw error - no template', inject(function(elementTemplates) {
 
       // given

--- a/test/spec/provider/cloud-element-templates/create/TemplateElementFactory.spec.js
+++ b/test/spec/provider/cloud-element-templates/create/TemplateElementFactory.spec.js
@@ -168,6 +168,29 @@ describe('provider/cloud-element-templates - TemplateElementFactory', function()
     }));
 
 
+    it('should handle <zeebe:property>', inject(function(templateElementFactory) {
+
+      // given
+      const elementTemplate = findTemplate('example.camunda.ZeebePropertyBinding');
+
+      // when
+      const element = templateElementFactory.create(elementTemplate);
+
+      const zeebeProperties = findExtension(element, 'zeebe:Properties');
+      const properties = zeebeProperties.properties;
+
+      // then
+      expect(properties).to.exist;
+      expect(properties).to.jsonEqual([
+        {
+          $type: 'zeebe:Property',
+          name: 'customPropertyName',
+          value: 'propertyValue'
+        }
+      ]);
+    }));
+
+
     it('should handle <zeebe:taskDefinition:type>', inject(function(templateElementFactory) {
 
       // given

--- a/test/spec/provider/cloud-element-templates/create/TemplatesElementFactory.json
+++ b/test/spec/provider/cloud-element-templates/create/TemplatesElementFactory.json
@@ -113,6 +113,23 @@
   },
   {
     "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Zeebe:property binding",
+    "id": "example.camunda.ZeebePropertyBinding",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "value": "propertyValue",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "customPropertyName"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Task definition type binding",
     "id": "example.camunda.TaskDefinitionTypeBinding",
     "appliesTo": [


### PR DESCRIPTION
- `zeebe:property` bindings (cf. https://github.com/bpmn-io/bpmn-js-properties-panel/issues/731)
- optional bindings (cf. https://github.com/bpmn-io/bpmn-js-properties-panel/issues/761)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
