### PR TITLE
Fix element template properties order

### DIFF
--- a/src/provider/cloud-element-templates/UpdateTemplatePropertiesOrder.js
+++ b/src/provider/cloud-element-templates/UpdateTemplatePropertiesOrder.js
@@ -1,6 +1,7 @@
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
 import { isObject } from 'min-dash';
+import { applyConditions } from './Condition';
 import { findExtension } from './Helper';
 
 /**
@@ -34,7 +35,7 @@ export default class UpdateTemplatePropertiesOrder extends CommandInterceptor {
       return;
     }
 
-    const templateProperties = template.properties;
+    const templateProperties = applyConditions(element, template).properties;
 
     // zeebe:Property
     const zeebeProperties = findExtension(businessObject, 'zeebe:Properties');

--- a/test/spec/provider/cloud-element-templates/fixtures/complex.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/complex.json
@@ -683,5 +683,933 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "GitLab Connector",
+    "id": "io.camunda.connectors.GitLab.v1",
+    "version": 1,
+    "description": "Administer and work with issues and releases",
+    "icon": {
+      "contents": "data:image/svg+xml;utf8,%3Csvg width='18px' height='18px' viewBox='0 -10 256 256' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' preserveAspectRatio='xMidYMid'%3E%3Cg%3E%3Cpath d='M128.07485,236.074667 L128.07485,236.074667 L175.17885,91.1043048 L80.9708495,91.1043048 L128.07485,236.074667 L128.07485,236.074667 Z' fill='%23E24329'%3E%3C/path%3E%3Cpath d='M128.07485,236.074423 L80.9708495,91.104061 L14.9557638,91.104061 L128.07485,236.074423 L128.07485,236.074423 Z' fill='%23FC6D26'%3E%3C/path%3E%3Cpath d='M14.9558857,91.1044267 L14.9558857,91.1044267 L0.641828571,135.159589 C-0.663771429,139.17757 0.766171429,143.57955 4.18438095,146.06275 L128.074971,236.074789 L14.9558857,91.1044267 L14.9558857,91.1044267 Z' fill='%23FCA326'%3E%3C/path%3E%3Cpath d='M14.9558857,91.1045486 L80.9709714,91.1045486 L52.6000762,3.79026286 C51.1408762,-0.703146667 44.7847619,-0.701927619 43.3255619,3.79026286 L14.9558857,91.1045486 L14.9558857,91.1045486 Z' fill='%23E24329'%3E%3C/path%3E%3Cpath d='M128.07485,236.074423 L175.17885,91.104061 L241.193935,91.104061 L128.07485,236.074423 L128.07485,236.074423 Z' fill='%23FC6D26'%3E%3C/path%3E%3Cpath d='M241.193935,91.1044267 L241.193935,91.1044267 L255.507992,135.159589 C256.813592,139.17757 255.38365,143.57955 251.96544,146.06275 L128.07485,236.074789 L241.193935,91.1044267 L241.193935,91.1044267 Z' fill='%23FCA326'%3E%3C/path%3E%3Cpath d='M241.193935,91.1045486 L175.17885,91.1045486 L203.549745,3.79026286 C205.008945,-0.703146667 211.365059,-0.701927619 212.824259,3.79026286 L241.193935,91.1045486 L241.193935,91.1045486 Z' fill='%23E24329'%3E%3C/path%3E%3C/g%3E%3C/svg%3E"
+    },
+    "category": {
+      "id": "connectors",
+      "name": "Connectors"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:ServiceTask"
+    },
+    "groups": [
+      {
+        "id": "endpoint",
+        "label": "HTTP Endpoint"
+      },
+      {
+        "id": "operation",
+        "label": "Operation"
+      },
+      {
+        "id": "output",
+        "label": "Response Mapping"
+      },
+      {
+        "id": "errors",
+        "label": "Error Handling"
+      }
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "io.camunda:http-json:1",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "group": "authentication",
+        "type": "Hidden",
+        "value": "noAuth",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "authentication.type"
+        }
+      },
+      {
+        "label": "GitLab base URL",
+        "group": "endpoint",
+        "type": "String",
+        "value": "https://gitlab.example.com",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "baseUrl"
+        },
+        "constraints": {
+          "notEmpty": true,
+          "pattern": {
+            "value": "^(=|http://|https://|secrets).*$",
+            "message": "Must be a http(s) URL."
+          }
+        }
+      },
+      {
+        "label": "GitLab access token",
+        "group": "endpoint",
+        "type": "String",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "gitlabAccessToken"
+        },
+        "constraints": {
+          "notEmpty": true
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "={\"PRIVATE-TOKEN\":gitlabAccessToken, \"Content-Type\":\"application/json\"}",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "headers"
+        },
+        "constraints": {
+          "notEmpty": true
+        }
+      },
+      {
+        "label": "Operation group",
+        "id": "operationGroup",
+        "group": "operation",
+        "description": "Choose operation group",
+        "type": "Dropdown",
+        "choices": [
+          {
+            "name": "Issues",
+            "value": "issues"
+          },
+          {
+            "name": "Releases",
+            "value": "releases"
+          }
+        ],
+        "binding": {
+          "type": "zeebe:input",
+          "name": "operationGroup"
+        }
+      },
+      {
+        "label": "Operation",
+        "id": "operation",
+        "group": "operation",
+        "description": "Choose operation to perform",
+        "type": "Dropdown",
+        "choices": [
+          {
+            "name": "Get an issue by ID",
+            "value": "getIssueById"
+          },
+          {
+            "name": "Create an issue",
+            "value": "createAnIssue"
+          },
+          {
+            "name": "Delete an issue",
+            "value": "deleteAnIssue"
+          },
+          {
+            "name": "Comment to an issue",
+            "value": "commentToAnIssue"
+          },
+          {
+            "name": "Search issues",
+            "value": "searchIssues"
+          }
+        ],
+        "binding": {
+          "type": "zeebe:input",
+          "name": "operation"
+        },
+        "condition": {
+          "property": "operationGroup",
+          "equals": "issues"
+        }
+      },
+      {
+        "label": "Operation",
+        "id": "operation",
+        "group": "operation",
+        "description": "Choose operation to perform",
+        "type": "Dropdown",
+        "choices": [
+          {
+            "name": "List all releases by project ID",
+            "value": "getReleasesByProjectId"
+          },
+          {
+            "name": "Get release by a tag name",
+            "value": "getReleaseByTagName"
+          },
+          {
+            "name": "Create a release",
+            "value": "createRelease"
+          }
+        ],
+        "binding": {
+          "type": "zeebe:input",
+          "name": "operation"
+        },
+        "condition": {
+          "property": "operationGroup",
+          "equals": "releases"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "get",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "method"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "getIssueById",
+            "searchIssues",
+            "getReleasesByProjectId",
+            "getReleaseByTagName"
+          ]
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "post",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "method"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "commentToAnIssue",
+            "createAnIssue",
+            "createRelease"
+          ]
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "delete",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "method"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "deleteAnIssue"
+          ]
+        }
+      },
+      {
+        "label": "Project ID",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "projectId"
+        },
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "getIssueById"
+          ]
+        }
+      },
+      {
+        "label": "Issue ID",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "issueId"
+        },
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "getIssueById"
+          ]
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "=baseUrl + \"/api/v4/projects/\"+ projectId +\"/issues/\" + issueId",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "url"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "getIssueById"
+          ]
+        }
+      },
+      {
+        "label": "Project ID",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "projectId"
+        },
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "createAnIssue"
+          ]
+        }
+      },
+      {
+        "label": "Title",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "issueTitle"
+        },
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "createAnIssue"
+          ]
+        }
+      },
+      {
+        "label": "Description",
+        "group": "operation",
+        "type": "Text",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "issueDescription"
+        },
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "createAnIssue"
+          ]
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "=baseUrl + \"/api/v4/projects/\"+ projectId +\"/issues\"",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "url"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "createAnIssue"
+          ]
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "={\"title\":issueTitle, \"description\":issueDescription}",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "queryParameters"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "createAnIssue"
+          ]
+        }
+      },
+      {
+        "label": "Project ID",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "projectId"
+        },
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "deleteAnIssue"
+          ]
+        }
+      },
+      {
+        "label": "Issue ID",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "issueId"
+        },
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "deleteAnIssue"
+          ]
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "=baseUrl + \"/api/v4/projects/\"+ projectId +\"/issues/\" + issueId",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "url"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "deleteAnIssue"
+          ]
+        }
+      },
+      {
+        "label": "Project ID",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "projectId"
+        },
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "commentToAnIssue"
+          ]
+        }
+      },
+      {
+        "label": "Issue ID",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "issueId"
+        },
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "commentToAnIssue"
+          ]
+        }
+      },
+      {
+        "label": "Note text",
+        "group": "operation",
+        "type": "Text",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "commentBody"
+        },
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "commentToAnIssue"
+          ]
+        }
+      },
+      {
+        "label": "Level on confidentiality",
+        "group": "operation",
+        "description": "Define whether issue is confidential",
+        "type": "Dropdown",
+        "value": "false",
+        "choices": [
+          {
+            "name": "Confidential",
+            "value": "true"
+          },
+          {
+            "name": "Non-confidential",
+            "value": "false"
+          }
+        ],
+        "binding": {
+          "type": "zeebe:input",
+          "name": "issueIsConfidential"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "commentToAnIssue"
+          ]
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "={\"body\":commentBody, \"confidential\":issueIsConfidential}",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "queryParameters"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "commentToAnIssue"
+          ]
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "=baseUrl + \"/api/v4/projects/\"+ projectId +\"/issues/\" + issueId + \"notes\"",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "url"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "commentToAnIssue"
+          ]
+        }
+      },
+      {
+        "label": "Scope",
+        "group": "operation",
+        "type": "Dropdown",
+        "optional": true,
+        "value": "all",
+        "choices": [
+          {
+            "name": "All",
+            "value": "all"
+          },
+          {
+            "name": "Created by access token owner",
+            "value": "created_by_me"
+          },
+          {
+            "name": "Assigned by access token owner",
+            "value": "assigned_to_me"
+          }
+        ],
+        "binding": {
+          "type": "zeebe:input",
+          "name": "searchIssueScope"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "searchIssues"
+          ]
+        }
+      },
+      {
+        "label": "State",
+        "group": "operation",
+        "type": "Dropdown",
+        "value": "all",
+        "optional": true,
+        "choices": [
+          {
+            "name": "All",
+            "value": "all"
+          },
+          {
+            "name": "Opened",
+            "value": "opened"
+          },
+          {
+            "name": "Closed",
+            "value": "closed"
+          }
+        ],
+        "binding": {
+          "type": "zeebe:input",
+          "name": "searchIssueState"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "searchIssues"
+          ]
+        }
+      },
+      {
+        "label": "Assignee ID",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "searchIssueAssigneeId"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "searchIssues"
+          ]
+        }
+      },
+      {
+        "label": "Assignee username",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "searchIssueAssigneeUsername"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "searchIssues"
+          ]
+        }
+      },
+      {
+        "label": "Author ID",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "searchIssueAuthorId"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "searchIssues"
+          ]
+        }
+      },
+      {
+        "label": "Contains text",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "searchIssueSearch"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "searchIssues"
+          ]
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "={\"state\":if searchIssueState = null then null else searchIssueState, \"scope\": if searchIssueScope = null then null else searchIssueScope, \"assignee_id\": if searchIssueAssigneeId = null then null else searchIssueAssigneeId, \"assignee_username\": if searchIssueAssigneeUsername = null then null else searchIssueAssigneeUsername, \"author_id\": if searchIssueAuthorId = null then null else searchIssueAuthorId, \"search\": if searchIssueSearch = null then null else searchIssueSearch}",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "queryParameters"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "searchIssues"
+          ]
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "=baseUrl + \"/api/v4/issues\"",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "url"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "searchIssues"
+          ]
+        }
+      },
+      {
+        "label": "Project ID",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "projectId"
+        },
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "getReleasesByProjectId"
+          ]
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "=baseUrl + \"/api/v4/projects/\"+ projectId +\"/releases\"",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "url"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "getReleasesByProjectId"
+          ]
+        }
+      },
+      {
+        "label": "Project ID",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "projectId"
+        },
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "getReleaseByTagName"
+          ]
+        }
+      },
+      {
+        "label": "Tag name",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "releaseTagName"
+        },
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "getReleaseByTagName"
+          ]
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "=baseUrl + \"/api/v4/projects/\"+ projectId +\"/releases/\" + releaseTagName",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "url"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "getReleaseByTagName"
+          ]
+        }
+      },
+      {
+        "label": "Project ID",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "projectId"
+        },
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "createRelease"
+          ]
+        }
+      },
+      {
+        "label": "Tag name",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "releaseTagName"
+        },
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "createRelease"
+          ]
+        }
+      },
+      {
+        "label": "Ref",
+        "description": "Commit or branch name to create release from",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "releaseRef"
+        },
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "createRelease"
+          ]
+        }
+      },
+      {
+        "label": "Release name",
+        "group": "operation",
+        "type": "String",
+        "feel": "optional",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "releaseName"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "createRelease"
+          ]
+        }
+      },
+      {
+        "label": "Description",
+        "group": "operation",
+        "type": "Text",
+        "feel": "optional",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "releaseDescription"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "createRelease"
+          ]
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "=baseUrl + \"/api/v4/projects/\"+ projectId +\"/releases\"",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "url"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "createRelease"
+          ]
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "={\"tag_name\": if releaseTagName = null then null else releaseTagName, \"name\": if releaseName = null then null else releaseName, \"description\": if releaseDescription = null then releaseDescription else releaseDescription, \"ref\": if releaseRef = null then null else releaseRef}",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "body"
+        },
+        "condition": {
+          "property": "operation",
+          "oneOf": [
+            "createRelease"
+          ]
+        }
+      },
+      {
+        "label": "Result Variable",
+        "description": "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>",
+        "group": "output",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "resultVariable"
+        }
+      },
+      {
+        "label": "Result Expression",
+        "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
+        "group": "output",
+        "type": "Text",
+        "feel": "required",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "resultExpression"
+        }
+      },
+      {
+        "label": "Error Expression",
+        "description": "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#bpmn-errors\" target=\"_blank\">documentation</a>",
+        "group": "errors",
+        "type": "Text",
+        "feel": "required",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "errorExpression"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/provider/cloud-element-templates/properties/UpdateTemplatePropertiesOrder.bpmn
+++ b/test/spec/provider/cloud-element-templates/properties/UpdateTemplatePropertiesOrder.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_00cqa19" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_00cqa19" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.9.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:serviceTask id="TASK" name="TASK" zeebe:modelerTemplate="cloud-element-templates.properties.UpdateProperties.order">
       <bpmn:extensionElements>
@@ -20,7 +20,7 @@
       </bpmn:extensionElements>
     </bpmn:serviceTask>
     <bpmn:serviceTask id="TASK_condition" name="TASK_condition" zeebe:modelerTemplate="cloud-element-templates.properties.UpdateProperties.order">
-       <bpmn:extensionElements>
+      <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:input source="input-2-source" target="input-2-target" />
           <zeebe:input source="input-3-source" target="input-3-target" />
@@ -36,6 +36,24 @@
         </zeebe:properties>
       </bpmn:extensionElements>
     </bpmn:serviceTask>
+    <bpmn:task id="Task2_conditions" name="foo" zeebe:modelerTemplate="cloud-element-templates.properties.UpdateProperties.order-conditions">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="2" target="input-2" />
+          <zeebe:input source="1" target="input-1" />
+          <zeebe:output source="output-2" target="2" />
+          <zeebe:output source="output-1" target="1" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="header-2" value="2" />
+          <zeebe:header key="header-1" value="1" />
+        </zeebe:taskHeaders>
+        <zeebe:properties>
+          <zeebe:property name="property-2" value="2" />
+          <zeebe:property name="property-1" value="1" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+    </bpmn:task>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -46,6 +64,9 @@
       <bpmndi:BPMNShape id="Activity_11gpt0o_di" bpmnElement="TASK_condition">
         <dc:Bounds x="310" y="80" width="100" height="80" />
         <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_07pe8vo_di" bpmnElement="Task2_conditions">
+        <dc:Bounds x="160" y="200" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/cloud-element-templates/properties/UpdateTemplatePropertiesOrder.json
+++ b/test/spec/provider/cloud-element-templates/properties/UpdateTemplatePropertiesOrder.json
@@ -1,7 +1,7 @@
 [
   {
     "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-    "name": "Update Properties - Order",
+    "name": "Update Properties Order",
     "id": "cloud-element-templates.properties.UpdateProperties.order",
     "appliesTo": [
       "bpmn:ServiceTask"
@@ -129,6 +129,170 @@
         "binding": {
           "type": "zeebe:property",
           "name": "property-3-name"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Update Properties Order - conditions",
+    "id": "cloud-element-templates.properties.UpdateProperties.order-conditions",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "foo",
+        "id": "parentProp",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        }
+      },
+      {
+        "type": "String",
+        "label": "Input 2",
+        "id":"hello",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "input-2"
+        },
+        "condition": {
+          "property": "parentProp",
+          "equals": "bar"
+        }
+      },
+      {
+        "label": "Input 1",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "input-1"
+        },
+        "condition": {
+          "property": "parentProp",
+          "equals": "foo"
+        }
+      },
+      {
+        "type": "String",
+        "label": "Input 2",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "input-2"
+        },
+        "condition": {
+          "property": "parentProp",
+          "equals": "foo"
+        }
+      },
+      {
+        "type": "String",
+        "label": "Output 2",
+        "binding": {
+          "type": "zeebe:output",
+          "source": "output-2"
+        },
+        "condition": {
+          "property": "parentProp",
+          "equals": "bar"
+        }
+      },
+      {
+        "label": "Output 1",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:output",
+          "source": "output-1"
+        },
+        "condition": {
+          "property": "parentProp",
+          "equals": "foo"
+        }
+      },
+      {
+        "type": "String",
+        "label": "Output 2",
+        "binding": {
+          "type": "zeebe:output",
+          "source": "output-2"
+        },
+        "condition": {
+          "property": "parentProp",
+          "equals": "foo"
+        }
+      },
+      {
+        "type": "String",
+        "label": "Task Header 2",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "header-2"
+        },
+        "condition": {
+          "property": "parentProp",
+          "equals": "bar"
+        }
+      },
+      {
+        "label": "Task Header 1",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "header-1"
+        },
+        "condition": {
+          "property": "parentProp",
+          "equals": "foo"
+        }
+      },
+      {
+        "type": "String",
+        "label": "Task Header 2",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "header-2"
+        },
+        "condition": {
+          "property": "parentProp",
+          "equals": "foo"
+        }
+      },
+      {
+        "label": "Property 2",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "property-2"
+        },
+        "condition": {
+          "property": "parentProp",
+          "equals": "bar"
+        }
+      },
+      {
+        "label": "Property 1",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "property-1"
+        },
+        "condition": {
+          "property": "parentProp",
+          "equals": "foo"
+        }
+      },
+      {
+        "label": "Property 2",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "property-2"
+        },
+        "condition": {
+          "property": "parentProp",
+          "equals": "foo"
         }
       }
     ]

--- a/test/spec/provider/cloud-element-templates/properties/UpdateTemplatePropertiesOrder.spec.js
+++ b/test/spec/provider/cloud-element-templates/properties/UpdateTemplatePropertiesOrder.spec.js
@@ -79,7 +79,7 @@ describe('provider/cloud-element-templates - UpdateTemplatePropertiesOrder', fun
 
     describe('zeebe:input', function() {
 
-      it('property set', inject(function(elementRegistry, bpmnjs) {
+      it('property set', function() {
 
         // given
         const task = el('TASK');
@@ -96,10 +96,10 @@ describe('provider/cloud-element-templates - UpdateTemplatePropertiesOrder', fun
         ];
 
         expectOrder(ioMapping.inputParameters, expectedInputs);
-      }));
+      });
 
 
-      it('property not set - optional', inject(function(elementRegistry, bpmnjs) {
+      it('property not set - optional', function() {
 
         // given
         const task = el('TASK');
@@ -117,7 +117,7 @@ describe('provider/cloud-element-templates - UpdateTemplatePropertiesOrder', fun
         ];
 
         expectOrder(ioMapping.inputParameters, expectedInputs);
-      }));
+      });
 
 
       it('property not set - conditional', inject(function(modeling) {
@@ -167,7 +167,7 @@ describe('provider/cloud-element-templates - UpdateTemplatePropertiesOrder', fun
 
     describe('zeebe:output', function() {
 
-      it('porperty set', inject(function(elementRegistry, bpmnjs) {
+      it('porperty set', function() {
 
         // given
         const task = el('TASK');
@@ -184,10 +184,10 @@ describe('provider/cloud-element-templates - UpdateTemplatePropertiesOrder', fun
         ];
 
         expectOrder(ioMapping.outputParameters, expectedOutputs);
-      }));
+      });
 
 
-      it('porperty not set - optional', inject(function(elementRegistry, bpmnjs) {
+      it('porperty not set - optional', function() {
 
         // given
         const task = el('TASK');
@@ -205,7 +205,7 @@ describe('provider/cloud-element-templates - UpdateTemplatePropertiesOrder', fun
         ];
 
         expectOrder(ioMapping.outputParameters, expectedOutputs);
-      }));
+      });
 
 
       it('porperty not set - conditional', inject(function(modeling) {
@@ -254,7 +254,7 @@ describe('provider/cloud-element-templates - UpdateTemplatePropertiesOrder', fun
 
     describe('zeebe:property', function() {
 
-      it('property set', inject(function(elementRegistry, bpmnjs) {
+      it('property set', function() {
 
         // given
         const task = el('TASK');
@@ -271,10 +271,10 @@ describe('provider/cloud-element-templates - UpdateTemplatePropertiesOrder', fun
         ];
 
         expectOrder(zeebeProperties.properties, expectedProperties);
-      }));
+      });
 
 
-      it('property not set - optional', inject(function(elementRegistry, bpmnjs) {
+      it('property not set - optional', function() {
 
         // given
         const task = el('TASK');
@@ -292,7 +292,7 @@ describe('provider/cloud-element-templates - UpdateTemplatePropertiesOrder', fun
         ];
 
         expectOrder(zeebeProperties.properties, expectedProperties);
-      }));
+      });
 
 
       it('property not set - conditional', inject(function(modeling) {
@@ -342,7 +342,7 @@ describe('provider/cloud-element-templates - UpdateTemplatePropertiesOrder', fun
 
     describe('zeebe:taskHeader', function() {
 
-      it('property set', inject(function(elementRegistry, bpmnjs) {
+      it('property set', function() {
 
         // given
         const task = el('TASK');
@@ -359,7 +359,7 @@ describe('provider/cloud-element-templates - UpdateTemplatePropertiesOrder', fun
         ];
 
         expectOrder(taskHeaders.values, expectedHeaders);
-      }));
+      });
 
 
       it('property not set - conditional', inject(function(modeling) {

--- a/test/spec/provider/cloud-element-templates/properties/UpdateTemplatePropertiesOrder.spec.js
+++ b/test/spec/provider/cloud-element-templates/properties/UpdateTemplatePropertiesOrder.spec.js
@@ -142,6 +142,26 @@ describe('provider/cloud-element-templates - UpdateTemplatePropertiesOrder', fun
         expectOrder(ioMapping.inputParameters, expectedInputs);
       }));
 
+
+      it('properties with matching binding but different conditions', function() {
+
+        // given
+        const task = el('Task2_conditions');
+
+        // when
+        update(task, 'Input 1', 'foo');
+
+        // then
+        const ioMapping = findExtension(task, 'zeebe:IoMapping');
+
+        const expectedInputs = [
+          findInputParameter(ioMapping, binding(task, 'Input 1')),
+          findInputParameter(ioMapping, binding(task, 'Input 2'))
+        ];
+
+        expectOrder(ioMapping.inputParameters, expectedInputs);
+      });
+
     });
 
 
@@ -208,6 +228,26 @@ describe('provider/cloud-element-templates - UpdateTemplatePropertiesOrder', fun
 
         expectOrder(ioMapping.outputParameters, expectedOutputs);
       }));
+
+
+      it('properties with matching binding but different conditions', function() {
+
+        // given
+        const task = el('Task2_conditions');
+
+        // when
+        update(task, 'Output 1', 'foo');
+
+        // then
+        const ioMapping = findExtension(task, 'zeebe:IoMapping');
+
+        const expectedOutputs = [
+          findOutputParameter(ioMapping, binding(task, 'Output 1')),
+          findOutputParameter(ioMapping, binding(task, 'Output 2'))
+        ];
+
+        expectOrder(ioMapping.outputParameters, expectedOutputs);
+      });
 
     });
 
@@ -277,6 +317,26 @@ describe('provider/cloud-element-templates - UpdateTemplatePropertiesOrder', fun
         expectOrder(zeebeProperties.properties, expectedProperties);
       }));
 
+
+      it('properties with matching binding but different conditions', function() {
+
+        // given
+        const task = el('Task2_conditions');
+
+        // when
+        update(task, 'Property 1', 'foo');
+
+        // then
+        const zeebeProperties = findExtension(task, 'zeebe:Properties');
+
+        const expectedProperties = [
+          findZeebeProperty(zeebeProperties, binding(task, 'Property 1')),
+          findZeebeProperty(zeebeProperties, binding(task, 'Property 2'))
+        ];
+
+        expectOrder(zeebeProperties.properties, expectedProperties);
+      });
+
     });
 
 
@@ -322,6 +382,26 @@ describe('provider/cloud-element-templates - UpdateTemplatePropertiesOrder', fun
 
         expectOrder(taskHeaders.values, expectedHeaders);
       }));
+
+
+      it('properties with matching binding but different conditions', function() {
+
+        // given
+        const task = el('Task2_conditions');
+
+        // when
+        update(task, 'Task Header 1', 'foo');
+
+        // then
+        const taskHeaders = findExtension(task, 'zeebe:TaskHeaders');
+
+        const expectedHeaders = [
+          findTaskHeader(taskHeaders, binding(task, 'Task Header 1')),
+          findTaskHeader(taskHeaders, binding(task, 'Task Header 2'))
+        ];
+
+        expectOrder(taskHeaders.values, expectedHeaders);
+      });
 
 
     });


### PR DESCRIPTION
Closes #897 

Ensure inactive properties (with unmet conditions) are filtered out before re-sorting properties.

Added the Gitlab connector example with 83f30df48043f9d0115bb1179b6a296c4d6cac89. Seems like a good complex example to test but we can just use it to validate this and remove if we don't want to keep it.