### PR TITLE
chore(zeebe): show Extension properties group for all elements

### DIFF
--- a/src/provider/shared/ExtensionPropertiesProps.js
+++ b/src/provider/shared/ExtensionPropertiesProps.js
@@ -17,10 +17,6 @@ import { without } from 'min-dash';
 
 
 export function ExtensionPropertiesProps({ element, injector, namespace = 'camunda' }) {
-  if (namespace === 'zeebe' && !is(element, 'zeebe:PropertiesHolder')) {
-    return [];
-  }
-
   let businessObject = getRelevantBusinessObject(element);
 
   // do not offer for empty pools

--- a/test/spec/provider/shared/ExtensionPropertiesProps.spec.js
+++ b/test/spec/provider/shared/ExtensionPropertiesProps.spec.js
@@ -165,7 +165,7 @@ describe('provider/shared - ExtensionPropertiesProps', function() {
         ));
 
 
-        it('should create non existing camunda:Properties', inject(
+        it(`should create non existing ${ namespace }:Properties`, inject(
           async function(elementRegistry, selection) {
 
             // given
@@ -215,7 +215,7 @@ describe('provider/shared - ExtensionPropertiesProps', function() {
         }));
 
 
-        it('should remove camunda:Properties on last delete', inject(
+        it(`should remove ${ namespace }:Properties on last delete`, inject(
           async function(elementRegistry, selection) {
 
             // given


### PR DESCRIPTION
Removes the check for `zeebe:PropertiesHolder` as _Extension properties_ are generally allowed.

![image](https://user-images.githubusercontent.com/7633572/216060279-e38f3b0f-1e94-4862-b6de-997027b17fcb.png)

Follow-up to https://github.com/camunda/zeebe-bpmn-moddle/pull/44
Related to https://github.com/camunda/camunda-modeler/issues/3365
