### PR TITLE
feat: fire template button events

### DIFF
--- a/src/provider/cloud-element-templates/util/templateUtil.js
+++ b/src/provider/cloud-element-templates/util/templateUtil.js
@@ -4,7 +4,10 @@ export {
 } from '../../element-templates/util/templateUtil';
 
 export function unlinkTemplate(element, injector) {
-  const modeling = injector.get('modeling');
+  const modeling = injector.get('modeling'),
+        eventBus = injector.get('eventBus');
+
+  eventBus.fire('elementTemplates.unlink', { element });
 
   // remove template attributes
   modeling.updateProperties(element, {
@@ -15,7 +18,10 @@ export function unlinkTemplate(element, injector) {
 }
 
 export function updateTemplate(element, newTemplate, injector) {
-  const elementTemplates = injector.get('elementTemplates');
+  const elementTemplates = injector.get('elementTemplates'),
+        eventBus = injector.get('eventBus');
+
+  eventBus.fire('elementTemplates.update', { element, newTemplate });
 
   return elementTemplates.applyTemplate(element, newTemplate);
 }

--- a/src/provider/element-templates/util/templateUtil.js
+++ b/src/provider/element-templates/util/templateUtil.js
@@ -5,7 +5,10 @@ import { isUndefined } from 'min-dash';
 
 
 export function unlinkTemplate(element, injector) {
-  const modeling = injector.get('modeling');
+  const modeling = injector.get('modeling'),
+        eventBus = injector.get('eventBus');
+
+  eventBus.fire('elementTemplates.unlink', { element });
 
   modeling.updateProperties(element, {
     'camunda:modelerTemplate': null,
@@ -15,7 +18,10 @@ export function unlinkTemplate(element, injector) {
 
 export function removeTemplate(element, injector) {
   const replace = injector.get('replace'),
-        selection = injector.get('selection');
+        selection = injector.get('selection'),
+        eventBus = injector.get('eventBus');
+
+  eventBus.fire('elementTemplates.remove', { element });
 
   const businessObject = getBusinessObject(element);
 
@@ -34,7 +40,10 @@ export function removeTemplate(element, injector) {
 }
 
 export function updateTemplate(element, newTemplate, injector) {
-  const elementTemplates = injector.get('elementTemplates');
+  const elementTemplates = injector.get('elementTemplates'),
+        eventBus = injector.get('eventBus');
+
+  eventBus.fire('elementTemplates.update', { element, newTemplate });
 
   return elementTemplates.applyTemplate(element, newTemplate);
 }

--- a/test/spec/provider/cloud-element-templates/util/templateUtil.spec.js
+++ b/test/spec/provider/cloud-element-templates/util/templateUtil.spec.js
@@ -82,6 +82,24 @@ describe('provider/cloud-element-template - templateUtil', function() {
       task = elementRegistry.get('Task_1');
       expect(getBusinessObject(task).get('zeebe:modelerTemplateIcon')).to.not.exist;
     }));
+
+    it('should fire elementTemplates.unlink event', inject(function(elementRegistry, injector, eventBus) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+      const spy = sinon.spy();
+
+      eventBus.on('elementTemplates.unlink', spy);
+
+      // when
+      unlinkTemplate(task, injector);
+
+      // then
+      expect(spy).to.have.been.calledOnce;
+      expect(spy.getCalls()[0].args[1]).to.eql({
+        element: task
+      });
+    }));
   });
 
 
@@ -160,6 +178,25 @@ describe('provider/cloud-element-template - templateUtil', function() {
       expect(eventBo.modelerTemplateVersion).not.to.exist;
       expect(eventBo.eventDefinitions).to.have.length(1);
     }));
+
+
+    it('should fire elementTemplates.remove event', inject(function(elementRegistry, injector, eventBus) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+      const spy = sinon.spy();
+
+      eventBus.on('elementTemplates.remove', spy);
+
+      // when
+      removeTemplate(task, injector);
+
+      // then
+      expect(spy).to.have.been.calledOnce;
+      expect(spy.getCalls()[0].args[1]).to.eql({
+        element: task
+      });
+    }));
   });
 
 
@@ -229,6 +266,29 @@ describe('provider/cloud-element-template - templateUtil', function() {
         expect(message.name).to.eql('user_edited');
       })
     );
+
+
+    it('should fire elementTemplates.update event', inject(function(elementRegistry, injector, eventBus) {
+
+      // given
+      const newTemplate = templates.find(
+        template => template.id === 'foo' && template.version === 2);
+
+      const task = elementRegistry.get('Task_1');
+      const spy = sinon.spy();
+
+      eventBus.on('elementTemplates.update', spy);
+
+      // when
+      updateTemplate(task, newTemplate, injector);
+
+      // then
+      expect(spy).to.have.been.calledOnce;
+      expect(spy.getCalls()[0].args[1]).to.eql({
+        element: task,
+        newTemplate
+      });
+    }));
   });
 
 


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js-tracking/issues/28

We already fire `elementTemplates.select`. This adds `elementTemplates.unlink`, `elementTemplates.update`, `elementTemplates.rempove`, following a similar approach to https://github.com/bpmn-io/diagram-js/issues/771.

The alternative would be relying on DOM events, which we avoided in example above.
