### PR TITLE
feat: don't sort input output mappings visually

### DIFF
--- a/src/provider/zeebe/properties/InputProps.js
+++ b/src/provider/zeebe/properties/InputProps.js
@@ -48,7 +48,8 @@ export function InputProps({ element, injector }) {
 
   return {
     items,
-    add: addFactory({ element, bpmnFactory, commandStack })
+    add: addFactory({ element, bpmnFactory, commandStack }),
+    shouldSort: false
   };
 }
 

--- a/src/provider/zeebe/properties/OutputProps.js
+++ b/src/provider/zeebe/properties/OutputProps.js
@@ -48,7 +48,8 @@ export function OutputProps({ element, injector }) {
 
   return {
     items,
-    add: addFactory({ element, bpmnFactory, commandStack })
+    add: addFactory({ element, bpmnFactory, commandStack }),
+    shouldSort: false
   };
 }
 

--- a/test/spec/provider/zeebe/InputProps.bpmn
+++ b/test/spec/provider/zeebe/InputProps.bpmn
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.6.0">
   <bpmn:process id="Process_1" isExecutable="true">
-    <bpmn:serviceTask id="ServiceTask_1">
+    <bpmn:serviceTask id="ServiceTask_1" name="ServiceTask_1">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:input source="= inputSourceValue1" target="inputTargetValue1" />
@@ -23,11 +23,22 @@
     <bpmn:serviceTask id="ServiceTask_noIoMapping" name="no IoMapping">
       <bpmn:extensionElements />
     </bpmn:serviceTask>
+    <bpmn:serviceTask id="UnsortedServiceTask" name="UnsortedServiceTask">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="" target="5" />
+          <zeebe:input source="" target="z" />
+          <zeebe:input source="" target="a" />
+          <zeebe:input source="" target="1" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="ServiceTask_0rud1s3_di" bpmnElement="ServiceTask_1">
         <dc:Bounds x="160" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ReceiveTask_0mkif7n_di" bpmnElement="ReceiveTask_1">
         <dc:Bounds x="320" y="240" width="100" height="80" />
@@ -40,6 +51,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_08s4ehk_di" bpmnElement="ServiceTask_noIoMapping">
         <dc:Bounds x="420" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_15fgyss_di" bpmnElement="UnsortedServiceTask">
+        <dc:Bounds x="650" y="160" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/zeebe/InputProps.spec.js
+++ b/test/spec/provider/zeebe/InputProps.spec.js
@@ -121,6 +121,50 @@ describe('provider/zeebe - InputProps', function() {
     }));
 
 
+    it('should add new input to bottom', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_2');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      const inputGroup = getGroup(container, 'inputs');
+      const addEntry = domQuery('.bio-properties-panel-add-entry', inputGroup);
+
+      // when
+      await act(() => {
+        addEntry.click();
+      });
+
+      // then
+      const inputItemLabel = getInputItemLabel(container, 0);
+
+      expect(inputItemLabel.innerHTML).to.equal('inputTargetValue1');
+    }));
+
+
+    it('should sort input items according to XML', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('UnsortedServiceTask');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // then
+      const inputParameters = getInputParameters(serviceTask);
+
+      for (let idx = 0; idx < inputParameters.length; idx++) {
+        const inputItemLabel = getInputItemLabel(container, idx).innerHTML;
+
+        expect(inputParameters[idx].target).to.equal(inputItemLabel);
+      }
+    }));
+
+
     it('should create non existing extension elements',
       inject(async function(elementRegistry, selection) {
 
@@ -267,4 +311,8 @@ function getListItems(container, type) {
 
 function getInputListItems(container) {
   return getListItems(container, 'input');
+}
+
+function getInputItemLabel(container, id) {
+  return domQueryAll('.bio-properties-panel-collapsible-entry-header-title', container)[id];
 }

--- a/test/spec/provider/zeebe/OutputProps.bpmn
+++ b/test/spec/provider/zeebe/OutputProps.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.6.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:serviceTask id="ServiceTask_1">
       <bpmn:extensionElements>
@@ -23,6 +23,16 @@
     <bpmn:serviceTask id="ServiceTask_noIoMapping" name="no IoMapping">
       <bpmn:extensionElements />
     </bpmn:serviceTask>
+    <bpmn:serviceTask id="UnsortedServiceTask" name="UnsortedServiceTask">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="" target="5" />
+          <zeebe:output source="" target="z" />
+          <zeebe:output source="" target="a" />
+          <zeebe:output source="" target="1" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -40,6 +50,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_18i7pky_di" bpmnElement="ServiceTask_noIoMapping">
         <dc:Bounds x="370" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1w6wh2a_di" bpmnElement="UnsortedServiceTask">
+        <dc:Bounds x="640" y="110" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/zeebe/OutputProps.spec.js
+++ b/test/spec/provider/zeebe/OutputProps.spec.js
@@ -121,6 +121,50 @@ describe('provider/zeebe - OutputProps', function() {
     }));
 
 
+    it('should add new output to bottom', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_2');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      const outputGroup = getGroup(container, 'outputs');
+      const addEntry = domQuery('.bio-properties-panel-add-entry', outputGroup);
+
+      // when
+      await act(() => {
+        addEntry.click();
+      });
+
+      // then
+      const outputItemLabel = getOutputItemLabel(container, 0);
+
+      expect(outputItemLabel.innerHTML).to.equal('outputTargetValue1');
+    }));
+
+
+    it('should sort output items according to XML', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('UnsortedServiceTask');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // then
+      const outputParameters = getOutputParameters(serviceTask);
+
+      for (let idx = 0; idx < outputParameters.length; idx++) {
+        const outputItemLabel = getOutputItemLabel(container, idx).innerHTML;
+
+        expect(outputParameters[idx].target).to.equal(outputItemLabel);
+      }
+    }));
+
+
     it('should create non existing extension elements',
       inject(async function(elementRegistry, selection) {
 
@@ -267,4 +311,8 @@ function getListItems(container, type) {
 
 function getOutputListItems(container) {
   return getListItems(container, 'output');
+}
+
+function getOutputItemLabel(container, id) {
+  return domQueryAll('.bio-properties-panel-collapsible-entry-header-title', container)[id];
 }


### PR DESCRIPTION
Currently ioMappings are visually sorted.

This is a problem, because the sorting in the XML has a semantic. See https://docs.camunda.io/docs/components/concepts/variables/#inputoutput-variable-mappings: 

> Variable mappings are evaluated in the defined order. Therefore, a source expression can access the target variable of a previous mapping.

This is highly relevant in Connectors land: we need to define certain variables first, and reference them then later.

Hence I propose this as a quick fix: with this PR the sorting is at least visible in the UI. As potential follow-up, we could support a reordering via the prop panel.

related to #838

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
