### PR TITLE
chore(CHANGELOG): update to v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ ___Note:__ Yet to be released changes appear here._
 
 * `FIX`: serialize templated properties in stable order ([#838](https://github.com/bpmn-io/bpmn-js-properties-panel/issues/838))
 * `FIX`: do not sort IO mappings alphabetically ([#845](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/845), [#843](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/843))
-* `DEPS`: update to `@bpmn-io/extract-process-variables`
+* `DEPS`: update to `@bpmn-io/extract-process-variables@0.7.0`
 
 ## 1.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.15.0
+
+* `FIX`: serialize templated properties in stable order ([#838](https://github.com/bpmn-io/bpmn-js-properties-panel/issues/838))
 * `FIX`: do not sort IO mappings alphabetically ([#845](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/845), [#843](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/843))
+* `DEPS`: update to `@bpmn-io/extract-process-variables`
 
 ## 1.14.0
 


### PR DESCRIPTION
About to cut a `v1.15.0` release.

@marstamm can you review this update properly represents the latest variable improvements?