### PR TITLE
Support Camunda 8.3 Signal Event Properties

### DIFF
--- a/src/provider/bpmn/properties/SignalProps.js
+++ b/src/provider/bpmn/properties/SignalProps.js
@@ -27,16 +27,15 @@ import {
   nextId
 } from '../../../utils/ElementUtil';
 
-export const EMPTY_OPTION = '';
-export const CREATE_NEW_OPTION = 'create-new';
-
-
 /**
  * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
 
+export const EMPTY_OPTION = '';
+export const CREATE_NEW_OPTION = 'create-new';
+
 /**
- * @returns {Array<Entry>} entries
+ * @returns {Entry[]}
  */
 export function SignalProps(props) {
   const {

--- a/src/provider/zeebe/ZeebePropertiesProvider.js
+++ b/src/provider/zeebe/ZeebePropertiesProvider.js
@@ -16,6 +16,7 @@ import {
   OutputProps,
   ScriptImplementationProps,
   ScriptProps,
+  SignalProps,
   TargetProps,
   TaskDefinitionProps,
   TaskScheduleProps,
@@ -67,6 +68,7 @@ export default class ZeebePropertiesProvider {
       updateErrorGroup(groups, element);
       updateEscalationGroup(groups, element);
       updateMessageGroup(groups, element);
+      updateSignalGroup(groups, element);
       updateTimerGroup(groups, element, this._injector);
       updateMultiInstanceGroup(groups, element);
 
@@ -290,6 +292,19 @@ function updateEscalationGroup(groups, element) {
   escalationGroup.entries = replaceEntries(
     escalationGroup.entries,
     EscalationProps({ element })
+  );
+}
+
+function updateSignalGroup(groups, element) {
+  const signalGroup = findGroup(groups, 'signal');
+
+  if (!signalGroup) {
+    return;
+  }
+
+  signalGroup.entries = replaceEntries(
+    signalGroup.entries,
+    SignalProps({ element })
   );
 }
 

--- a/src/provider/zeebe/ZeebePropertiesProvider.js
+++ b/src/provider/zeebe/ZeebePropertiesProvider.js
@@ -26,6 +26,10 @@ import { ExtensionPropertiesProps } from '../shared/ExtensionPropertiesProps';
 
 import { isMessageEndEvent, isMessageThrowEvent } from './utils/ZeebeServiceTaskUtil';
 
+/**
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
+ */
+
 const LOW_PRIORITY = 500;
 
 const ZEEBE_GROUPS = [
@@ -270,7 +274,7 @@ function updateErrorGroup(groups, element) {
     return;
   }
 
-  errorGroup.entries = overrideGenericEntries(
+  errorGroup.entries = replaceEntries(
     errorGroup.entries,
     ErrorProps({ element })
   );
@@ -283,7 +287,7 @@ function updateEscalationGroup(groups, element) {
     return;
   }
 
-  escalationGroup.entries = overrideGenericEntries(
+  escalationGroup.entries = replaceEntries(
     escalationGroup.entries,
     EscalationProps({ element })
   );
@@ -296,7 +300,7 @@ function updateMessageGroup(groups, element) {
     return;
   }
 
-  messageGroup.entries = overrideGenericEntries(
+  messageGroup.entries = replaceEntries(
     messageGroup.entries,
     MessageProps({ element })
   );
@@ -347,13 +351,14 @@ function findGroup(groups, id) {
 }
 
 /**
- * Replace generic bpmn components with specific zeebe ones.
+ * Replace entries with the same ID.
+ *s
+ * @param {Entry[]} oldEntries
+ * @param {Entry[]} newEntries
  *
- * @param {Array} oldEntries
- * @param {Array} newEntries
- * @returns {Array} combined entries
+ * @returns {Entry[]} combined entries
  */
-function overrideGenericEntries(oldEntries, newEntries) {
+function replaceEntries(oldEntries, newEntries) {
 
   const filteredEntries = oldEntries.filter(oldEntry => (
     !newEntries.find(newEntry => newEntry.id === oldEntry.id)

--- a/src/provider/zeebe/properties/SignalProps.js
+++ b/src/provider/zeebe/properties/SignalProps.js
@@ -1,0 +1,86 @@
+import { isFeelEntryEdited } from '@bpmn-io/properties-panel';
+
+import { FeelEntryWithVariableContext } from '../../../entries/FeelEntryWithContext';
+
+import {
+  useService
+} from '../../../hooks';
+
+import {
+  getSignal,
+  isSignalSupported
+} from '../../../utils/EventDefinitionUtil';
+
+/**
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
+ */
+
+export const EMPTY_OPTION = '';
+export const CREATE_NEW_OPTION = 'create-new';
+
+/**
+ * @returns {Entry[]}
+ */
+export function SignalProps(props) {
+  const {
+    element
+  } = props;
+
+  if (!isSignalSupported(element)) {
+    return [];
+  }
+
+  const signal = getSignal(element);
+
+  let entries = [];
+
+  if (signal) {
+    entries = [
+      ...entries,
+      {
+        id: 'signalName',
+        component: SignalName,
+        isEdited: isFeelEntryEdited
+      },
+    ];
+  }
+
+  return entries;
+}
+
+function SignalName(props) {
+  const { element } = props;
+
+  const commandStack = useService('commandStack');
+  const translate = useService('translate');
+  const debounce = useService('debounceInput');
+
+  const signal = getSignal(element);
+
+  const getValue = () => {
+    return signal.get('name');
+  };
+
+  const setValue = (value) => {
+    return commandStack.execute(
+      'element.updateModdleProperties',
+      {
+        element,
+        moddleElement: signal,
+        properties: {
+          name: value
+        }
+      }
+    );
+  };
+
+  return FeelEntryWithVariableContext({
+    element,
+    id: 'signalName',
+    label: translate('Name'),
+    feel: 'optional',
+    getValue,
+    setValue,
+    debounce
+  });
+}

--- a/src/provider/zeebe/properties/index.js
+++ b/src/provider/zeebe/properties/index.js
@@ -13,6 +13,7 @@ export { OutputPropagationProps } from './OutputPropagationProps';
 export { OutputProps } from './OutputProps';
 export { ScriptImplementationProps } from './ScriptImplementationProps';
 export { ScriptProps } from './ScriptProps';
+export { SignalProps } from './SignalProps';
 export { TargetProps } from './TargetProps';
 export { TaskDefinitionProps } from './TaskDefinitionProps';
 export { TaskScheduleProps } from './TaskScheduleProps';

--- a/src/provider/zeebe/utils/InputOutputUtil.js
+++ b/src/provider/zeebe/utils/InputOutputUtil.js
@@ -15,6 +15,8 @@ import {
 } from '../../../utils/ElementUtil';
 import { isZeebeServiceTask } from './ZeebeServiceTaskUtil';
 
+import { getEventDefinition } from '../../bpmn/utils/EventDefinitionUtil';
+
 function getElements(bo, type, prop) {
   const elems = getExtensionElementsList(bo, type);
   return !prop ? elems : (elems[0] || {})[prop] || [];
@@ -69,7 +71,7 @@ export function areInputParametersSupported(element) {
     'bpmn:CallActivity',
     'bpmn:BusinessRuleTask',
     'bpmn:ScriptTask'
-  ]) || isZeebeServiceTask(element);
+  ]) || isZeebeServiceTask(element) || isSignalThrowEvent(element);
 }
 
 export function areOutputParametersSupported(element) {
@@ -86,4 +88,15 @@ export function areOutputParametersSupported(element) {
 
 export function createIOMapping(properties, parent, bpmnFactory) {
   return createElement('zeebe:IoMapping', properties, parent, bpmnFactory);
+}
+
+function isSignalThrowEvent(element) {
+  if (!isAny(element, [
+    'bpmn:EndEvent',
+    'bpmn:IntermediateThrowEvent'
+  ])) {
+    return false;
+  }
+
+  return !!getEventDefinition(element, 'bpmn:SignalEventDefinition');
 }

--- a/test/spec/provider/zeebe/ErrorProps.spec.js
+++ b/test/spec/provider/zeebe/ErrorProps.spec.js
@@ -103,7 +103,7 @@ describe('provider/zeebe - ErrorProps', function() {
     }));
 
 
-    it('should display expresion-like as text (catch event)', inject(async function(elementRegistry, selection) {
+    it('should display expression-like as text (catch event)', inject(async function(elementRegistry, selection) {
 
       // given
       const errorEvent = elementRegistry.get('ErrorEventWithExpression');

--- a/test/spec/provider/zeebe/InputProps.bpmn
+++ b/test/spec/provider/zeebe/InputProps.bpmn
@@ -33,6 +33,28 @@
         </zeebe:ioMapping>
       </bpmn:extensionElements>
     </bpmn:serviceTask>
+    <bpmn:intermediateThrowEvent id="SignalIntermediateThrowEvent_1" name="SignalIntermediateThrowEvent_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="= inputSourceValue1" target="inputTargetValue1" />
+          <zeebe:input source="= inputSourceValue2" target="inputTargetValue2" />
+          <zeebe:input source="= inputSourceValue3" target="inputTargetValue3" />
+          <zeebe:input source="= inputSourceValue4" target="inputTargetValue4" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_0kvpcac" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="SignalEndEvent_1" name="SignalEndEvent_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="= inputSourceValue1" target="inputTargetValue1" />
+          <zeebe:input source="= inputSourceValue2" target="inputTargetValue2" />
+          <zeebe:input source="= inputSourceValue3" target="inputTargetValue3" />
+          <zeebe:input source="= inputSourceValue4" target="inputTargetValue4" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_0syfq4h" />
+    </bpmn:endEvent>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -59,6 +81,18 @@
       <bpmndi:BPMNShape id="Activity_08s4ehk_di" bpmnElement="ServiceTask_NoIoMapping">
         <dc:Bounds x="240" y="170" width="100" height="80" />
         <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1fg4k22_di" bpmnElement="SignalIntermediateThrowEvent_1">
+        <dc:Bounds x="392" y="82" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="369" y="125" width="83" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_160gbv9_di" bpmnElement="SignalEndEvent_1">
+        <dc:Bounds x="512" y="82" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="487" y="125" width="86" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/zeebe/InputProps.bpmn
+++ b/test/spec/provider/zeebe/InputProps.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.10.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:serviceTask id="ServiceTask_1" name="ServiceTask_1">
       <bpmn:extensionElements>
@@ -11,19 +11,19 @@
         </zeebe:ioMapping>
       </bpmn:extensionElements>
     </bpmn:serviceTask>
-    <bpmn:receiveTask id="ReceiveTask_1" />
-    <bpmn:serviceTask id="ServiceTask_empty" name="empty" />
-    <bpmn:serviceTask id="ServiceTask_2">
+    <bpmn:receiveTask id="ReceiveTask_1" name="ReceiveTask_1" />
+    <bpmn:serviceTask id="ServiceTask_NoExtensionElements" name="ServiceTask_NoExtensionElements" />
+    <bpmn:serviceTask id="ServiceTask_2" name="ServiceTask_2">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:input source="= inputSourceValue1" target="inputTargetValue1" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="ServiceTask_noIoMapping" name="no IoMapping">
+    <bpmn:serviceTask id="ServiceTask_NoIoMapping" name="ServiceTask_NoIoMapping">
       <bpmn:extensionElements />
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="UnsortedServiceTask" name="UnsortedServiceTask">
+    <bpmn:serviceTask id="ServiceTask_Unsorted" name="ServiceTask_Unsorted">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:input source="" target="5" />
@@ -37,23 +37,28 @@
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="ServiceTask_0rud1s3_di" bpmnElement="ServiceTask_1">
-        <dc:Bounds x="160" y="77" width="100" height="80" />
+        <dc:Bounds x="120" y="70" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1dticgb_di" bpmnElement="ServiceTask_2">
+        <dc:Bounds x="240" y="70" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ReceiveTask_0mkif7n_di" bpmnElement="ReceiveTask_1">
-        <dc:Bounds x="320" y="240" width="100" height="80" />
+        <dc:Bounds x="120" y="270" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0v1cphs_di" bpmnElement="ServiceTask_empty">
-        <dc:Bounds x="190" y="370" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_15fgyss_di" bpmnElement="ServiceTask_Unsorted">
+        <dc:Bounds x="360" y="170" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1dticgb_di" bpmnElement="ServiceTask_2">
-        <dc:Bounds x="420" y="100" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_0v1cphs_di" bpmnElement="ServiceTask_NoExtensionElements">
+        <dc:Bounds x="120" y="170" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_08s4ehk_di" bpmnElement="ServiceTask_noIoMapping">
-        <dc:Bounds x="420" y="400" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_15fgyss_di" bpmnElement="UnsortedServiceTask">
-        <dc:Bounds x="650" y="160" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_08s4ehk_di" bpmnElement="ServiceTask_NoIoMapping">
+        <dc:Bounds x="240" y="170" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/zeebe/InputProps.spec.js
+++ b/test/spec/provider/zeebe/InputProps.spec.js
@@ -148,7 +148,7 @@ describe('provider/zeebe - InputProps', function() {
     it('should sort input items according to XML', inject(async function(elementRegistry, selection) {
 
       // given
-      const serviceTask = elementRegistry.get('UnsortedServiceTask');
+      const serviceTask = elementRegistry.get('ServiceTask_Unsorted');
 
       await act(() => {
         selection.select(serviceTask);
@@ -169,7 +169,7 @@ describe('provider/zeebe - InputProps', function() {
       inject(async function(elementRegistry, selection) {
 
         // given
-        const serviceTask = elementRegistry.get('ServiceTask_empty');
+        const serviceTask = elementRegistry.get('ServiceTask_NoExtensionElements');
 
         await act(() => {
           selection.select(serviceTask);
@@ -196,7 +196,7 @@ describe('provider/zeebe - InputProps', function() {
       inject(async function(elementRegistry, selection) {
 
         // given
-        const serviceTask = elementRegistry.get('ServiceTask_noIoMapping');
+        const serviceTask = elementRegistry.get('ServiceTask_NoIoMapping');
 
         await act(() => {
           selection.select(serviceTask);

--- a/test/spec/provider/zeebe/InputProps.spec.js
+++ b/test/spec/provider/zeebe/InputProps.spec.js
@@ -61,32 +61,36 @@ describe('provider/zeebe - InputProps', function() {
   }));
 
 
-  describe('bpmn:ServiceTask#input', function() {
+  it('should NOT display for receive task', inject(async function(elementRegistry, selection) {
 
-    it('should NOT display for receive task', inject(async function(elementRegistry, selection) {
+    // given
+    const receiveTask = elementRegistry.get('ReceiveTask_1');
+
+    await act(() => {
+      selection.select(receiveTask);
+    });
+
+    // when
+    const inputGroup = getGroup(container, 'inputs');
+
+    // then
+    expect(inputGroup).to.not.exist;
+  }));
+
+
+  [
+    [ 'service task', 'ServiceTask_1' ],
+    [ 'signal intermediate throw event', 'SignalIntermediateThrowEvent_1' ],
+    [ 'signal end event', 'SignalEndEvent_1' ]
+  ].forEach(([ label, id ]) => {
+
+    it(`should display - ${ label }`, inject(async function(elementRegistry, selection) {
 
       // given
-      const receiveTask = elementRegistry.get('ReceiveTask_1');
+      const element = elementRegistry.get(id);
 
       await act(() => {
-        selection.select(receiveTask);
-      });
-
-      // when
-      const inputGroup = getGroup(container, 'inputs');
-
-      // then
-      expect(inputGroup).to.not.exist;
-    }));
-
-
-    it('should display', inject(async function(elementRegistry, selection) {
-
-      // given
-      const serviceTask = elementRegistry.get('ServiceTask_1');
-
-      await act(() => {
-        selection.select(serviceTask);
+        selection.select(element);
       });
 
       // when
@@ -95,14 +99,14 @@ describe('provider/zeebe - InputProps', function() {
 
       // then
       expect(inputGroup).to.exist;
-      expect(inputListItems.length).to.equal(getInputParameters(serviceTask).length);
+      expect(inputListItems.length).to.equal(getInputParameters(element).length);
     }));
 
 
-    it('should add new input', inject(async function(elementRegistry, selection) {
+    it(`should add new input - ${ label }`, inject(async function(elementRegistry, selection) {
 
       // given
-      const serviceTask = elementRegistry.get('ServiceTask_1');
+      const serviceTask = elementRegistry.get(id);
 
       await act(() => {
         selection.select(serviceTask);
@@ -121,108 +125,10 @@ describe('provider/zeebe - InputProps', function() {
     }));
 
 
-    it('should add new input to bottom', inject(async function(elementRegistry, selection) {
+    it(`should delete input - ${ label }`, inject(async function(elementRegistry, selection) {
 
       // given
-      const serviceTask = elementRegistry.get('ServiceTask_2');
-
-      await act(() => {
-        selection.select(serviceTask);
-      });
-
-      const inputGroup = getGroup(container, 'inputs');
-      const addEntry = domQuery('.bio-properties-panel-add-entry', inputGroup);
-
-      // when
-      await act(() => {
-        addEntry.click();
-      });
-
-      // then
-      const inputItemLabel = getInputItemLabel(container, 0);
-
-      expect(inputItemLabel.innerHTML).to.equal('inputTargetValue1');
-    }));
-
-
-    it('should sort input items according to XML', inject(async function(elementRegistry, selection) {
-
-      // given
-      const serviceTask = elementRegistry.get('ServiceTask_Unsorted');
-
-      await act(() => {
-        selection.select(serviceTask);
-      });
-
-      // then
-      const inputParameters = getInputParameters(serviceTask);
-
-      for (let idx = 0; idx < inputParameters.length; idx++) {
-        const inputItemLabel = getInputItemLabel(container, idx).innerHTML;
-
-        expect(inputParameters[idx].target).to.equal(inputItemLabel);
-      }
-    }));
-
-
-    it('should create non existing extension elements',
-      inject(async function(elementRegistry, selection) {
-
-        // given
-        const serviceTask = elementRegistry.get('ServiceTask_NoExtensionElements');
-
-        await act(() => {
-          selection.select(serviceTask);
-        });
-
-        // assume
-        expect(getBusinessObject(serviceTask).get('extensionElements')).not.to.exist;
-
-        const inputGroup = getGroup(container, 'inputs');
-        const addEntry = domQuery('.bio-properties-panel-add-entry', inputGroup);
-
-        // when
-        await act(() => {
-          addEntry.click();
-        });
-
-        // then
-        expect(getBusinessObject(serviceTask).get('extensionElements')).to.exist;
-      })
-    );
-
-
-    it('should create non existing ioMapping',
-      inject(async function(elementRegistry, selection) {
-
-        // given
-        const serviceTask = elementRegistry.get('ServiceTask_NoIoMapping');
-
-        await act(() => {
-          selection.select(serviceTask);
-        });
-
-        // assume
-        expect(getIoMapping(serviceTask)).not.to.exist;
-
-        const inputGroup = getGroup(container, 'inputs');
-        const addEntry = domQuery('.bio-properties-panel-add-entry', inputGroup);
-
-        // when
-        await act(() => {
-          addEntry.click();
-        });
-
-        // then
-        expect(getIoMapping(serviceTask)).to.exist;
-      })
-    );
-
-
-    it('should delete input', inject(async function(elementRegistry, selection) {
-
-      // given
-      const serviceTask = elementRegistry.get('ServiceTask_1');
+      const serviceTask = elementRegistry.get(id);
 
       await act(() => {
         selection.select(serviceTask);
@@ -241,36 +147,11 @@ describe('provider/zeebe - InputProps', function() {
     }));
 
 
-    it('should remove ioMapping on last delete', inject(async function(elementRegistry, selection) {
-
-      // given
-      const serviceTask = elementRegistry.get('ServiceTask_2');
-
-      await act(() => {
-        selection.select(serviceTask);
-      });
-
-      // assume
-      expect(getIoMapping(serviceTask)).to.exist;
-
-      const inputListItems = getInputListItems(getGroup(container, 'inputs'));
-      const removeEntry = domQuery('.bio-properties-panel-remove-entry', inputListItems[0]);
-
-      // when
-      await act(() => {
-        removeEntry.click();
-      });
-
-      // then
-      expect(getIoMapping(serviceTask)).not.to.exist;
-    }));
-
-
-    it('should update on external change',
+    it(`should update on external change - ${ label }`,
       inject(async function(elementRegistry, selection, commandStack) {
 
         // given
-        const serviceTask = elementRegistry.get('ServiceTask_1');
+        const serviceTask = elementRegistry.get(id);
         const originalInputs = getInputParameters(serviceTask);
 
         await act(() => {
@@ -295,6 +176,129 @@ describe('provider/zeebe - InputProps', function() {
     );
 
   });
+
+
+  it('should add new input to bottom', inject(async function(elementRegistry, selection) {
+
+    // given
+    const serviceTask = elementRegistry.get('ServiceTask_2');
+
+    await act(() => {
+      selection.select(serviceTask);
+    });
+
+    const inputGroup = getGroup(container, 'inputs');
+    const addEntry = domQuery('.bio-properties-panel-add-entry', inputGroup);
+
+    // when
+    await act(() => {
+      addEntry.click();
+    });
+
+    // then
+    const inputItemLabel = getInputItemLabel(container, 0);
+
+    expect(inputItemLabel.innerHTML).to.equal('inputTargetValue1');
+  }));
+
+
+  it('should sort input items according to XML', inject(async function(elementRegistry, selection) {
+
+    // given
+    const serviceTask = elementRegistry.get('ServiceTask_Unsorted');
+
+    await act(() => {
+      selection.select(serviceTask);
+    });
+
+    // then
+    const inputParameters = getInputParameters(serviceTask);
+
+    for (let idx = 0; idx < inputParameters.length; idx++) {
+      const inputItemLabel = getInputItemLabel(container, idx).innerHTML;
+
+      expect(inputParameters[idx].target).to.equal(inputItemLabel);
+    }
+  }));
+
+
+  it('should create non existing extension elements',
+    inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_NoExtensionElements');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // assume
+      expect(getBusinessObject(serviceTask).get('extensionElements')).not.to.exist;
+
+      const inputGroup = getGroup(container, 'inputs');
+      const addEntry = domQuery('.bio-properties-panel-add-entry', inputGroup);
+
+      // when
+      await act(() => {
+        addEntry.click();
+      });
+
+      // then
+      expect(getBusinessObject(serviceTask).get('extensionElements')).to.exist;
+    })
+  );
+
+
+  it('should create non existing ioMapping',
+    inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_NoIoMapping');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // assume
+      expect(getIoMapping(serviceTask)).not.to.exist;
+
+      const inputGroup = getGroup(container, 'inputs');
+      const addEntry = domQuery('.bio-properties-panel-add-entry', inputGroup);
+
+      // when
+      await act(() => {
+        addEntry.click();
+      });
+
+      // then
+      expect(getIoMapping(serviceTask)).to.exist;
+    })
+  );
+
+
+  it('should remove ioMapping on last delete', inject(async function(elementRegistry, selection) {
+
+    // given
+    const serviceTask = elementRegistry.get('ServiceTask_2');
+
+    await act(() => {
+      selection.select(serviceTask);
+    });
+
+    // assume
+    expect(getIoMapping(serviceTask)).to.exist;
+
+    const inputListItems = getInputListItems(getGroup(container, 'inputs'));
+    const removeEntry = domQuery('.bio-properties-panel-remove-entry', inputListItems[0]);
+
+    // when
+    await act(() => {
+      removeEntry.click();
+    });
+
+    // then
+    expect(getIoMapping(serviceTask)).not.to.exist;
+  }));
 
 });
 

--- a/test/spec/provider/zeebe/OutputProps.bpmn
+++ b/test/spec/provider/zeebe/OutputProps.bpmn
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.10.0">
   <bpmn:process id="Process_1" isExecutable="true">
-    <bpmn:serviceTask id="ServiceTask_1">
+    <bpmn:serviceTask id="ServiceTask_1" name="ServiceTask_1">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="= outputSourceValue1" target="outputTargetValue1" />
@@ -11,19 +11,19 @@
         </zeebe:ioMapping>
       </bpmn:extensionElements>
     </bpmn:serviceTask>
-    <bpmn:task id="Task_1" />
-    <bpmn:serviceTask id="ServiceTask_empty" name="empty" />
-    <bpmn:serviceTask id="ServiceTask_2">
+    <bpmn:task id="Task_1" name="Task_1" />
+    <bpmn:serviceTask id="ServiceTask_NoExtensionElements" name="ServiceTask_NoExtensionElements" />
+    <bpmn:serviceTask id="ServiceTask_2" name="ServiceTask_2">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="= outputSourceValue1" target="outputTargetValue1" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="ServiceTask_noIoMapping" name="no IoMapping">
+    <bpmn:serviceTask id="ServiceTask_NoIoMapping" name="ServiceTask_NoIoMapping">
       <bpmn:extensionElements />
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="UnsortedServiceTask" name="UnsortedServiceTask">
+    <bpmn:serviceTask id="ServiceTask_Unsorted" name="ServiceTask_Unsorted">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="" target="5" />
@@ -37,22 +37,28 @@
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="ServiceTask_0rud1s3_di" bpmnElement="ServiceTask_1">
-        <dc:Bounds x="160" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0tyoei0_di" bpmnElement="Task_1">
-        <dc:Bounds x="340" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_10ckisu_di" bpmnElement="ServiceTask_empty">
-        <dc:Bounds x="200" y="230" width="100" height="80" />
+        <dc:Bounds x="160" y="60" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1jxbsb5_di" bpmnElement="ServiceTask_2">
-        <dc:Bounds x="440" y="230" width="100" height="80" />
+        <dc:Bounds x="280" y="60" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_18i7pky_di" bpmnElement="ServiceTask_noIoMapping">
-        <dc:Bounds x="370" y="400" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_10ckisu_di" bpmnElement="ServiceTask_NoExtensionElements">
+        <dc:Bounds x="160" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1w6wh2a_di" bpmnElement="UnsortedServiceTask">
-        <dc:Bounds x="640" y="110" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_18i7pky_di" bpmnElement="ServiceTask_NoIoMapping">
+        <dc:Bounds x="280" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1w6wh2a_di" bpmnElement="ServiceTask_Unsorted">
+        <dc:Bounds x="400" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0tyoei0_di" bpmnElement="Task_1">
+        <dc:Bounds x="160" y="260" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/zeebe/OutputProps.spec.js
+++ b/test/spec/provider/zeebe/OutputProps.spec.js
@@ -148,7 +148,7 @@ describe('provider/zeebe - OutputProps', function() {
     it('should sort output items according to XML', inject(async function(elementRegistry, selection) {
 
       // given
-      const serviceTask = elementRegistry.get('UnsortedServiceTask');
+      const serviceTask = elementRegistry.get('ServiceTask_Unsorted');
 
       await act(() => {
         selection.select(serviceTask);
@@ -169,7 +169,7 @@ describe('provider/zeebe - OutputProps', function() {
       inject(async function(elementRegistry, selection) {
 
         // given
-        const serviceTask = elementRegistry.get('ServiceTask_empty');
+        const serviceTask = elementRegistry.get('ServiceTask_NoExtensionElements');
 
         await act(() => {
           selection.select(serviceTask);
@@ -196,7 +196,7 @@ describe('provider/zeebe - OutputProps', function() {
       inject(async function(elementRegistry, selection) {
 
         // given
-        const serviceTask = elementRegistry.get('ServiceTask_noIoMapping');
+        const serviceTask = elementRegistry.get('ServiceTask_NoIoMapping');
 
         await act(() => {
           selection.select(serviceTask);

--- a/test/spec/provider/zeebe/SignalProps.bpmn
+++ b/test/spec/provider/zeebe/SignalProps.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1nq3bn3" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.10.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:intermediateThrowEvent id="SignalIntermediateThrowEvent_Static" name="SignalIntermediateThrowEvent_Static">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_1g3f14b" signalRef="Signal_2edkina" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateThrowEvent id="SignalIntermediateThrowEvent_Expression" name="SignalIntermediateThrowEvent_Expression">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_196tqut" signalRef="Signal_0rg0snp" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="SignalEndEvent_Static" name="SignalEndEvent_Static">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_1szkkeb" signalRef="Signal_2edkina" />
+    </bpmn:endEvent>
+    <bpmn:endEvent id="SignalEndEvent_Expression" name="SignalEndEvent_Expression">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_1yl4jow" signalRef="Signal_0rg0snp" />
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:signal id="Signal_2edkina" name="foo" />
+  <bpmn:signal id="Signal_0rg0snp" name="=foo" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_148s8p3_di" bpmnElement="SignalIntermediateThrowEvent_Static">
+        <dc:Bounds x="182" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="158" y="122" width="84" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0b2tbaq_di" bpmnElement="SignalIntermediateThrowEvent_Expression">
+        <dc:Bounds x="182" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="157" y="205" width="87" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0x4l2mz_di" bpmnElement="SignalEndEvent_Static">
+        <dc:Bounds x="292" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="122" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1e82e3p_di" bpmnElement="SignalEndEvent_Expression">
+        <dc:Bounds x="292" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="205" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/zeebe/SignalProps.spec.js
+++ b/test/spec/provider/zeebe/SignalProps.spec.js
@@ -1,0 +1,217 @@
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  act
+} from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  changeInput,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/render';
+
+// these properties can't live without the generic BPMN error props
+import BpmnPropertiesProvider from 'src/provider/bpmn';
+import ZeebePropertiesProvider from 'src/provider/zeebe';
+
+import DescriptionProvider from 'src/contextProvider/zeebe/DescriptionProvider';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import {
+  getSignal
+} from 'src/provider/bpmn/utils/EventDefinitionUtil';
+
+import diagramXML from './SignalProps.bpmn';
+import { setEditorValue } from '../../../TestHelper';
+
+
+describe('provider/zeebe - SignalProps', function() {
+
+  const testModules = [
+    CoreModule,
+    SelectionModule,
+    ModelingModule,
+    BpmnPropertiesPanel,
+    BpmnPropertiesProvider,
+    ZeebePropertiesProvider
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    modules: testModules,
+    moddleExtensions,
+    propertiesPanel: {
+      description: DescriptionProvider
+    },
+    debounceInput: false
+  }));
+
+
+  describe('bpmn:Signal#name', function() {
+
+    [
+      [ 'intermediate throw event', 'SignalIntermediateThrowEvent' ],
+      [ 'end event', 'SignalEndEvent' ]
+    ].forEach(([ label, id ]) => {
+
+      it(`${ label } - should display (static)`, inject(async function(elementRegistry, selection) {
+
+        // given
+        const signalEvent = elementRegistry.get(`${ id }_Static`);
+
+        await act(() => {
+          selection.select(signalEvent);
+        });
+
+        // when
+        const signalNameInput = domQuery('input[name=signalName]', container);
+
+        // then
+        expect(signalNameInput).to.exist;
+      }));
+
+
+      it(`${ label } - should display (expression)`, inject(async function(elementRegistry, selection) {
+
+        // given
+        const signalEvent = elementRegistry.get(`${ id }_Expression`);
+
+        await act(() => {
+          selection.select(signalEvent);
+        });
+
+        // when
+        const signalNameInput = domQuery('[name=signalName]', container);
+
+        // then
+        expect(signalNameInput).to.exist;
+      }));
+
+
+      it(`${ label } - should display FEEL icon`, inject(async function(elementRegistry, selection) {
+
+        // given
+        const signalEvent = elementRegistry.get(`${ id }_Static`);
+
+        await act(() => {
+          selection.select(signalEvent);
+        });
+
+        // when
+        const signalNameIcon = domQuery('[data-entry-id="signalName"] .bio-properties-panel-feel-icon', container);
+
+        // then
+        expect(signalNameIcon).to.exist;
+      }));
+
+
+      it(`${ label } - should update (text)`, inject(async function(elementRegistry, selection) {
+
+        // given
+        const signalEvent = elementRegistry.get(`${ id }_Static`);
+
+        await act(() => {
+          selection.select(signalEvent);
+        });
+
+        // when
+        const signalNameInput = domQuery('input[name=signalName]', container);
+
+        await act(() => {
+          changeInput(signalNameInput, 'newValue');
+        });
+
+        // then
+        expect(getSignal(signalEvent).get('name')).to.equal('newValue');
+      }));
+
+
+      it(`${ label } - should update (expression)`, inject(async function(elementRegistry, selection) {
+
+        // given
+        const signalEvent = elementRegistry.get(`${ id }_Expression`);
+
+        await act(() => {
+          selection.select(signalEvent);
+        });
+
+        // when
+        const signalNameInput = domQuery('[name=signalName] [role=textbox]', container);
+
+        await setEditorValue(signalNameInput, 'newValue');
+
+        // then
+        expect(getSignal(signalEvent).get('name')).to.equal('=newValue');
+      }));
+
+
+      it(`${ label } - should update on external change`, inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const signalEvent = elementRegistry.get(`${ id }_Static`);
+
+        const originalValue = getSignal(signalEvent).get('name');
+
+        await act(() => {
+          selection.select(signalEvent);
+        });
+
+        const signalNameInput = domQuery('input[name=signalName]', container);
+
+        changeInput(signalNameInput, 'newValue');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(signalNameInput.value).to.equal(originalValue);
+      }));
+
+
+      it(`${ label } - should not blow up on empty error code`, inject(async function(elementRegistry, selection) {
+
+        // given
+        const signalEvent = elementRegistry.get(`${ id }_Static`);
+
+        await act(() => {
+          selection.select(signalEvent);
+        });
+
+        // when
+        const signalNameInput = domQuery('input[name=signalName]', container);
+
+        await act(() => {
+          changeInput(signalNameInput, '');
+        });
+
+        // then
+        expect(getSignal(signalEvent).get('name')).to.be.undefined;
+      }));
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
* add _Inputs_ group for signal intermediate throw and end events
* change signal _Name_ entry to optional FEEL entry

![image](https://user-images.githubusercontent.com/7633572/234803916-a944df5c-b96d-4df9-8cf7-73d5675695b9.png)

---

Closes https://github.com/bpmn-io/bpmn-js-properties-panel/issues/909