### PR TITLE
fix(cloud-element-templates): keep template properties order

### DIFF
--- a/src/provider/cloud-element-templates/UpdateTemplatePropertiesOrder.js
+++ b/src/provider/cloud-element-templates/UpdateTemplatePropertiesOrder.js
@@ -1,0 +1,236 @@
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+import { isObject } from 'min-dash';
+import { findExtension } from './Helper';
+
+/**
+ * Restores the original order of the template properties
+ * on the moddle element.
+ */
+export default class UpdateTemplatePropertiesOrder extends CommandInterceptor {
+  constructor(eventBus, elementTemplates, commandStack, bpmnFactory) {
+    super(eventBus);
+
+    this._eventBus = eventBus;
+    this._elementTemplates = elementTemplates;
+    this._commandStack = commandStack;
+    this._bpmnFactory = bpmnFactory;
+
+    this.postExecute([
+      'element.updateProperties', 'element.updateModdleProperties'
+    ], this._updatePropertiesOrder, true, this);
+  }
+
+  _updatePropertiesOrder(context) {
+    const {
+      element
+    } = context;
+
+    const template = this._elementTemplates.get(element);
+    const businessObject = element.businessObject;
+    const commands = [];
+
+    if (!template) {
+      return;
+    }
+
+    const templateProperties = template.properties;
+
+    // zeebe:Property
+    const zeebeProperties = findExtension(businessObject, 'zeebe:Properties');
+
+    if (zeebeProperties) {
+      this._updateZeebePropertiesOrder(zeebeProperties, templateProperties, commands, context);
+    }
+
+    // zeebe:IoMapping
+    const ioMapping = findExtension(businessObject, 'zeebe:IoMapping');
+
+    if (ioMapping) {
+
+      // zeebe:Input
+      this._updateInputOrder(ioMapping, templateProperties, commands, context);
+
+      // zeebe:Output
+      this._updateOutputOrder(ioMapping, templateProperties, commands, context);
+    }
+
+    // zeebe:TaskHeaders
+    const taskHeaders = findExtension(businessObject, 'zeebe:TaskHeaders');
+
+    if (taskHeaders) {
+      this._updateTaskHeadersOrder(taskHeaders, templateProperties, commands, context);
+    }
+
+
+    if (commands.length) {
+      const commandsToExecute = commands.filter((command) => command !== null);
+
+      commandsToExecute.length && this._commandStack.execute(
+        'properties-panel.multi-command-executor',
+        commandsToExecute
+      );
+
+      return;
+    }
+  }
+
+  _updateZeebePropertiesOrder(zeebeProperties, templateProperties, commands, context) {
+    const findIndex = (properties, propertyToFind) =>
+      properties.findIndex(prop =>
+        prop.binding.type == 'zeebe:property' && prop.binding.name === propertyToFind.get('name')
+      );
+
+    const properties = zeebeProperties.get('properties');
+
+    if (properties.length < 1)
+      return;
+
+    let newPropertiesOrder = [ ...properties ];
+
+    sortProperties(newPropertiesOrder, findIndex, templateProperties);
+
+    if (!arrayEquals(newPropertiesOrder, properties)) {
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          ...context,
+          moddleElement: zeebeProperties,
+          properties: {
+            properties: newPropertiesOrder
+          }
+        }
+      });
+    }
+  }
+
+  _updateInputOrder(ioMapping, templateProperties, commands, context) {
+
+    const findIndex = (properties, propertyToFind) =>
+      properties.findIndex(prop =>
+        prop.binding.type == 'zeebe:input' && prop.binding.name === propertyToFind.get('target')
+      );
+
+    const inputParameters = ioMapping.get('inputParameters');
+
+    if (inputParameters.length < 1)
+      return;
+
+    let newInputOrder = [ ...inputParameters ];
+
+    sortProperties(newInputOrder, findIndex, templateProperties);
+
+    if (!arrayEquals(newInputOrder,inputParameters)) {
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          ...context,
+          moddleElement: ioMapping,
+          properties: { inputParameters: newInputOrder }
+        }
+      });
+    }
+  }
+
+  _updateOutputOrder(ioMapping, templateProperties, commands, context) {
+
+    const findIndex = (properties, propertyToFind) =>
+      properties.findIndex(prop =>
+        prop.binding.type == 'zeebe:output' && prop.binding.source === propertyToFind.get('source')
+      );
+
+    const outputParameters = ioMapping.get('outputParameters');
+
+    if (outputParameters.length < 1)
+      return;
+
+    let newOutputOrder = [ ...outputParameters ];
+
+    sortProperties(newOutputOrder, findIndex, templateProperties);
+
+    if (!arrayEquals(newOutputOrder, outputParameters)) {
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          ...context,
+          moddleElement: ioMapping,
+          properties: { outputParameters: newOutputOrder }
+        }
+      });
+    }
+  }
+
+  _updateTaskHeadersOrder(taskHeaders, templateProperties, commands, context) {
+
+    const findIndex = (properties, propertyToFind) =>
+      properties.findIndex(prop =>
+        prop.binding.type == 'zeebe:taskHeader' && prop.binding.key === propertyToFind.get('key')
+      );
+
+    const headers = taskHeaders.get('zeebe:values');
+
+    if (headers.length < 1)
+      return;
+
+    let newHeadersOrder = [ ...headers ];
+
+    sortProperties(newHeadersOrder, findIndex, templateProperties);
+
+    if (!arrayEquals(newHeadersOrder, headers)) {
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          ...context,
+          moddleElement: taskHeaders,
+          properties: { values: newHeadersOrder }
+        }
+      });
+    }
+  }
+
+}
+
+UpdateTemplatePropertiesOrder.$inject = [
+  'eventBus',
+  'elementTemplates',
+  'commandStack',
+  'bpmnFactory'
+];
+
+
+// helpers
+
+function normalizeReplacer(key, value) {
+
+  if (isObject(value)) {
+    const keys = Object.keys(value).sort();
+
+    return keys.reduce((obj, key) => {
+      obj[key] = value[key];
+
+      return obj;
+    }, {});
+  }
+
+  return value;
+}
+
+function objectEquals(a, b) {
+  return JSON.stringify(a, normalizeReplacer) === JSON.stringify(b, normalizeReplacer);
+}
+
+function arrayEquals(a, b) {
+  return a.every((element, idx) => objectEquals(element, b[idx]));
+}
+
+function sortProperties(array, findIndex, templateProperties) {
+  return array.sort((a, b) => {
+    const aIndex = findIndex(templateProperties, a);
+    const bIndex = findIndex(templateProperties, b);
+
+    return aIndex - bIndex;
+  });
+}

--- a/src/provider/cloud-element-templates/index.js
+++ b/src/provider/cloud-element-templates/index.js
@@ -7,6 +7,7 @@ import ReplaceBehavior from './ReplaceBehavior';
 import commandsModule from './cmd';
 import templateElementFactoryModule from './create';
 import ElementTemplatesPropertiesProvider from './ElementTemplatesPropertiesProvider';
+import UpdateTemplatePropertiesOrder from './UpdateTemplatePropertiesOrder';
 
 import zeebePropertiesProviderModule from '../zeebe';
 
@@ -21,11 +22,13 @@ export default {
     'elementTemplatesLoader',
     'replaceBehavior',
     'elementTemplatesPropertiesProvider',
-    'elementTemplatesConditionChecker'
+    'elementTemplatesConditionChecker',
+    'updateTemplatePropertiesOrder'
   ],
   elementTemplates: [ 'type', ElementTemplates ],
   elementTemplatesLoader: [ 'type', ElementTemplatesLoader ],
   replaceBehavior: [ 'type', ReplaceBehavior ],
   elementTemplatesPropertiesProvider: [ 'type', ElementTemplatesPropertiesProvider ],
-  elementTemplatesConditionChecker: [ 'type', ElementTemplatesConditionChecker ]
+  elementTemplatesConditionChecker: [ 'type', ElementTemplatesConditionChecker ],
+  updateTemplatePropertiesOrder: [ 'type', UpdateTemplatePropertiesOrder ]
 };

--- a/test/spec/provider/cloud-element-templates/fixtures/complex.bpmn
+++ b/test/spec/provider/cloud-element-templates/fixtures/complex.bpmn
@@ -77,6 +77,24 @@
         </zeebe:taskHeaders>
       </bpmn:extensionElements>
     </bpmn:serviceTask>
+    <bpmn:serviceTask id="Activity_070m932" name="update template properties order" zeebe:modelerTemplate="cloud-element-templates.properties.update-properties-order">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="input-1-source" target="input-1-target" />
+          <zeebe:input source="input-3-source" target="input-3-target" />
+          <zeebe:output source="output-1-source" target="output-1-target" />
+          <zeebe:output source="output-3-source" target="output-3-target" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="header-1-key" value="header-1-value" />
+          <zeebe:header key="header-2-key" value="header-2-value" />
+        </zeebe:taskHeaders>
+        <zeebe:properties>
+          <zeebe:property name="property-1-name" value="property-1-value" />
+          <zeebe:property name="property-3-name" value="property-3-value" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+  </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0vvlc66">
@@ -117,6 +135,9 @@
       <bpmndi:BPMNShape id="REST_outdated_deprecated_di" bpmnElement="REST_outdated_deprecated">
         <dc:Bounds x="410" y="580" width="100" height="80" />
         <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xl49z8_di" bpmnElement="Activity_070m932">
+        <dc:Bounds x="270" y="690" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0gw5hlt_di" bpmnElement="Flow_0gw5hlt">
         <di:waypoint x="215" y="117" />

--- a/test/spec/provider/cloud-element-templates/fixtures/update-template-properties-order.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/update-template-properties-order.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "Update Properties - Order",
+  "id": "cloud-element-templates.properties.update-properties-order",
+  "appliesTo": [
+    "bpmn:ServiceTask"
+  ],
+  "properties": [
+    {
+      "id": "name",
+      "type": "Hidden",
+      "value": "task-name",
+      "binding": {
+        "type": "property",
+        "name": "name"
+      }
+    },
+    {
+      "label": "Task Header 1 (conditional)",
+      "type": "String",
+      "value": "header-1-value",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "header-1-key"
+      },
+      "condition": {
+         "equals": "update template properties order",
+        "property": "name"
+      }
+    },
+    {
+      "label": "Task Header 2",
+      "type": "String",
+      "value": "header-2-value",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "header-2-key"
+      }
+    },
+    {
+      "label": "Input 1 (conditional)",
+      "type": "String",
+      "value": "input-1-source",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "input-1-target"
+      },
+      "condition": {
+         "equals": "update template properties order",
+        "property": "name"
+      }
+    },
+    {
+      "label": "Input 2 (optional)",
+      "type": "String",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:input",
+        "name": "input-2-target"
+      }
+    },
+    {
+      "label": "Input 3",
+      "type": "String",
+      "value": "input-3-source",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "input-3-target"
+      }
+    },
+    {
+      "label": "Output 1 (conditional)",
+      "type": "String",
+      "value": "output-1-target",
+      "binding": {
+        "type": "zeebe:output",
+        "source": "output-1-source"
+      },
+      "condition": {
+         "equals": "update template properties order",
+        "property": "name"
+      }
+    },
+    {
+      "label": "Output 2 (optional)",
+      "type": "String",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:output",
+        "source": "output-2-source"
+      }
+    },
+    {
+      "label": "Output 3",
+      "type": "String",
+      "value": "output-3-target",
+      "binding": {
+        "type": "zeebe:output",
+        "source": "output-3-source"
+      }
+    },
+    {
+      "label": "Property 1 (conditional)",
+      "type": "String",
+      "value": "property-1-value",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "property-1-name"
+      },
+      "condition": {
+         "equals": "update template properties order",
+        "property": "name"
+      }
+    },
+    {
+      "label": "Property 2 (optional)",
+      "type": "String",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "property-2-name"
+      }
+    },
+    {
+      "label": "Property 3",
+      "type": "String",
+      "value": "property-3-value",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "property-3-name"
+      }
+    }
+  ]
+}

--- a/test/spec/provider/cloud-element-templates/properties/UpdateTemplatePropertiesOrder.bpmn
+++ b/test/spec/provider/cloud-element-templates/properties/UpdateTemplatePropertiesOrder.bpmn
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_00cqa19" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.6.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="TASK" name="TASK" zeebe:modelerTemplate="cloud-element-templates.properties.UpdateProperties.order">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="input-1-source" target="input-1-target" />
+          <zeebe:input source="input-3-source" target="input-3-target" />
+          <zeebe:output source="output-1-source" target="output-1-target" />
+          <zeebe:output source="output-3-source" target="output-3-target" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="header-1-key" value="header-1-value" />
+          <zeebe:header key="header-2-key" value="header-2-value" />
+        </zeebe:taskHeaders>
+        <zeebe:properties>
+          <zeebe:property name="property-1-name" value="property-1-value" />
+          <zeebe:property name="property-3-name" value="property-3-value" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="TASK_condition" name="TASK_condition" zeebe:modelerTemplate="cloud-element-templates.properties.UpdateProperties.order">
+       <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="input-2-source" target="input-2-target" />
+          <zeebe:input source="input-3-source" target="input-3-target" />
+          <zeebe:output source="output-2-source" target="output-2-target" />
+          <zeebe:output source="output-3-source" target="output-3-target" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="header-2-key" value="header-2-value" />
+        </zeebe:taskHeaders>
+        <zeebe:properties>
+          <zeebe:property name="property-2-name" value="property-2-value" />
+          <zeebe:property name="property-3-name" value="property-3-value" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_0nbwi2u_di" bpmnElement="TASK">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_11gpt0o_di" bpmnElement="TASK_condition">
+        <dc:Bounds x="310" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/cloud-element-templates/properties/UpdateTemplatePropertiesOrder.json
+++ b/test/spec/provider/cloud-element-templates/properties/UpdateTemplatePropertiesOrder.json
@@ -1,0 +1,136 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Update Properties - Order",
+    "id": "cloud-element-templates.properties.UpdateProperties.order",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "id": "name",
+        "type": "Hidden",
+        "value": "task-name",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        }
+      },
+      {
+        "label": "Task Header 1",
+        "type": "String",
+        "value": "header-1-value",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "header-1-key"
+        },
+        "condition": {
+          "equals": "TASK",
+          "property": "name"
+        }
+      },
+      {
+        "label": "Task Header 2",
+        "type": "String",
+        "value": "header-2-value",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "header-2-key"
+        }
+      },
+      {
+        "label": "Input 1",
+        "type": "String",
+        "value": "input-1-source",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "input-1-target"
+        },
+        "condition": {
+          "equals": "TASK",
+          "property": "name"
+        }
+      },
+      {
+        "label": "Input 2",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "input-2-target"
+        }
+      },
+      {
+        "label": "Input 3",
+        "type": "String",
+        "value": "input-3-source",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "input-3-target"
+        }
+      },
+      {
+        "label": "Output 1",
+        "type": "String",
+        "value": "output-1-target",
+        "binding": {
+          "type": "zeebe:output",
+          "source": "output-1-source"
+        },
+        "condition": {
+          "equals": "TASK",
+          "property": "name"
+        }
+      },
+      {
+        "label": "Output 2",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:output",
+          "source": "output-2-source"
+        }
+      },
+      {
+        "label": "Output 3",
+        "type": "String",
+        "value": "output-3-target",
+        "binding": {
+          "type": "zeebe:output",
+          "source": "output-3-source"
+        }
+      },
+      {
+        "label": "Property 1",
+        "type": "String",
+        "value": "property-1-value",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "property-1-name"
+        },
+        "condition": {
+          "equals": "TASK",
+          "property": "name"
+        }
+      },
+      {
+        "label": "Property 2",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:property",
+          "name": "property-2-name"
+        }
+      },
+      {
+        "label": "Property 3",
+        "type": "String",
+        "value": "property-3-value",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "property-3-name"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/provider/cloud-element-templates/properties/UpdateTemplatePropertiesOrder.spec.js
+++ b/test/spec/provider/cloud-element-templates/properties/UpdateTemplatePropertiesOrder.spec.js
@@ -1,0 +1,528 @@
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  findExtension
+} from 'src/provider/cloud-element-templates/Helper';
+
+import {
+  bootstrapModeler,
+  getBpmnJS,
+  inject
+} from 'test/TestHelper';
+
+import elementTemplateChooserModule from '@bpmn-io/element-template-chooser';
+import zeebeElementTemplatesModule from 'src/provider/cloud-element-templates';
+import zeebePropertiesProviderModule from 'src/provider/zeebe';
+
+import bpmnPropertiesProviderModule from 'src/provider/bpmn';
+import propertiesCommandsModule from 'src/cmd';
+import propertiesRenderModule from 'src/render';
+
+import zeebeBehaviorsModule from 'camunda-bpmn-js-behaviors/lib/camunda-cloud';
+import zeebeModdlePackage from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import {
+  setPropertyValue
+} from 'src/provider/cloud-element-templates/util/propertyUtil';
+
+import {
+  findInputParameter,
+  findOutputParameter,
+  findTaskHeader,
+  findZeebeProperty
+} from 'src/provider/cloud-element-templates/Helper';
+
+
+describe('provider/cloud-element-templates - UpdateTemplatePropertiesOrder', function() {
+
+  let container, propertiesContainer, modelerContainer;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+
+    modelerContainer = document.createElement('div');
+    modelerContainer.classList.add('modeler-container');
+
+    propertiesContainer = document.createElement('div');
+    propertiesContainer.classList.add('properties-container');
+
+    container.appendChild(modelerContainer);
+    container.appendChild(propertiesContainer);
+  });
+
+
+  describe('should preserve definition order on update', function() {
+
+    const elementTemplates = require('./UpdateTemplatePropertiesOrder.json');
+    const diagramXML = require('./UpdateTemplatePropertiesOrder.bpmn').default;
+
+    beforeEach(() => bootstrapModeler(diagramXML, {
+      container: modelerContainer,
+      additionalModules: [
+        bpmnPropertiesProviderModule,
+        zeebePropertiesProviderModule,
+        zeebeBehaviorsModule,
+        zeebeElementTemplatesModule,
+        propertiesRenderModule,
+        propertiesCommandsModule,
+        elementTemplateChooserModule
+      ],
+      moddleExtensions: {
+        zeebe: zeebeModdlePackage
+      },
+      propertiesPanel: {
+        parent: propertiesContainer
+      },
+      elementTemplates
+    })());
+
+
+    describe('zeebe:input', function() {
+
+      it('property set', inject(function(elementRegistry, bpmnjs) {
+
+        // given
+        const task = el('TASK');
+
+        // when
+        update(task, 'Input 1', 'foobar');
+
+        // then
+        const ioMapping = findExtension(task, 'zeebe:IoMapping');
+
+        const expectedInputs = [
+          findInputParameter(ioMapping, binding(task, 'Input 1')),
+          findInputParameter(ioMapping, binding(task, 'Input 3'))
+        ];
+
+        expectOrder(ioMapping.inputParameters, expectedInputs);
+      }));
+
+
+      it('property not set - optional', inject(function(elementRegistry, bpmnjs) {
+
+        // given
+        const task = el('TASK');
+
+        // when
+        update(task, 'Input 2', 'foobar');
+
+        // then
+        const ioMapping = findExtension(task, 'zeebe:IoMapping');
+
+        const expectedInputs = [
+          findInputParameter(ioMapping, binding(task, 'Input 1')),
+          findInputParameter(ioMapping, binding(task, 'Input 2')),
+          findInputParameter(ioMapping, binding(task, 'Input 3'))
+        ];
+
+        expectOrder(ioMapping.inputParameters, expectedInputs);
+      }));
+
+
+      it('property not set - conditional', inject(function(modeling) {
+
+        // given
+        const task = el('TASK_condition');
+
+        // when
+        modeling.updateProperties(task, {
+          name: 'TASK'
+        });
+
+        // then
+        const ioMapping = findExtension(task, 'zeebe:IoMapping');
+
+        const expectedInputs = [
+          findInputParameter(ioMapping, binding(task, 'Input 1')),
+          findInputParameter(ioMapping, binding(task, 'Input 2')),
+          findInputParameter(ioMapping, binding(task, 'Input 3'))
+        ];
+
+        expectOrder(ioMapping.inputParameters, expectedInputs);
+      }));
+
+    });
+
+
+    describe('zeebe:output', function() {
+
+      it('porperty set', inject(function(elementRegistry, bpmnjs) {
+
+        // given
+        const task = el('TASK');
+
+        // when
+        update(task, 'Output 1', 'foobar');
+
+        // then
+        const ioMapping = findExtension(task, 'zeebe:IoMapping');
+
+        const expectedOutputs = [
+          findOutputParameter(ioMapping, binding(task, 'Output 1')),
+          findOutputParameter(ioMapping, binding(task, 'Output 3'))
+        ];
+
+        expectOrder(ioMapping.outputParameters, expectedOutputs);
+      }));
+
+
+      it('porperty not set - optional', inject(function(elementRegistry, bpmnjs) {
+
+        // given
+        const task = el('TASK');
+
+        // when
+        update(task, 'Output 2', 'foobar');
+
+        const ioMapping = findExtension(task, 'zeebe:IoMapping');
+
+        // then
+        const expectedOutputs = [
+          findOutputParameter(ioMapping, binding(task, 'Output 1')),
+          findOutputParameter(ioMapping, binding(task, 'Output 2')),
+          findOutputParameter(ioMapping, binding(task, 'Output 3'))
+        ];
+
+        expectOrder(ioMapping.outputParameters, expectedOutputs);
+      }));
+
+
+      it('porperty not set - conditional', inject(function(modeling) {
+
+        // given
+        const task = el('TASK_condition');
+
+        // when
+        modeling.updateProperties(task, {
+          name: 'TASK'
+        });
+        const ioMapping = findExtension(task, 'zeebe:IoMapping');
+
+        // then
+        const expectedOutputs = [
+          findOutputParameter(ioMapping, binding(task, 'Output 1')),
+          findOutputParameter(ioMapping, binding(task, 'Output 2')),
+          findOutputParameter(ioMapping, binding(task, 'Output 3'))
+        ];
+
+        expectOrder(ioMapping.outputParameters, expectedOutputs);
+      }));
+
+    });
+
+
+    describe('zeebe:property', function() {
+
+      it('property set', inject(function(elementRegistry, bpmnjs) {
+
+        // given
+        const task = el('TASK');
+
+        // when
+        update(task, 'Property 1', 'foobar');
+
+        // then
+        const zeebeProperties = findExtension(task, 'zeebe:Properties');
+
+        const expectedProperties = [
+          findZeebeProperty(zeebeProperties, binding(task, 'Property 1')),
+          findZeebeProperty(zeebeProperties, binding(task, 'Property 3'))
+        ];
+
+        expectOrder(zeebeProperties.properties, expectedProperties);
+      }));
+
+
+      it('property not set - optional', inject(function(elementRegistry, bpmnjs) {
+
+        // given
+        const task = el('TASK');
+
+        // when
+        update(task, 'Property 2', 'foobar');
+
+        // then
+        const zeebeProperties = findExtension(task, 'zeebe:Properties');
+
+        const expectedProperties = [
+          findZeebeProperty(zeebeProperties, binding(task, 'Property 1')),
+          findZeebeProperty(zeebeProperties, binding(task, 'Property 2')),
+          findZeebeProperty(zeebeProperties, binding(task, 'Property 3'))
+        ];
+
+        expectOrder(zeebeProperties.properties, expectedProperties);
+      }));
+
+
+      it('property not set - conditional', inject(function(modeling) {
+
+        // given
+        const task = el('TASK_condition');
+
+        // when
+        modeling.updateProperties(task, {
+          name: 'TASK'
+        });
+
+        // then
+        const zeebeProperties = findExtension(task, 'zeebe:Properties');
+
+        const expectedProperties = [
+          findZeebeProperty(zeebeProperties, binding(task, 'Property 1')),
+          findZeebeProperty(zeebeProperties, binding(task, 'Property 2')),
+          findZeebeProperty(zeebeProperties, binding(task, 'Property 3'))
+        ];
+
+        expectOrder(zeebeProperties.properties, expectedProperties);
+      }));
+
+    });
+
+
+    describe('zeebe:taskHeader', function() {
+
+      it('property set', inject(function(elementRegistry, bpmnjs) {
+
+        // given
+        const task = el('TASK');
+
+        // when
+        update(task, 'Task Header 1', 'foobar');
+
+        // then
+        const taskHeaders = findExtension(task, 'zeebe:TaskHeaders');
+
+        const expectedHeaders = [
+          findTaskHeader(taskHeaders, binding(task, 'Task Header 1')),
+          findTaskHeader(taskHeaders, binding(task, 'Task Header 2'))
+        ];
+
+        expectOrder(taskHeaders.values, expectedHeaders);
+      }));
+
+
+      it('property not set - conditional', inject(function(modeling) {
+
+        // given
+        const task = el('TASK_condition');
+
+        // when
+        modeling.updateProperties(task, {
+          name: 'TASK'
+        });
+
+        // then
+        const taskHeaders = findExtension(task, 'zeebe:TaskHeaders');
+
+        const expectedHeaders = [
+          findTaskHeader(taskHeaders, binding(task, 'Task Header 1')),
+          findTaskHeader(taskHeaders, binding(task, 'Task Header 2'))
+        ];
+
+        expectOrder(taskHeaders.values, expectedHeaders);
+      }));
+
+
+    });
+
+  });
+
+
+  describe('should correct definition order on update', function() {
+
+    const elementTemplates = require('./UpdateTemplatePropertiesOrder.json');
+    const diagramXML = require('./UpdateTemplatePropertiesOrder.wrong-order.bpmn').default;
+
+    beforeEach(() => bootstrapModeler(diagramXML, {
+      container: modelerContainer,
+      additionalModules: [
+        bpmnPropertiesProviderModule,
+        zeebePropertiesProviderModule,
+        zeebeBehaviorsModule,
+        zeebeElementTemplatesModule,
+        propertiesRenderModule,
+        propertiesCommandsModule,
+        elementTemplateChooserModule
+      ],
+      moddleExtensions: {
+        zeebe: zeebeModdlePackage
+      },
+      propertiesPanel: {
+        parent: propertiesContainer
+      },
+      elementTemplates
+    })());
+
+
+    it('zeebe:input', function() {
+
+      // given
+      const task = el('TASK');
+      const ioMapping = findExtension(task, 'zeebe:IoMapping');
+
+      // assume
+      const inputs = [
+        findInputParameter(ioMapping, binding(task, 'Input 3')),
+        findInputParameter(ioMapping, binding(task, 'Input 1'))
+      ];
+
+      expectOrder(ioMapping.inputParameters, inputs);
+
+      // when
+      update(task, 'Input 1', 'foobar');
+
+      // then
+
+      const expectedInputs = [
+        findInputParameter(ioMapping, binding(task, 'Input 1')),
+        findInputParameter(ioMapping, binding(task, 'Input 3'))
+      ];
+
+      expectOrder(ioMapping.inputParameters, expectedInputs);
+    });
+
+
+    it('zeebe:output', function() {
+
+      // given
+      const task = el('TASK');
+      const ioMapping = findExtension(task, 'zeebe:IoMapping');
+
+      // assume
+      const outputs = [
+        findOutputParameter(ioMapping, binding(task, 'Output 3')),
+        findOutputParameter(ioMapping, binding(task, 'Output 1'))
+      ];
+
+      expectOrder(ioMapping.outputParameters, outputs);
+
+      // when
+      update(task, 'Output 1', 'foobar');
+
+      // then
+      const expectedOutputs = [
+        findOutputParameter(ioMapping, binding(task, 'Output 1')),
+        findOutputParameter(ioMapping, binding(task, 'Output 3'))
+      ];
+
+      expectOrder(ioMapping.outputParameters, expectedOutputs);
+    });
+
+
+    it('zeebe:property', function() {
+
+      // given
+      const task = el('TASK');
+
+      const zeebeProperties = findExtension(task, 'zeebe:Properties');
+
+      // assume
+      const properties = [
+        findZeebeProperty(zeebeProperties, binding(task, 'Property 3')),
+        findZeebeProperty(zeebeProperties, binding(task, 'Property 1'))
+      ];
+
+      expectOrder(zeebeProperties.properties, properties);
+
+      // when
+      update(task, 'Property 1', 'foobar');
+
+      // then
+      const expectedProperties = [
+        findZeebeProperty(zeebeProperties, binding(task, 'Property 1')),
+        findZeebeProperty(zeebeProperties, binding(task, 'Property 3'))
+      ];
+
+      expectOrder(zeebeProperties.properties, expectedProperties);
+    });
+
+
+    it('zeebe:taskHeader', function() {
+
+      // given
+      const task = el('TASK');
+
+      const taskHeaders = findExtension(task, 'zeebe:TaskHeaders');
+
+      // assume
+      const headers = [
+        findTaskHeader(taskHeaders, binding(task, 'Task Header 2')),
+        findTaskHeader(taskHeaders, binding(task, 'Task Header 1'))
+      ];
+
+      expectOrder(taskHeaders.values, headers);
+
+      // when
+      update(task, 'Task Header 1', 'foobar');
+
+      // then
+      const expectedHeaders = [
+        findTaskHeader(taskHeaders, binding(task, 'Task Header 1')),
+        findTaskHeader(taskHeaders, binding(task, 'Task Header 2'))
+      ];
+
+      expectOrder(taskHeaders.values, expectedHeaders);
+    });
+
+  });
+
+});
+
+
+// helpers /////////////
+
+function el(id) {
+  return getBpmnJS().invoke((elementRegistry) => {
+
+    const element = elementRegistry.get(id);
+
+    expect(element, `element <#${id}> exists`).to.exist;
+
+    return element;
+  });
+}
+
+function update(element, propertyLabel, value) {
+
+  const property = prop(element, propertyLabel);
+
+  return getBpmnJS().invoke((commandStack, bpmnFactory) => {
+    return setPropertyValue(bpmnFactory, commandStack, element, property, value);
+  });
+}
+
+function expectOrder(arrayLike, expectedValues) {
+  for (let i = 0; i < expectedValues.length - 1; i++) {
+    expect(arrayLike[i]).to.eql(expectedValues[i]);
+  }
+
+}
+
+/**
+ * @param {djs.model.Base} element
+ * @param {string} label
+ *
+ * @return {object} property
+ */
+function prop(element, label) {
+
+  return getBpmnJS().invoke((elementTemplates) => {
+
+    const template = elementTemplates.get(element);
+
+    expect(template, `element <#${element.id}> has template`).to.exist;
+
+    const property = template.properties.find(property => {
+      return property.label === label;
+    });
+
+    expect(property, `template <#${template.id}> to have property labeled <${ label }>`).to.exist;
+
+    return property;
+  });
+}
+
+function binding(element, label) {
+  return prop(element, label).binding;
+}

--- a/test/spec/provider/cloud-element-templates/properties/UpdateTemplatePropertiesOrder.wrong-order.bpmn
+++ b/test/spec/provider/cloud-element-templates/properties/UpdateTemplatePropertiesOrder.wrong-order.bpmn
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_00cqa19" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.13.0-nightly.20220123">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="TASK" name="TASK" zeebe:modelerTemplate="cloud-element-templates.properties.UpdateProperties.order">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="input-3-source" target="input-3-target" />
+          <zeebe:input source="input-1-source" target="input-1-target" />
+          <zeebe:output source="output-3-source" target="output-3-target" />
+          <zeebe:output source="output-1-source" target="output-1-target" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="header-2-key" value="header-2-value" />
+          <zeebe:header key="header-1-key" value="header-1-value" />
+        </zeebe:taskHeaders>
+        <zeebe:properties>
+          <zeebe:property name="property-3-name" value="property-3-value" />
+          <zeebe:property name="property-1-name" value="property-1-value" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_0nbwi2u_di" bpmnElement="TASK">
+        <dc:Bounds x="280" y="230" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Closes #838

We could consider refactoring `propertyUtil` later on to not delete the modified properties and just update the values instead, see https://github.com/bpmn-io/bpmn-js-properties-panel/issues/838#issuecomment-1369792405
