### PR TITLE
chore(TimerProps): separate BPMN and Camunda 7 concerns

### DIFF
--- a/src/provider/bpmn/properties/TimerProps.js
+++ b/src/provider/bpmn/properties/TimerProps.js
@@ -1,6 +1,5 @@
 import {
-  getBusinessObject,
-  is
+  getBusinessObject
 } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
@@ -12,7 +11,6 @@ import {
   getTimerEventDefinition,
   getTimerDefinitionType
 } from '../../../utils/EventDefinitionUtil';
-
 
 import {
   SelectEntry,
@@ -32,7 +30,6 @@ import {
 export function TimerProps(props) {
   const {
     element,
-    listener,
     idPrefix
   } = props;
 
@@ -48,7 +45,7 @@ export function TimerProps(props) {
   const timerEventDefinitionType = getTimerDefinitionType(timerEventDefinition);
 
   // (1) Only show for supported elements
-  if (!isTimerSupported(element) && !isTimerSupportedOnListener(listener)) {
+  if (!isTimerSupported(element)) {
     return [];
   }
 
@@ -230,10 +227,6 @@ function getTimerEventDefinitionValueDescription(timerDefinitionType, translate)
       <a href="https://docs.camunda.org/manual/latest/reference/bpmn20/events/timer-events/#time-duration" target="_blank" rel="noopener">{ translate('Documentation: Timer events') }</a>
     </div>);
   }
-}
-
-function isTimerSupportedOnListener(listener) {
-  return listener && is(listener, 'camunda:TaskListener') && getTimerEventDefinition(listener);
 }
 
 function getId(idPrefix, id) {

--- a/src/provider/camunda-platform/properties/ListenerProps.js
+++ b/src/provider/camunda-platform/properties/ListenerProps.js
@@ -35,7 +35,7 @@ import {
 } from './ImplementationProps';
 
 import { ScriptProps } from './ScriptProps';
-import { TimerProps } from '../../bpmn/properties';
+import { TimerProps } from './TimerProps';
 import { getTimerEventDefinition } from '../../bpmn/utils/EventDefinitionUtil';
 
 import { without } from 'min-dash';


### PR DESCRIPTION
* remove Camunda 7 concern from BPMN `TimerProps`
* import Camunda 7 `TimerProps` in Camunda 7 `ListenerProps`

Closes https://github.com/bpmn-io/bpmn-js-properties-panel/issues/910
