### PR TITLE
feat(cloud-element-templates): make `Text` fields auto-resizable

### DIFF
--- a/src/provider/cloud-element-templates/properties/CustomProperties.js
+++ b/src/provider/cloud-element-templates/properties/CustomProperties.js
@@ -391,6 +391,7 @@ function TextAreaProperty(props) {
     label,
     feel,
     monospace: !!language,
+    autoResize: true,
     description: PropertyDescription({ description }),
     getValue: propertyGetter(element, property),
     setValue: propertySetter(bpmnFactory, commandStack, element, property),

--- a/test/spec/provider/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/provider/cloud-element-templates/properties/CustomProperties.spec.js
@@ -4,6 +4,7 @@ import {
   bootstrapPropertiesPanel,
   changeInput,
   getBpmnJS,
+  withPropertiesPanel,
   inject
 } from 'test/TestHelper';
 
@@ -822,6 +823,19 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         const input = findTextarea(entry);
 
         expect(input.className).to.include('bio-properties-panel-input-monospace');
+      });
+
+
+      withPropertiesPanel('>=1.3.0')('should be auto-resizable', async function() {
+
+        // when
+        await expectSelected('textTask');
+
+        // then
+        const entry = findEntry('custom-entry-my.example.custom-language-text-0', container);
+        const input = findTextarea(entry);
+
+        expect(input.className).to.include('auto-resize');
       });
 
     });


### PR DESCRIPTION
This ensures that `Text` fields are auto-resizable, and assume the default content size. Such behavior is expected from multi-line text editors nowadays.

![capture jqTrCl_optimized](https://user-images.githubusercontent.com/58601/216586036-db32ab24-ce9e-4350-9c6b-08b0b502526f.gif)

Related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/858 