### PR TITLE
Fix templates render for properties with same bindings

### DIFF
--- a/test/spec/provider/cloud-element-templates/ElementTemplateConditionChecker.spec.js
+++ b/test/spec/provider/cloud-element-templates/ElementTemplateConditionChecker.spec.js
@@ -92,6 +92,33 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
     );
 
 
+    it('should switch between conditional properties', inject(
+      async function(elementRegistry, modeling) {
+
+        // given
+        const element = elementRegistry.get('Task_1');
+        let businessObject = getBusinessObject(element);
+        changeTemplate(element, template);
+
+        // when
+        modeling.updateProperties(element, {
+          name: 'foo'
+        });
+
+        // then
+        expectPropertyValue(businessObject, 'default value');
+
+        // when
+        modeling.updateProperties(element, {
+          name: 'bar'
+        });
+
+        // then
+        expectPropertyValue(businessObject, 'default value v2');
+      })
+    );
+
+
     it('undo', inject(function(commandStack, elementRegistry, modeling) {
 
       // given
@@ -184,6 +211,34 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
 
         // then
         expect(taskDefinition).to.be.undefined;
+      })
+    );
+
+
+    it('should switch between conditional properties', inject(
+      async function(elementRegistry, modeling) {
+
+        // given
+        const element = elementRegistry.get('Task_1');
+        let businessObject = getBusinessObject(element);
+
+        changeTemplate(element, template);
+
+        // when
+        modeling.updateProperties(element, {
+          name: 'foo'
+        });
+
+        // then
+        expectTaskDefinitionType(businessObject, 'someValue');
+
+        // when
+        modeling.updateProperties(element, {
+          name: 'foobar'
+        });
+
+        // then
+        expectTaskDefinitionType(businessObject, 'someValue2');
       })
     );
 
@@ -312,6 +367,34 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
     );
 
 
+    it('should switch between conditional properties', inject(
+      async function(elementRegistry, modeling) {
+
+        // given
+        const element = elementRegistry.get('Task_1');
+        changeTemplate(element, template);
+
+        const businessObject = getBusinessObject(element);
+
+        // when
+        modeling.updateProperties(element, {
+          name: 'foo'
+        });
+
+        // then
+        expectOutputTarget(businessObject, '');
+
+        // when
+        modeling.updateProperties(element, {
+          name: 'foobar'
+        });
+
+        // then
+        expectOutputTarget(businessObject, 'someValue');
+      })
+    );
+
+
     it('undo', inject(function(commandStack, elementRegistry, modeling) {
 
       // given
@@ -433,6 +516,34 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
     );
 
 
+    it('should switch between conditional properties', inject(
+      async function(elementRegistry, modeling) {
+
+        // given
+        const element = elementRegistry.get('Task_1');
+        changeTemplate(element, template);
+
+        const businessObject = getBusinessObject(element);
+
+        // when
+        modeling.updateProperties(element, {
+          name: 'foo'
+        });
+
+        // then
+        expectTaskHeaderValue(businessObject, '1');
+
+        // when
+        modeling.updateProperties(element, {
+          name: 'foobar'
+        });
+
+        // then
+        expectTaskHeaderValue(businessObject, '2');
+      })
+    );
+
+
     it('undo', inject(function(commandStack, elementRegistry, modeling) {
 
       // given
@@ -514,6 +625,34 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
       );
 
 
+      it('should switch between conditional properties', inject(
+        async function(elementRegistry, modeling) {
+
+          // given
+          const element = elementRegistry.get('Task_1'),
+                businessObject = getBusinessObject(element);
+
+          changeTemplate(element, template);
+
+          // when
+          modeling.updateProperties(element, {
+            name: 'foo'
+          });
+
+          // then
+          expectZeebePropertyValue(businessObject, '');
+
+          // when
+          modeling.updateProperties(element, {
+            name: 'foobar'
+          });
+
+          // then
+          expectZeebePropertyValue(businessObject, 'someValue');
+        })
+      );
+
+
       it('undo', inject(function(commandStack, elementRegistry, modeling) {
 
         // given
@@ -585,7 +724,6 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
 
         // then
         const zeebeProperties = findExtension(businessObject, 'zeebe:Properties');
-
         expect(zeebeProperties).not.to.exist;
       })
     );
@@ -615,4 +753,43 @@ function changeTemplate(element, newTemplate, oldTemplate) {
 
     return elementTemplates.applyTemplate(element, newTemplate);
   });
+}
+
+function expectPropertyValue(businessObject, value) {
+  const property = businessObject.get('customProperty');
+
+  expect(property).to.exist;
+  expect(property).to.eql(value);
+}
+
+function expectTaskDefinitionType(businessObject, type) {
+  const taskDefinition = findExtension(businessObject, 'zeebe:TaskDefinition');
+
+  expect(taskDefinition).to.exist;
+  expect(taskDefinition.type).to.eql(type);
+}
+
+function expectOutputTarget(businessObject, target) {
+  const ioMapping = findExtension(businessObject, 'zeebe:IoMapping');
+  const outputs = ioMapping.get('zeebe:outputParameters');
+
+  expect(outputs).to.have.lengthOf(1);
+  expect(outputs[0].target).to.eql(target);
+}
+
+
+function expectTaskHeaderValue(businessObject, value) {
+  const taskHeaders = findExtension(businessObject, 'zeebe:TaskHeaders').get('values');
+
+  expect(taskHeaders).to.have.lengthOf(1);
+  expect(taskHeaders[0].value).to.eql(value);
+}
+
+function expectZeebePropertyValue(businessObject, value) {
+  const zeebeProperties = findExtension(businessObject, 'zeebe:Properties');
+  const properties = zeebeProperties.get('zeebe:properties');
+
+  expect(zeebeProperties).to.exist;
+  expect(properties).to.have.lengthOf(1);
+  expect(properties[0].value).to.eql(value);
 }

--- a/test/spec/provider/cloud-element-templates/ElementTemplateConditionChecker.spec.js
+++ b/test/spec/provider/cloud-element-templates/ElementTemplateConditionChecker.spec.js
@@ -106,7 +106,7 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
         });
 
         // then
-        expectPropertyValue(businessObject, 'default value');
+        expectPropertyValue(businessObject, 'nameProp=foo');
 
         // when
         modeling.updateProperties(element, {
@@ -114,7 +114,7 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
         });
 
         // then
-        expectPropertyValue(businessObject, 'default value v2');
+        expectPropertyValue(businessObject, 'nameProp=bar');
       })
     );
 
@@ -230,7 +230,7 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
         });
 
         // then
-        expectTaskDefinitionType(businessObject, 'someValue');
+        expectTaskDefinitionType(businessObject, 'nameProp=foo');
 
         // when
         modeling.updateProperties(element, {
@@ -238,7 +238,7 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
         });
 
         // then
-        expectTaskDefinitionType(businessObject, 'someValue2');
+        expectTaskDefinitionType(businessObject, 'nameProp=foobar');
       })
     );
 
@@ -390,7 +390,7 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
         });
 
         // then
-        expectOutputTarget(businessObject, 'someValue');
+        expectOutputTarget(businessObject, 'nameProp=foobar');
       })
     );
 
@@ -531,7 +531,7 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
         });
 
         // then
-        expectTaskHeaderValue(businessObject, '1');
+        expectTaskHeaderValue(businessObject, 'nameProp=foo');
 
         // when
         modeling.updateProperties(element, {
@@ -539,7 +539,7 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
         });
 
         // then
-        expectTaskHeaderValue(businessObject, '2');
+        expectTaskHeaderValue(businessObject, 'nameProp=foobar');
       })
     );
 
@@ -564,7 +564,7 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
       commandStack.undo();
 
       // then
-      expect(findExtension(businessObject, 'zeebe:TaskHeaders')).to.be.undefined;
+      expect(findExtension(businessObject, 'zeebe:TaskHeaders')).not.to.exist;
 
     }));
 
@@ -585,14 +585,13 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
       commandStack.undo();
 
       // assume
-      expect(findExtension(businessObject, 'zeebe:TaskHeaders')).to.be.undefined;
+      expect(findExtension(businessObject, 'zeebe:TaskHeaders')).not.to.exist;
 
       // when
       commandStack.redo();
 
       // then
       expect(findExtension(businessObject, 'zeebe:TaskHeaders')).to.exist;
-
     }));
 
   });
@@ -648,7 +647,7 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
           });
 
           // then
-          expectZeebePropertyValue(businessObject, 'someValue');
+          expectZeebePropertyValue(businessObject, 'nameProp=foobar');
         })
       );
 

--- a/test/spec/provider/cloud-element-templates/ElementTemplates.spec.js
+++ b/test/spec/provider/cloud-element-templates/ElementTemplates.spec.js
@@ -465,6 +465,52 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
       expect(taskDefinitions[0].get('type')).to.eql('http');
     }));
 
+
+    it('should apply valid dynamic property binding', inject(function(elementRegistry, elementTemplates) {
+
+      // given
+      elementTemplates.set([
+        require('./fixtures/condition-dropdown-dynamic-values.json'),
+        require('./fixtures/condition-dropdown-dynamic-values-1.json')
+      ]);
+
+      const template = elementTemplates.get('condition-dropdown-dynamic-values');
+      const task = elementTemplates.applyTemplate(elementRegistry.get('Task_3'), template);
+
+      // assume
+      expect(
+        task.businessObject.extensionElements.values[0].inputParameters[0].source
+      ).to.eql(
+        'action1'
+      );
+
+      expect(
+        task.businessObject.extensionElements.values[1].type
+      ).to.eql(
+        'action1-value'
+      );
+
+      // when
+      const newTemplate = elementTemplates.get('condition-dropdown-dynamic-values-1');
+      const updatedTask = elementTemplates.applyTemplate(task, newTemplate);
+
+      // then
+      expect(updatedTask).to.exist;
+
+      // assume
+      expect(
+        updatedTask.businessObject.extensionElements.values[0].inputParameters[0].source
+      ).to.eql(
+        'action1'
+      );
+
+      expect(
+        updatedTask.businessObject.extensionElements.values[1].type
+      ).to.eql(
+        'action1-value-2'
+      );
+    }));
+
   });
 
 });

--- a/test/spec/provider/cloud-element-templates/fixtures/condition-dropdown-dynamic-values-1.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/condition-dropdown-dynamic-values-1.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "Condition (dropdown, dynamic values, different binding)",
+  "id": "condition-dropdown-dynamic-values-1",
+  "appliesTo": [
+    "bpmn:Task"
+  ],
+  "properties": [
+    {
+      "id": "operation",
+      "label": "operation",
+      "description": "Operation to be done",
+      "type": "Dropdown",
+      "value": "action1",
+      "choices": [
+        {
+          "name": "Action 1",
+          "value": "action1"
+        },
+        {
+          "name": "Action 2",
+          "value": "action2"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:input",
+        "name": "functionType"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Type",
+      "type": "String",
+      "value": "action1-value-2",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      },
+      "condition": {
+        "equals": "action1",
+        "property": "operation"
+      }
+    },
+    {
+      "label": "Type",
+      "type": "String",
+      "value": "action2-value-2",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      },
+      "condition": {
+        "property": "operation",
+        "equals": "action2"
+      }
+    }
+  ]
+}

--- a/test/spec/provider/cloud-element-templates/fixtures/condition-dropdown-dynamic-values.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/condition-dropdown-dynamic-values.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "Condition (dropdown, dynamic values)",
+  "id": "condition-dropdown-dynamic-values",
+  "appliesTo": [
+    "bpmn:Task"
+  ],
+  "properties": [
+    {
+      "id": "operation",
+      "label": "operation",
+      "description": "Operation to be done",
+      "type": "Dropdown",
+      "value": "action1",
+      "choices": [
+        {
+          "name": "Action 1",
+          "value": "action1"
+        },
+        {
+          "name": "Action 2",
+          "value": "action2"
+        },
+        {
+          "name": "Action 3",
+          "value": "action3"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:input",
+        "name": "functionType"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Type",
+      "type": "String",
+      "value": "action1-value",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      },
+      "condition": {
+        "property": "operation",
+        "equals": "action1"
+      }
+    },
+    {
+      "label": "Type",
+      "type": "String",
+      "value": "action2-value",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      },
+      "condition": {
+        "property": "operation",
+        "equals": "action2"
+      }
+    },
+    {
+      "label": "Type",
+      "type": "String",
+      "value": "action3-value",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      },
+      "condition": {
+        "property": "operation",
+        "equals": "action3"
+      }
+    }
+  ]
+}

--- a/test/spec/provider/cloud-element-templates/fixtures/condition.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/condition.json
@@ -24,8 +24,8 @@
         "name": "customProperty"
       },
       "condition": {
-        "property": "nameProp",
-        "equals": "foo"
+        "equals": "foo",
+        "property": "nameProp"
       }
     },
     {

--- a/test/spec/provider/cloud-element-templates/fixtures/condition.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/condition.json
@@ -6,7 +6,7 @@
   "appliesTo": ["bpmn:Task"],
   "properties": [
     {
-      "id": "parentProperty",
+      "id": "nameProp",
       "label": "name",
       "type": "String",
       "binding": {
@@ -18,13 +18,13 @@
       "id": "otherProperty",
       "label": "property",
       "type": "String",
-      "value": "default value",
+      "value": "nameProp=foo",
       "binding": {
         "type": "property",
         "name": "customProperty"
       },
       "condition": {
-        "property": "parentProperty",
+        "property": "nameProp",
         "equals": "foo"
       }
     },
@@ -32,13 +32,13 @@
       "id": "otherProperty2",
       "label": "property",
       "type": "String",
-      "value": "default value v2",
+      "value": "nameProp=bar",
       "binding": {
         "type": "property",
         "name": "customProperty"
       },
       "condition": {
-        "property": "parentProperty",
+        "property": "nameProp",
         "equals": "bar"
       }
     },
@@ -51,31 +51,31 @@
         "name": "noDefaultProperty"
       },
       "condition": {
-        "property": "parentProperty",
+        "property": "nameProp",
         "equals": "foo"
       }
     },
     {
       "label": "name",
       "type": "String",
-      "value": "someValue",
+      "value": "nameProp=foo",
       "binding": {
         "type": "zeebe:taskDefinition:type"
       },
       "condition": {
-        "property": "parentProperty",
+        "property": "nameProp",
         "equals": "foo"
       }
     },
     {
       "label": "name",
       "type": "String",
-      "value": "someValue2",
+      "value": "nameProp=foobar",
       "binding": {
         "type": "zeebe:taskDefinition:type"
       },
       "condition": {
-        "property": "parentProperty",
+        "property": "nameProp",
         "equals": "foobar"
       }
     },
@@ -88,7 +88,7 @@
         "name": "body"
       },
       "condition": {
-        "property": "parentProperty",
+        "property": "nameProp",
         "oneOf": ["foo", "bar"]
       }
     },
@@ -101,46 +101,46 @@
         "source": "= body"
       },
       "condition": {
-        "property": "parentProperty",
+        "property": "nameProp",
         "equals": "foo"
       }
     },
     {
       "label": "zeebe:output2",
-      "value": "someValue",
+      "value": "nameProp=foobar",
       "type": "String",
       "binding": {
         "type": "zeebe:output",
         "source": "= body"
       },
       "condition": {
-        "property": "parentProperty",
+        "property": "nameProp",
         "equals": "foobar"
       }
     },
     {
       "label": "zeebe:taskHeader",
-      "value": "1",
+      "value": "nameProp=foo",
       "type": "String",
       "binding": {
         "type": "zeebe:taskHeader",
         "key": "someOtherKey"
       },
       "condition": {
-        "property": "parentProperty",
+        "property": "nameProp",
         "equals": "foo"
       }
     },
     {
       "label": "zeebe:taskHeader2",
-      "value": "2",
+      "value": "nameProp=foobar",
       "type": "String",
       "binding": {
         "type": "zeebe:taskHeader",
         "key": "someOtherKey"
       },
       "condition": {
-        "property": "parentProperty",
+        "property": "nameProp",
         "equals": "foobar"
       }
     },
@@ -166,20 +166,20 @@
         "name": "someName"
       },
       "condition": {
-        "property": "parentProperty",
+        "property": "nameProp",
         "equals": "foo"
       }
     },
     {
       "label": "zeebe:property2",
-      "value": "someValue",
+      "value": "nameProp=foobar",
       "type": "String",
       "binding": {
         "type": "zeebe:property",
         "name": "someName"
       },
       "condition": {
-        "property": "parentProperty",
+        "property": "nameProp",
         "equals": "foobar"
       }
     },

--- a/test/spec/provider/cloud-element-templates/fixtures/condition.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/condition.json
@@ -29,6 +29,20 @@
       }
     },
     {
+      "id": "otherProperty2",
+      "label": "property",
+      "type": "String",
+      "value": "default value v2",
+      "binding": {
+        "type": "property",
+        "name": "customProperty"
+      },
+      "condition": {
+        "property": "parentProperty",
+        "equals": "bar"
+      }
+    },
+    {
       "id": "noDefaultProperty",
       "label": "property",
       "type": "Hidden",
@@ -43,6 +57,7 @@
     },
     {
       "label": "name",
+      "type": "String",
       "value": "someValue",
       "binding": {
         "type": "zeebe:taskDefinition:type"
@@ -50,6 +65,18 @@
       "condition": {
         "property": "parentProperty",
         "equals": "foo"
+      }
+    },
+    {
+      "label": "name",
+      "type": "String",
+      "value": "someValue2",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      },
+      "condition": {
+        "property": "parentProperty",
+        "equals": "foobar"
       }
     },
     {
@@ -79,6 +106,19 @@
       }
     },
     {
+      "label": "zeebe:output2",
+      "value": "someValue",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:output",
+        "source": "= body"
+      },
+      "condition": {
+        "property": "parentProperty",
+        "equals": "foobar"
+      }
+    },
+    {
       "label": "zeebe:taskHeader",
       "value": "1",
       "type": "String",
@@ -89,6 +129,19 @@
       "condition": {
         "property": "parentProperty",
         "equals": "foo"
+      }
+    },
+    {
+      "label": "zeebe:taskHeader2",
+      "value": "2",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "someOtherKey"
+      },
+      "condition": {
+        "property": "parentProperty",
+        "equals": "foobar"
       }
     },
     {
@@ -115,6 +168,19 @@
       "condition": {
         "property": "parentProperty",
         "equals": "foo"
+      }
+    },
+    {
+      "label": "zeebe:property2",
+      "value": "someValue",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "someName"
+      },
+      "condition": {
+        "property": "parentProperty",
+        "equals": "foobar"
       }
     },
     {


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/3029

There are 2 issues related to this:
* properties were being compared only by their biding to check which ones need to be added/removed -> this becomes problematic when we have properties with different conditions that share the same binding
* the template is initially applied in full and then the comparisons are made. It compared what needs to be removed but since the bindings are shared, when removing the old conditional property, the binding was removed completely.

**Artifacts to test:**
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/testing-conditional-props/camunda-modeler-testing-conditional-props-linux-x64.tar.gz
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/testing-conditional-props/camunda-modeler-testing-conditional-props-mac.dmg
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/testing-conditional-props/camunda-modeler-testing-conditional-props-mac.zip
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/testing-conditional-props/camunda-modeler-testing-conditional-props-win-ia32.zip
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/testing-conditional-props/camunda-modeler-testing-conditional-props-win-x64.zip



----

Can also be tested locally via

```
npm install
npm run start:cloud-templates
```