### PR TITLE
Update to @bpmn-io/properties-panel@0.25.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,8 +8,7 @@ jobs:
         os: [ ubuntu-latest ]
         node-version: [ 16 ]
         integration-deps:
-        - "@bpmn-io/properties-panel@0.17.x"
-        - "@bpmn-io/properties-panel@0.20.x"
+        - "@bpmn-io/properties-panel@0.25.x"
         - diagram-js@8.x bpmn-js@9.x
         - "" # as defined in package.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: update available variables on commandstack changes ([#393](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/814))
+* `FEAT`: configure feel tooltip placement using the properties panel configuration ([#393](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/814))
+
+### Breaking changes
+This release requires `@bpmn-io/properties-panel@0.25.0` or higher. Older releases of `@bpmn-io/properties-panel` will break the feel editor.
+
 ## 1.11.2
 
 * `FIX`: ensure `ImplementationProps` does not remove empty properties ([#811](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/811))

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "zeebe-bpmn-moddle": "^0.16.0"
   },
   "peerDependencies": {
-    "@bpmn-io/properties-panel": ">= 0.24",
+    "@bpmn-io/properties-panel": ">= 0.25",
     "bpmn-js": ">= 8",
     "camunda-bpmn-js-behaviors": ">= 0.4",
     "diagram-js": ">= 7"

--- a/src/entries/FeelEntryWithContext.js
+++ b/src/entries/FeelEntryWithContext.js
@@ -1,0 +1,5 @@
+import { FeelEntry, FeelTextAreaEntry } from '@bpmn-io/properties-panel';
+import { withTooltipContainer, withVariableContext } from '../provider/HOCs';
+
+export const FeelEntryWithContext = withVariableContext(withTooltipContainer(FeelEntry));
+export const FeelTextAreaEntryWithContext = withVariableContext(withTooltipContainer(FeelTextAreaEntry));

--- a/src/provider/HOCs/index.js
+++ b/src/provider/HOCs/index.js
@@ -1,1 +1,2 @@
 export { withVariableContext } from './withVariableContext';
+export { withTooltipContainer } from './withTooltipContainer';

--- a/src/provider/HOCs/withTooltipContainer.js
+++ b/src/provider/HOCs/withTooltipContainer.js
@@ -1,0 +1,16 @@
+import { useMemo } from '@bpmn-io/properties-panel/preact/hooks';
+import { useService } from '../../hooks';
+
+export function withTooltipContainer(Component) {
+  return props => {
+    const tooltipContainer = useMemo(() => {
+      const config = useService('config');
+
+      return config && config.propertiesPanel && config.propertiesPanel.feelTooltipContainer;
+    }, [ ]);
+
+    return <Component { ...props }
+      tooltipContainer={ tooltipContainer }
+    ></Component>;
+  };
+}

--- a/src/provider/cloud-element-templates/properties/CustomProperties.js
+++ b/src/provider/cloud-element-templates/properties/CustomProperties.js
@@ -7,8 +7,6 @@ import {
 
 import { useService } from '../../../hooks';
 
-import { withVariableContext } from '../../HOCs';
-
 import { PropertyDescription } from '../../element-templates/components/PropertyDescription';
 
 import { getPropertyValue, setPropertyValue } from '../util/propertyUtil';
@@ -19,7 +17,7 @@ import {
   CheckboxEntry, isCheckboxEntryEdited,
   TextAreaEntry, isTextAreaEntryEdited,
   TextFieldEntry, isTextFieldEntryEdited,
-  FeelEntry, FeelTextAreaEntry, isFeelEntryEdited
+  isFeelEntryEdited
 } from '@bpmn-io/properties-panel';
 
 import {
@@ -30,6 +28,8 @@ import {
   ZEEBE_PROPERTY_TYPE,
   ZEEBE_TASK_HEADER_TYPE
 } from '../util/bindingTypes';
+
+import { FeelEntryWithContext, FeelTextAreaEntryWithContext } from '../../../entries/FeelEntryWithContext';
 
 const DEFAULT_CUSTOM_GROUP = {
   id: 'ElementTemplates__CustomProperties',
@@ -278,7 +278,7 @@ function FeelTextAreaProperty(props) {
         debounce = useService('debounceInput'),
         translate = useService('translate');
 
-  return withVariableContext(FeelTextAreaEntry)({
+  return FeelTextAreaEntryWithContext({
     debounce,
     element,
     getValue: propertyGetter(element, property),
@@ -311,7 +311,7 @@ function FeelProperty(props) {
         debounce = useService('debounceInput'),
         translate = useService('translate');
 
-  return withVariableContext(FeelEntry)({
+  return FeelEntryWithContext({
     debounce,
     element,
     getValue: propertyGetter(element, property),

--- a/src/provider/zeebe/properties/AssignmentDefinitionProps.js
+++ b/src/provider/zeebe/properties/AssignmentDefinitionProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import { FeelEntry, isFeelEntryEdited } from '@bpmn-io/properties-panel';
+import { isFeelEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   getExtensionElementsList
@@ -17,7 +17,7 @@ import {
   useService
 } from '../../../hooks';
 
-import { withVariableContext } from '../../HOCs';
+import { FeelEntryWithContext } from '../../../entries/FeelEntryWithContext';
 
 
 export function AssignmentDefinitionProps(props) {
@@ -125,7 +125,7 @@ function Assignee(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return withVariableContext(FeelEntry)({
+  return FeelEntryWithContext({
     element,
     id: 'assignmentDefinitionAssignee',
     label: translate('Assignee'),
@@ -212,7 +212,7 @@ function CandidateGroups(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return withVariableContext(FeelEntry)({
+  return FeelEntryWithContext({
     element,
     id: 'assignmentDefinitionCandidateGroups',
     label: translate('Candidate groups'),
@@ -299,7 +299,7 @@ function CandidateUsers(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return withVariableContext(FeelEntry)({
+  return FeelEntryWithContext({
     element,
     id: 'assignmentDefinitionCandidateUsers',
     label: translate('Candidate users'),

--- a/src/provider/zeebe/properties/CalledDecisionProps.js
+++ b/src/provider/zeebe/properties/CalledDecisionProps.js
@@ -5,7 +5,7 @@ import {
 
 import {
   TextFieldEntry, isTextFieldEntryEdited,
-  FeelEntry, isFeelEntryEdited
+  isFeelEntryEdited
 } from '@bpmn-io/properties-panel';
 
 import {
@@ -18,7 +18,8 @@ import {
 
 import { useService } from '../../../hooks';
 
-import { withVariableContext } from '../../HOCs';
+import { FeelEntryWithContext } from '../../../entries/FeelEntryWithContext';
+
 
 
 export function CalledDecisionProps(props) {
@@ -122,7 +123,7 @@ function DecisionID(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return withVariableContext(FeelEntry)({
+  return FeelEntryWithContext({
     element,
     id,
     label: translate('Decision ID'),

--- a/src/provider/zeebe/properties/ConditionProps.js
+++ b/src/provider/zeebe/properties/ConditionProps.js
@@ -15,11 +15,9 @@ import {
   useService
 } from '../../../hooks';
 
-import { withVariableContext } from '../../HOCs';
+import { isFeelEntryEdited } from '@bpmn-io/properties-panel';
 
-import {
-  FeelEntry, isFeelEntryEdited
-} from '@bpmn-io/properties-panel';
+import { FeelEntryWithContext } from '../../../entries/FeelEntryWithContext';
 
 
 export function ConditionProps(props) {
@@ -104,7 +102,7 @@ function ConditionExpression(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return withVariableContext(FeelEntry)({
+  return FeelEntryWithContext({
     element,
     id: 'conditionExpression',
     label: translate('Condition expression'),

--- a/src/provider/zeebe/properties/InputOutputParameter.js
+++ b/src/provider/zeebe/properties/InputOutputParameter.js
@@ -2,13 +2,13 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import { TextFieldEntry, FeelEntry } from '@bpmn-io/properties-panel';
+import { TextFieldEntry } from '@bpmn-io/properties-panel';
 
 import {
   useService
 } from '../../../hooks';
 
-import { withVariableContext } from '../../HOCs';
+import { FeelEntryWithContext } from '../../../entries/FeelEntryWithContext';
 
 
 export default function InputOutputParameter(props) {
@@ -93,7 +93,7 @@ function SourceProperty(props) {
     return parameter.source;
   };
 
-  return withVariableContext(FeelEntry)({
+  return FeelEntryWithContext({
     bpmnElement: element,
     element: parameter,
     id: idPrefix + '-source',

--- a/src/provider/zeebe/properties/MessageProps.js
+++ b/src/provider/zeebe/properties/MessageProps.js
@@ -5,12 +5,11 @@ import {
 } from 'bpmn-js/lib/util/DiUtil';
 
 import {
-  FeelEntry, isFeelEntryEdited
+  isFeelEntryEdited
 } from '@bpmn-io/properties-panel';
 
 import { useService } from '../../../hooks';
 
-import { withVariableContext } from '../../HOCs';
 
 import {
   getMessage
@@ -23,6 +22,8 @@ import {
 import {
   getExtensionElementsList
 } from '../../../utils/ExtensionElementsUtil';
+
+import { FeelEntryWithContext } from '../../../entries/FeelEntryWithContext';
 
 
 export function MessageProps(props) {
@@ -82,7 +83,7 @@ function MessageName(props) {
     );
   };
 
-  return withVariableContext(FeelEntry)({
+  return FeelEntryWithContext({
     element,
     id: 'messageName',
     label: translate('Name'),
@@ -168,7 +169,7 @@ function SubscriptionCorrelationKey(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return withVariableContext(FeelEntry)({
+  return FeelEntryWithContext({
     element,
     id: 'messageSubscriptionCorrelationKey',
     label: translate('Subscription correlation key'),

--- a/src/provider/zeebe/properties/MultiInstanceProps.js
+++ b/src/provider/zeebe/properties/MultiInstanceProps.js
@@ -4,7 +4,7 @@ import {
 
 import {
   TextFieldEntry, isTextFieldEntryEdited,
-  FeelEntry, isFeelEntryEdited
+  isFeelEntryEdited
 } from '@bpmn-io/properties-panel';
 
 import {
@@ -17,7 +17,7 @@ import {
 
 import { useService } from '../../../hooks';
 
-import { withVariableContext } from '../../HOCs';
+import { FeelEntryWithContext } from '../../../entries/FeelEntryWithContext';
 
 
 export function MultiInstanceProps(props) {
@@ -76,7 +76,7 @@ function InputCollection(props) {
     return setProperty(element, 'inputCollection', value, commandStack, bpmnFactory);
   };
 
-  return withVariableContext(FeelEntry)({
+  return FeelEntryWithContext({
     element,
     id: 'multiInstance-inputCollection',
     label: translate('Input collection'),
@@ -161,7 +161,7 @@ function OutputElement(props) {
     return setProperty(element, 'outputElement', value, commandStack, bpmnFactory);
   };
 
-  return withVariableContext(FeelEntry)({
+  return FeelEntryWithContext({
     element,
     id: 'multiInstance-outputElement',
     label: translate('Output element'),
@@ -202,7 +202,7 @@ function CompletionCondition(props) {
     }
   };
 
-  return withVariableContext(FeelEntry)({
+  return FeelEntryWithContext({
     element,
     id: 'multiInstance-completionCondition',
     label: translate('Completion condition'),

--- a/src/provider/zeebe/properties/TargetProps.js
+++ b/src/provider/zeebe/properties/TargetProps.js
@@ -4,7 +4,7 @@ import {
 } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
-  FeelEntry, isFeelEntryEdited
+  isFeelEntryEdited
 } from '@bpmn-io/properties-panel';
 
 import {
@@ -18,7 +18,7 @@ import {
 
 import { useService } from '../../../hooks';
 
-import { withVariableContext } from '../../HOCs';
+import { FeelEntryWithContext } from '../../../entries/FeelEntryWithContext';
 
 
 export function TargetProps(props) {
@@ -119,7 +119,7 @@ function TargetProcessId(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return withVariableContext(FeelEntry)({
+  return FeelEntryWithContext({
     element,
     id,
     label: translate('Process ID'),

--- a/src/provider/zeebe/properties/TaskDefinitionProps.js
+++ b/src/provider/zeebe/properties/TaskDefinitionProps.js
@@ -2,7 +2,7 @@ import {
   getBusinessObject
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import { FeelEntry, isFeelEntryEdited } from '@bpmn-io/properties-panel';
+import { isFeelEntryEdited } from '@bpmn-io/properties-panel';
 
 import {
   getExtensionElementsList
@@ -14,11 +14,11 @@ import {
 
 import { useService } from '../../../hooks';
 
-import { withVariableContext } from '../../HOCs';
-
 import {
   isZeebeServiceTask
 } from '../utils/ZeebeServiceTaskUtil';
+
+import { FeelEntryWithContext } from '../../../entries/FeelEntryWithContext';
 
 
 export function TaskDefinitionProps(props) {
@@ -122,7 +122,7 @@ function TaskDefinitionType(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return withVariableContext(FeelEntry)({
+  return FeelEntryWithContext({
     element,
     id,
     label: translate('Type'),
@@ -210,7 +210,7 @@ function TaskDefinitionRetries(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return withVariableContext(FeelEntry)({
+  return FeelEntryWithContext({
     element,
     id,
     label: translate('Retries'),

--- a/src/provider/zeebe/properties/TimerProps.js
+++ b/src/provider/zeebe/properties/TimerProps.js
@@ -7,8 +7,6 @@ import {
   useService
 } from '../../../hooks';
 
-import { withVariableContext } from '../../HOCs';
-
 import {
   isTimerSupported,
   getTimerEventDefinition,
@@ -16,9 +14,11 @@ import {
 } from '../../../utils/EventDefinitionUtil';
 
 import {
-  FeelEntry, isFeelEntryEdited,
+  isFeelEntryEdited,
   SelectEntry, isSelectEntryEdited,
 } from '@bpmn-io/properties-panel';
+
+import { FeelEntryWithContext } from '../../../entries/FeelEntryWithContext';
 
 
 /**
@@ -232,7 +232,7 @@ function TimerEventDefinitionValue(props) {
     });
   };
 
-  return withVariableContext(FeelEntry)({
+  return FeelEntryWithContext({
     element,
     id: legacyId || 'timerEventDefinitionValue',
     label: label || translate('Value'),

--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -63,6 +63,8 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
 
   afterEach(() => cleanup());
 
+  let container;
+
   beforeEach(function() {
     modelerContainer = document.createElement('div');
     modelerContainer.classList.add('modeler-container');
@@ -70,7 +72,7 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
     propertiesContainer = document.createElement('div');
     propertiesContainer.classList.add('properties-container');
 
-    const container = TestContainer.get(this);
+    container = TestContainer.get(this);
 
     container.appendChild(modelerContainer);
     container.appendChild(propertiesContainer);
@@ -103,6 +105,7 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
       moddleExtensions,
       propertiesPanel: {
         parent: propertiesContainer,
+        feelTooltipContainer: container,
         description,
         layout
       },

--- a/test/spec/provider/HOCs/withTooltipContainer.bpmn
+++ b/test/spec/provider/HOCs/withTooltipContainer.bpmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_17tkbpr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_1i2l690" isExecutable="true">
+    <bpmn:serviceTask id="Task_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1i2l690">
+      <bpmndi:BPMNShape id="Activity_056sw82_di" bpmnElement="Task_1">
+        <dc:Bounds x="400" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/HOCs/withTooltipContainer.spec.js
+++ b/test/spec/provider/HOCs/withTooltipContainer.spec.js
@@ -1,0 +1,115 @@
+import TestContainer from 'mocha-test-container-support';
+import { render } from '@testing-library/preact';
+
+import CoreModule from 'bpmn-js/lib/core';
+import { bootstrapModeler, inject } from 'bpmn-js/test/helper';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import { withTooltipContainer } from 'src/provider/HOCs';
+
+import xml from './withTooltipContainer.bpmn';
+import { BpmnPropertiesPanelContext } from '../../../../src/context';
+
+describe('HOCs - withTooltipContainer.js', function() {
+
+  const testModules = [
+    CoreModule
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+
+  function bootstrap(diagramXML, options) {
+    return bootstrapModeler(diagramXML, {
+      container,
+      modules: testModules,
+      moddleExtensions,
+      ...options
+    });
+  }
+
+  beforeEach(bootstrap(xml));
+
+  it('should supply tooltipContainer to Component', inject(function(injector, config) {
+
+    // given
+    const component = sinon.spy();
+    config.propertiesPanel = {
+      feelTooltipContainer: '#foo'
+    };
+
+    // when
+    createTooltipComponent({
+      component,
+      injector,
+      container
+    });
+
+
+    // then
+    expect(component).to.have.been.calledWith(
+      sinon.match({
+        tooltipContainer: '#foo'
+      })
+    );
+
+  }));
+
+
+  it('should not supply default', inject(function(injector) {
+
+    // given
+    const component = sinon.spy();
+
+
+    // when
+    createTooltipComponent({
+      component,
+      injector,
+      container
+    });
+
+
+    // then
+    expect(component).to.have.been.calledWith(
+      sinon.match({
+        tooltipContainer: undefined
+      })
+    );
+
+  }));
+
+});
+
+
+function createTooltipComponent(options) {
+  const {
+    component,
+    injector,
+    container,
+  } = options;
+
+  const context = {
+    getService: injector.get
+  };
+
+  const WrappedComponent = withTooltipContainer(component);
+
+  return render(
+    <BpmnPropertiesPanelContext.Provider value={ context }>
+      <WrappedComponent />
+    </BpmnPropertiesPanelContext.Provider>,
+    {
+      container
+    }
+  );
+}


### PR DESCRIPTION
The dev dependency update was already merged by renovate, this integrates the new features

- Restrict Tooltip placement
- Update FEEL variables on change (this breaks focus on `properties-panel<0.25`)

![Recording 2022-11-23 at 11 20 20](https://user-images.githubusercontent.com/21984219/203522691-95af6bf5-7c04-4ad1-bc0c-f65f59cbbf3c.gif)


<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
