### PR TITLE
Allow Timedate in boundary timers. 

### DIFF
--- a/src/provider/zeebe/properties/TimerProps.js
+++ b/src/provider/zeebe/properties/TimerProps.js
@@ -265,6 +265,10 @@ function isTimerDefinitionTypeSupported(timerDefinitionType, element) {
     if (is(element, 'bpmn:StartEvent')) {
       return true;
     }
+
+    if (is(element, 'bpmn:BoundaryEvent')) {
+      return true;
+    }
     return false;
 
   case 'timeCycle':

--- a/test/spec/provider/zeebe/TimerProps.spec.js
+++ b/test/spec/provider/zeebe/TimerProps.spec.js
@@ -73,7 +73,8 @@ describe('provider/zeebe - TimerProps', function() {
             elementRegistry.get('nonInterruptingBoundaryEventCycle'),
             elementRegistry.get('timerStartEventEmpty'),
             elementRegistry.get('nonInterruptingTimerStartEventCycle'),
-            elementRegistry.get('nonInterruptingTimerStartEventDate')
+            elementRegistry.get('nonInterruptingTimerStartEventDate'),
+            elementRegistry.get('interruptingBoundaryEventDuration')
           ];
 
           for (const element of elements) {
@@ -96,7 +97,6 @@ describe('provider/zeebe - TimerProps', function() {
           // given
           const elements = [
             elementRegistry.get('intermediateTimerCatchEventDuration'),
-            elementRegistry.get('interruptingBoundaryEventDuration'),
             elementRegistry.get('interruptingTimerStartEventDate')
           ];
 


### PR DESCRIPTION
This addresses the issue: https://github.com/camunda/camunda-modeler/issues/3516

I would like to allow a TimeDate for both interrupting and non-interrupting boundary timers, as this seems to be allowed.
As per the other Issue @nikku reached out to the zeebe Core team if this should be allowed.

I have managed to deploy a bmpn model to a self-managed Camunda, but the documentation does not say that this should be possible. 

The change is luckily rather minimal. 
