### PR TITLE
feat: render `Text#language` fields using monospace font

### DIFF
--- a/src/provider/cloud-element-templates/properties/CustomProperties.js
+++ b/src/provider/cloud-element-templates/properties/CustomProperties.js
@@ -376,7 +376,8 @@ function TextAreaProperty(props) {
     description,
     editable,
     label,
-    feel
+    feel,
+    language
   } = property;
 
   const bpmnFactory = useService('bpmnFactory'),
@@ -389,6 +390,7 @@ function TextAreaProperty(props) {
     id,
     label,
     feel,
+    monospace: !!language,
     description: PropertyDescription({ description }),
     getValue: propertyGetter(element, property),
     setValue: propertySetter(bpmnFactory, commandStack, element, property),

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.spec.js
@@ -59,6 +59,9 @@ import defaultValuesElementTemplates from './CustomProperties.default-values.jso
 import groupsDiagramXML from './CustomProperties.groups.bpmn';
 import groupsElementTemplates from './CustomProperties.groups.json';
 
+import textLanguageDiagramXML from './CustomProperties.text-language.bpmn';
+import textLanguageElementTemplates from './CustomProperties.text-language.json';
+
 
 describe('provider/cloud-element-templates - CustomProperties', function() {
 
@@ -687,7 +690,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
   describe('types', function() {
 
-    describe('dropdown', function() {
+    describe('Dropdown', function() {
 
       beforeEach(bootstrapPropertiesPanel(diagramXML, {
         container,
@@ -786,6 +789,39 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
         // then
         expect(businessObject.get('name')).to.equal('medium');
+      });
+
+    });
+
+
+    describe('Text', function() {
+
+      beforeEach(bootstrapPropertiesPanel(textLanguageDiagramXML, {
+        container,
+        debounceInput: false,
+        elementTemplates: textLanguageElementTemplates,
+        moddleExtensions: {
+          zeebe: zeebeModdlePackage
+        },
+        modules: [
+          BpmnPropertiesPanel,
+          coreModule,
+          elementTemplatesModule,
+          modelingModule
+        ]
+      }));
+
+
+      it('should display <language> annotated with monospace font', async function() {
+
+        // when
+        await expectSelected('textTask');
+
+        // then
+        const entry = findEntry('custom-entry-my.example.custom-language-text-0', container);
+        const input = findTextarea(entry);
+
+        expect(input.className).to.include('bio-properties-panel-input-monospace');
       });
 
     });

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.text-language.bpmn
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.text-language.bpmn
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_165ah7c" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.13.0-nightly.20220113" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.3.0">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:serviceTask id="textTask" name="Text Feel Task" zeebe:modelerTemplate="my.example.custom-language-text">
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="textTask_di" bpmnElement="textTask">
+        <dc:Bounds x="250" y="53" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.text-language.json
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.text-language.json
@@ -1,0 +1,23 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Custom Language Text",
+    "id": "my.example.custom-language-text",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "label": "GraphQL query",
+        "type": "Text",
+        "language": "graphql",
+        "value": "{}",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "valueInput"
+        },
+        "optional": true
+      }
+    ]
+  }
+]


### PR DESCRIPTION
![screenshot XsLXf7](https://user-images.githubusercontent.com/58601/216579405-ca6a5e9d-0ff9-4805-af6f-ae1bd4c8b113.png)

Related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/858