### PR TITLE
chore: add connectors extension to dev setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "babel-loader": "^8.2.2",
         "babel-plugin-istanbul": "^6.1.1",
         "bpmn-js": "9.4.1",
+        "bpmn-js-connectors-extension": "^0.4.1",
         "bpmn-moddle": "^7.1.2",
         "camunda-bpmn-js-behaviors": "^0.2.0",
         "camunda-bpmn-moddle": "^7.0.1",
@@ -74,7 +75,7 @@
         "@bpmn-io/properties-panel": "^0.21.0",
         "bpmn-js": "8.x || 9.x",
         "camunda-bpmn-js-behaviors": "0.2.x",
-        "diagram-js": "^9.0.0"
+        "diagram-js": "7.x || 8.x"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -610,12 +611,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.2.tgz",
       "integrity": "sha512-Wpq46GzfER5kVkqFCJtHTXsdlqh6SRPA60jTrKECQ1cl84/ALpQJrqAFlEXpue+Lxi7/6xzFIxC5V3UsS/x9aA==",
-      "dev": true
-    },
-    "node_modules/@bpmn-io/element-templates-icons-renderer/node_modules/tiny-svg": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.3.tgz",
-      "integrity": "sha512-u5KGg889pD1W2c9GlLrTnAGzIkAO00/VXZGyzeiGHw+b9er8McLO0SnhxPQQDwDqFO0MrJ825AEsRUoTiDZFuQ==",
       "dev": true
     },
     "node_modules/@bpmn-io/element-templates-validator": {
@@ -2071,6 +2066,20 @@
         "tiny-svg": "^2.2.4"
       }
     },
+    "node_modules/bpmn-js-connectors-extension": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/bpmn-js-connectors-extension/-/bpmn-js-connectors-extension-0.4.1.tgz",
+      "integrity": "sha512-H8CjR0EaljddIJYtgdbJe8jz8NV6suvSJMY0VcRJS06E8AFHM0GzQ03V/x6ydMigNlV0TARVQm7ZJKvbypO7WA==",
+      "dev": true,
+      "dependencies": {
+        "min-dom": "^3.2.1",
+        "tiny-svg": "^2.2.4"
+      },
+      "peerDependencies": {
+        "bpmn-js": ">= 8.7",
+        "diagram-js": ">= 7.8"
+      }
+    },
     "node_modules/bpmn-js/node_modules/bpmn-moddle": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-7.1.3.tgz",
@@ -2128,12 +2137,6 @@
         "moddle": "^5.0.2",
         "saxen": "^8.1.2"
       }
-    },
-    "node_modules/bpmn-js/node_modules/tiny-svg": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.4.tgz",
-      "integrity": "sha512-NOi39lBknf4UdDEahNkbEAJnzhu1ZcN2j75IS2vLRmIhsfxdZpTChfLKBcN1ShplVmPIXJAIafk6YY5/Aa80lQ==",
-      "dev": true
     },
     "node_modules/bpmn-moddle": {
       "version": "7.1.2",
@@ -8098,9 +8101,9 @@
       "dev": true
     },
     "node_modules/tiny-svg": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.2.tgz",
-      "integrity": "sha512-u6zCuMkDR/3VAh83X7hDRn/pi0XhwG2ycuNS0cTFtQjGdOG2tSvEb8ds65VeGWc3H6PUjJKeunueXqgkZqtMsg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.4.tgz",
+      "integrity": "sha512-NOi39lBknf4UdDEahNkbEAJnzhu1ZcN2j75IS2vLRmIhsfxdZpTChfLKBcN1ShplVmPIXJAIafk6YY5/Aa80lQ==",
       "dev": true
     },
     "node_modules/tinydate": {
@@ -9115,12 +9118,6 @@
           "version": "8.0.2",
           "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.2.tgz",
           "integrity": "sha512-Wpq46GzfER5kVkqFCJtHTXsdlqh6SRPA60jTrKECQ1cl84/ALpQJrqAFlEXpue+Lxi7/6xzFIxC5V3UsS/x9aA==",
-          "dev": true
-        },
-        "tiny-svg": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.3.tgz",
-          "integrity": "sha512-u5KGg889pD1W2c9GlLrTnAGzIkAO00/VXZGyzeiGHw+b9er8McLO0SnhxPQQDwDqFO0MrJ825AEsRUoTiDZFuQ==",
           "dev": true
         }
       }
@@ -10381,13 +10378,17 @@
             "moddle": "^5.0.2",
             "saxen": "^8.1.2"
           }
-        },
-        "tiny-svg": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.4.tgz",
-          "integrity": "sha512-NOi39lBknf4UdDEahNkbEAJnzhu1ZcN2j75IS2vLRmIhsfxdZpTChfLKBcN1ShplVmPIXJAIafk6YY5/Aa80lQ==",
-          "dev": true
         }
+      }
+    },
+    "bpmn-js-connectors-extension": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/bpmn-js-connectors-extension/-/bpmn-js-connectors-extension-0.4.1.tgz",
+      "integrity": "sha512-H8CjR0EaljddIJYtgdbJe8jz8NV6suvSJMY0VcRJS06E8AFHM0GzQ03V/x6ydMigNlV0TARVQm7ZJKvbypO7WA==",
+      "dev": true,
+      "requires": {
+        "min-dom": "^3.2.1",
+        "tiny-svg": "^2.2.4"
       }
     },
     "bpmn-moddle": {
@@ -14907,9 +14908,9 @@
       "dev": true
     },
     "tiny-svg": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.2.tgz",
-      "integrity": "sha512-u6zCuMkDR/3VAh83X7hDRn/pi0XhwG2ycuNS0cTFtQjGdOG2tSvEb8ds65VeGWc3H6PUjJKeunueXqgkZqtMsg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.4.tgz",
+      "integrity": "sha512-NOi39lBknf4UdDEahNkbEAJnzhu1ZcN2j75IS2vLRmIhsfxdZpTChfLKBcN1ShplVmPIXJAIafk6YY5/Aa80lQ==",
       "dev": true
     },
     "tinydate": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "babel-loader": "^8.2.2",
     "babel-plugin-istanbul": "^6.1.1",
     "bpmn-js": "9.4.1",
+    "bpmn-js-connectors-extension": "^0.4.1",
     "bpmn-moddle": "^7.1.2",
     "camunda-bpmn-js-behaviors": "^0.2.0",
     "camunda-bpmn-moddle": "^7.0.1",

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -115,6 +115,11 @@ export function insertCoreStyles() {
     'element-template-chooser.css',
     require('@bpmn-io/element-template-chooser/dist/element-template-chooser.css').default
   );
+
+  insertCSS(
+    'connectors-extension.css',
+    require('bpmn-js-connectors-extension/dist/connectors-extension.css').default
+  );
 }
 
 export function insertBpmnStyles() {

--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -36,6 +36,7 @@ import CloudElementTemplatesPropertiesProvider from 'src/provider/cloud-element-
 
 import ElementTemplateChooserModule from '@bpmn-io/element-template-chooser';
 import ElementTemplatesIconsRenderer from '@bpmn-io/element-templates-icons-renderer';
+import ConnectorsExtensionModule from 'bpmn-js-connectors-extension';
 
 import CamundaBehaviorsModule from 'camunda-bpmn-js-behaviors/lib/camunda-platform';
 import ZeebeBehaviorsModule from 'camunda-bpmn-js-behaviors/lib/camunda-cloud';
@@ -248,7 +249,8 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
           BpmnPropertiesProvider,
           CloudElementTemplatesPropertiesProvider,
           ElementTemplateChooserModule,
-          ElementTemplatesIconsRenderer
+          ElementTemplatesIconsRenderer,
+          ConnectorsExtensionModule
         ],
         moddleExtensions: {
           zeebe: ZeebeModdle


### PR DESCRIPTION
This helps with manually testing `elementTemplates.createElement`.

![Recording 2022-09-21 at 14 26 49](https://user-images.githubusercontent.com/21984219/191503377-7edf2578-1b9b-4318-a8a9-33c377c0d5b6.gif)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
