### PR TITLE
feat: handle zeebe task retries

### DIFF
--- a/src/provider/cloud-element-templates/CreateHelper.js
+++ b/src/provider/cloud-element-templates/CreateHelper.js
@@ -81,6 +81,20 @@ export function createTaskDefinitionWithType(value, bpmnFactory) {
 }
 
 /**
+ * Create a task definition representing the given value.
+ *
+ * @param {String} value
+ * @param {BpmnFactory} bpmnFactory
+ *
+ * @return {ModdleElement}
+ */
+export function createTaskDefinitionWithRetries(value, bpmnFactory) {
+  return bpmnFactory.create('zeebe:TaskDefinition', {
+    retries: value
+  });
+}
+
+/**
  * Create zeebe:Property from the given binding.
  *
  * @param {PropertyBinding} binding

--- a/src/provider/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/provider/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -10,6 +10,7 @@ import {
 import {
   createInputParameter,
   createOutputParameter,
+  createTaskDefinitionWithRetries,
   createTaskDefinitionWithType,
   createTaskHeader,
   createZeebeProperty,
@@ -206,13 +207,17 @@ export default class ChangeElementTemplateHandler {
 
         if (!shouldKeepValue(oldTaskDefinition, oldProperty, newProperty)) {
 
-          // TODO(pinussilvestrus): for now we only support <type>
+          // TODO(pinussilvestrus): for now we only support <type> and <retries>
           // this needs to be adjusted once we support more
           let properties = {};
 
           if (oldBindingType === 'zeebe:taskDefinition:type' || !oldBindingType) {
             properties = {
               type: newPropertyValue
+            };
+          } else if (oldBindingType === 'zeebe:taskDefinition:retries' || !oldBindingType) {
+            properties = {
+              retries: newPropertyValue
             };
           }
 
@@ -228,10 +233,12 @@ export default class ChangeElementTemplateHandler {
       else {
         let newTaskDefinition;
 
-        // TODO(pinussilvestrus): for now we only support <type>
+        // TODO(pinussilvestrus): for now we only support <type> and <retries>
         // this needs to be adjusted once we support more
         if (newBindingType === 'zeebe:taskDefinition:type') {
           newTaskDefinition = createTaskDefinitionWithType(newPropertyValue, bpmnFactory);
+        } else if (newBindingType === 'zeebe:taskDefinition:retries') {
+          newTaskDefinition = createTaskDefinitionWithRetries(newPropertyValue, bpmnFactory);
         }
 
         commandStack.execute('element.updateModdleProperties', {

--- a/src/provider/cloud-element-templates/create/TaskDefinitionRetriesBindingProvider.js
+++ b/src/provider/cloud-element-templates/create/TaskDefinitionRetriesBindingProvider.js
@@ -1,0 +1,23 @@
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import { createTaskDefinitionWithRetries } from '../CreateHelper';
+
+
+export default class TaskDefinitionRetriesBindingProvider {
+  static create(element, options) {
+    const {
+      property,
+      bpmnFactory
+    } = options;
+
+    const {
+      value
+    } = property;
+
+    const extensionElements = getBusinessObject(element).get('extensionElements');
+
+    const taskDefinition = createTaskDefinitionWithRetries(value, bpmnFactory);
+    taskDefinition.$parent = extensionElements;
+    extensionElements.get('values').push(taskDefinition);
+  }
+}

--- a/src/provider/cloud-element-templates/create/TemplateElementFactory.js
+++ b/src/provider/cloud-element-templates/create/TemplateElementFactory.js
@@ -7,6 +7,7 @@ import { find } from 'min-dash';
 import validate from '../util/validate';
 
 import PropertyBindingProvider from './PropertyBindingProvider';
+import TaskDefinitionRetriesBindingProvider from './TaskDefinitionRetriesBindingProvider';
 import TaskDefinitionTypeBindingProvider from './TaskDefinitionTypeBindingProvider';
 import InputBindingProvider from './InputBindingProvider';
 import OutputBindingProvider from './OutputBindingProvider';
@@ -16,6 +17,7 @@ import ZeebePropertiesProvider from './ZeebePropertiesProvider';
 import {
   EXTENSION_BINDING_TYPES,
   PROPERTY_TYPE,
+  ZEEBE_TASK_DEFINITION_RETRIES_TYPE,
   ZEEBE_TASK_DEFINITION_TYPE_TYPE,
   ZEBBE_INPUT_TYPE,
   ZEEBE_OUTPUT_TYPE,
@@ -34,6 +36,7 @@ export default class TemplateElementFactory {
 
     this._providers = {
       [PROPERTY_TYPE]: PropertyBindingProvider,
+      [ZEEBE_TASK_DEFINITION_RETRIES_TYPE]: TaskDefinitionRetriesBindingProvider,
       [ZEEBE_TASK_DEFINITION_TYPE_TYPE]: TaskDefinitionTypeBindingProvider,
       [ZEBBE_PROPERTY_TYPE]: ZeebePropertiesProvider,
       [ZEBBE_INPUT_TYPE]: InputBindingProvider,

--- a/src/provider/cloud-element-templates/util/bindingTypes.js
+++ b/src/provider/cloud-element-templates/util/bindingTypes.js
@@ -4,6 +4,7 @@ export const ZEBBE_PROPERTY_TYPE = 'zeebe:property';
 export const ZEBBE_INPUT_TYPE = 'zeebe:input';
 export const ZEEBE_OUTPUT_TYPE = 'zeebe:output';
 export const ZEEBE_PROPERTY_TYPE = 'zeebe:property';
+export const ZEEBE_TASK_DEFINITION_RETRIES_TYPE = 'zeebe:taskDefinition:retries';
 export const ZEEBE_TASK_DEFINITION_TYPE_TYPE = 'zeebe:taskDefinition:type';
 export const ZEEBE_TASK_HEADER_TYPE = 'zeebe:taskHeader';
 
@@ -11,11 +12,13 @@ export const EXTENSION_BINDING_TYPES = [
   ZEBBE_INPUT_TYPE,
   ZEEBE_OUTPUT_TYPE,
   ZEEBE_PROPERTY_TYPE,
+  ZEEBE_TASK_DEFINITION_RETRIES_TYPE,
   ZEEBE_TASK_DEFINITION_TYPE_TYPE,
   ZEEBE_TASK_HEADER_TYPE
 ];
 
 export const TASK_DEFINITION_TYPES = [
+  ZEEBE_TASK_DEFINITION_RETRIES_TYPE,
   ZEEBE_TASK_DEFINITION_TYPE_TYPE
 ];
 

--- a/src/provider/cloud-element-templates/util/propertyUtil.js
+++ b/src/provider/cloud-element-templates/util/propertyUtil.js
@@ -13,7 +13,7 @@ import {
   ZEBBE_INPUT_TYPE,
   ZEEBE_OUTPUT_TYPE,
   ZEEBE_PROPERTY_TYPE,
-  ZEEBE_TASK_HEADER_TYPE
+  ZEEBE_TASK_HEADER_TYPE, ZEEBE_TASK_DEFINITION_RETRIES_TYPE
 } from '../util/bindingTypes';
 
 import {
@@ -26,7 +26,7 @@ import {
 
 import {
   createInputParameter,
-  createOutputParameter,
+  createOutputParameter, createTaskDefinitionWithRetries,
   createTaskDefinitionWithType,
   createTaskHeader,
   createZeebeProperty,
@@ -251,6 +251,8 @@ export function setPropertyValue(bpmnFactory, commandStack, element, property, v
 
     if (type === ZEEBE_TASK_DEFINITION_TYPE_TYPE) {
       newTaskDefinition = createTaskDefinitionWithType(value, bpmnFactory);
+    } else if (type === ZEEBE_TASK_DEFINITION_RETRIES_TYPE) {
+      newTaskDefinition = createTaskDefinitionWithRetries(value, bpmnFactory);
     } else {
       throw unknownBindingError(element, property);
     }

--- a/test/spec/provider/cloud-element-templates/fixtures/complex.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/complex.json
@@ -149,10 +149,17 @@
     "entriesVisible": true,
     "properties": [
       {
-        "type": "Hidden",
+        "type": "String",
         "value": "http",
         "binding": {
           "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "type": "String",
+        "value": "5",
+        "binding": {
+          "type": "zeebe:taskDefinition:retries"
         }
       },
       {


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->

WIP / RFC

This PR is related to https://github.com/camunda/camunda-modeler/issues/2936 and hopes to allow to see and edit retries in zeebe/cloud/v8 element templates.
This should be doable now that schema support landed with https://github.com/camunda/element-templates-json-schema/pull/90 

This is very definitely not working and probably very misguided
- mostly duplicating code related to `taskDefinition:type` to service `taskDefinition:retries`
- `type` and `retries` are two keys attached to the `taskDefinition`, yet I cannot figure out how to merge those two attributes when processing a change on one of them... so I just duplicated the independent taskCreation logic
- I tried to see how this behaved by running `npm run start:cloud-templates` *but* I couldn't figure out how to inject the latest / master element-templates-json-schema... So no way to test this.

CC @nikku I'm afraid I won't be able to go much further without help.
