### PR TITLE
feat: allow time date in boundary and intermediate catch events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: allow time date in boundary and intermediate catch events ([#931](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/931))
+
+### Breaking Changes
+
+* support of legacy `timerEventDefinitionDurationValue` ID for Camunda 8 _Timer_ group _Value_ entry was removed; `timerEventDefinitionValue` ID is now used for all _Value_ entries ([#931](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/931))
+
 ## 1.25.0
 
 * `FEAT`: fire `elementTemplats.unlink`, `elementTemplats.update` and `elementTemplats.remove` events ([#927](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/927))
@@ -266,7 +272,7 @@ _A complete rewrite of the library, based on modern foundations._
 
 For more changes, read the alpha releases entries below.
 
-### Breaking changes
+### Breaking Changes
 
 * `PropertiesProvider#getTabs` is no longer used. Migrate to the new `PropertiesProvider#getGroups` API instead.
   Check out [the example migration](https://github.com/bpmn-io/bpmn-js-examples/pull/142) and [this pull request](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/590) for guidance.

--- a/src/provider/zeebe/utils/TimerUtil.js
+++ b/src/provider/zeebe/utils/TimerUtil.js
@@ -1,0 +1,77 @@
+import {
+  getBusinessObject,
+  is,
+  isAny
+} from 'bpmn-js/lib/util/ModelUtil';
+
+
+export function getTimerEventDefinition(element) {
+  const businessObject = getBusinessObject(element);
+
+  return businessObject.get('eventDefinitions').find(eventDefinition => {
+    return is(eventDefinition, 'bpmn:TimerEventDefinition');
+  });
+}
+
+/**
+ * Check whether a given timer expression type is supported for a given element.
+ *
+ * @param {string} type
+ * @param {Element|ModdleElement} element
+ *
+ * @return {boolean}
+ */
+export function isTimerExpressionTypeSupported(type, element) {
+  const businessObject = getBusinessObject(element);
+
+  switch (type) {
+  case 'timeDate':
+    return isAny(element, [
+      'bpmn:BoundaryEvent',
+      'bpmn:IntermediateCatchEvent',
+      'bpmn:StartEvent'
+    ]);
+
+  case 'timeCycle':
+    if (is(element, 'bpmn:StartEvent') && (!hasParentEventSubProcess(businessObject)) || !isInterrupting(businessObject)) {
+      return true;
+    }
+
+    if (is(element, 'bpmn:BoundaryEvent') && !isInterrupting(businessObject)) {
+      return true;
+    }
+
+    return false;
+
+  case 'timeDuration':
+    if (isAny(element, [
+      'bpmn:BoundaryEvent',
+      'bpmn:IntermediateCatchEvent'
+    ])) {
+      return true;
+    }
+
+    if (is(element, 'bpmn:StartEvent') && hasParentEventSubProcess(businessObject)) {
+      return true;
+    }
+
+    return false;
+
+  default:
+    return false;
+  }
+}
+
+function isInterrupting(businessObject) {
+  if (is(businessObject, 'bpmn:BoundaryEvent')) {
+    return businessObject.get('cancelActivity') !== false;
+  }
+
+  return businessObject.get('isInterrupting') !== false;
+}
+
+function hasParentEventSubProcess(businessObject) {
+  const parent = businessObject.$parent;
+
+  return parent && is(parent, 'bpmn:SubProcess') && parent.get('triggeredByEvent');
+}

--- a/test/spec/provider/zeebe/TimerProps.bpmn
+++ b/test/spec/provider/zeebe/TimerProps.bpmn
@@ -1,174 +1,410 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1dxdt1l" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
-  <bpmn:process id="Process_033aedt" isExecutable="true">
-    <bpmn:startEvent id="timerStartEventCycle" name="timerStartEventCycle">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1papscu">
-        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">myCycle</bpmn:timeCycle>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w3xyk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.3.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Cycle" name="StartEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
-    <bpmn:startEvent id="timerStartEventDate" name="timerStartEventDate">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0y5v7kb">
-        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">myDate</bpmn:timeDate>
-      </bpmn:timerEventDefinition>
-    </bpmn:startEvent>
-    <bpmn:intermediateCatchEvent id="intermediateTimerCatchEventDuration" name="intermediateTimerCatchEventDuration">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0rntt0k">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">myDuration</bpmn:timeDuration>
-      </bpmn:timerEventDefinition>
-    </bpmn:intermediateCatchEvent>
-    <bpmn:task id="Activity_02nwjbf" />
-    <bpmn:boundaryEvent id="nonInterruptingBoundaryEventDuration" name="nonInterruptingBoundaryEventDuration" cancelActivity="false" attachedToRef="Activity_02nwjbf">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0g9s9gu">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">myDuration</bpmn:timeDuration>
-      </bpmn:timerEventDefinition>
-    </bpmn:boundaryEvent>
-    <bpmn:boundaryEvent id="nonInterruptingBoundaryEventCycle" name="nonInterruptingBoundaryEventCycle" cancelActivity="false" attachedToRef="Activity_02nwjbf">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0jbwunb">
-        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">myCycle</bpmn:timeCycle>
-      </bpmn:timerEventDefinition>
-    </bpmn:boundaryEvent>
-    <bpmn:task id="Activity_06vbwdw" />
-    <bpmn:boundaryEvent id="interruptingBoundaryEventDuration" name="interruptingBoundaryEventDuration" attachedToRef="Activity_06vbwdw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1keqphx">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">myDuration</bpmn:timeDuration>
-      </bpmn:timerEventDefinition>
-    </bpmn:boundaryEvent>
-    <bpmn:startEvent id="timerStartEventEmpty" name="timerStartEventEmpty">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0xsp1dx" />
-    </bpmn:startEvent>
-    <bpmn:intermediateCatchEvent id="intermediateTimerCatchEventDurationEmpty" name="intermediateTimerCatchEventDurationEmpty">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1966fbi" />
-    </bpmn:intermediateCatchEvent>
-    <bpmn:subProcess id="Activity_0pesngd" name="event subprocess" triggeredByEvent="true">
-      <bpmn:startEvent id="interruptingTimerStartEventDate" name="interruptingTimerStartEventDate">
-        <bpmn:timerEventDefinition id="TimerEventDefinition_12r4dq7">
-          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">today()</bpmn:timeDate>
-        </bpmn:timerEventDefinition>
-      </bpmn:startEvent>
-      <bpmn:startEvent id="nonInterruptingTimerStartEventDate" name="nonInterruptingTimerStartEventDate" isInterrupting="false">
-        <bpmn:timerEventDefinition id="TimerEventDefinition_0qa1ogs">
-          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">today()</bpmn:timeDate>
+    <bpmn:task id="Task_1" />
+    <bpmn:task id="Task_2" />
+    <bpmn:subProcess id="SubProcess_Cycle" name="SubProcess_Cycle" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Cycle" name="EventSubProcess_NonInterruptingStartEvent_Cycle" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
         </bpmn:timerEventDefinition>
       </bpmn:startEvent>
     </bpmn:subProcess>
-    <bpmn:subProcess id="Activity_16tsjf9" name="event subprocess" triggeredByEvent="true">
-      <bpmn:startEvent id="nonInterruptingTimerStartEventCycle" name="nonInterruptingTimerStartEventCycle" isInterrupting="false">
-        <bpmn:timerEventDefinition id="TimerEventDefinition_0kiq3dw">
-          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R-1/P1D</bpmn:timeCycle>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Date" name="IntermediateCatchEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Date" name="StartEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_5" />
+    <bpmn:task id="Task_6" />
+    <bpmn:subProcess id="SubProcess_Date" name="SubProcess_Date" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Date" name="EventSubProcess_StartEvent_Date">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Date" name="EventSubProcess_NonInterruptingStartEvent_Date" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
         </bpmn:timerEventDefinition>
       </bpmn:startEvent>
     </bpmn:subProcess>
-    <bpmn:group id="Group_0evc7ip" categoryValueRef="CategoryValue_0vsifnx" />
-    <bpmn:group id="Group_0333nab" categoryValueRef="CategoryValue_03ljmd0" />
-    <bpmn:group id="Group_08mza04" categoryValueRef="CategoryValue_1lexm62" />
+    <bpmn:boundaryEvent id="BoundaryEvent_Date" name="BoundaryEvent_Date" attachedToRef="Task_5">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Date" name="NonInterruptingBoundaryEvent_Date" cancelActivity="false" attachedToRef="Task_6">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Duration" name="IntermediateCatchEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:task id="Task_7" />
+    <bpmn:task id="Task_8" />
+    <bpmn:subProcess id="SubProcess_Duration" name="SubProcess_Duration" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Duration" name="EventSubProcess_StartEvent_Duration">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Duration" name="EventSubProcess_NonInterruptingStartEvent_Duration" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Duration" name="BoundaryEvent_Duration" attachedToRef="Task_7">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Duration" name="NonInterruptingBoundaryEvent_Duration" cancelActivity="false" attachedToRef="Task_8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:startEvent id="StartEvent_CycleCron" name="StartEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" />
+    <bpmn:subProcess id="SubProcess_CycleCron" name="SubProcess_CycleCron" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_CycleCron" name="EventSubProcess_NonInterruptingStartEvent_CycleCron" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Empty" name="IntermediateCatchEvent_Empty">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Empty" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Empty" name="StartEvent_Empty">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Empty" />
+    </bpmn:startEvent>
+    <bpmn:task id="Task_9" />
+    <bpmn:task id="Task_10" />
+    <bpmn:subProcess id="SubProcess_Empty" name="SubProcess_Empty" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Empty" name="EventSubProcess_StartEvent_Empty">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Empty" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Empty" name="EventSubProcess_NonInterruptingStartEvent_Empty" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Empty" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Empty" name="BoundaryEvent_Empty" attachedToRef="Task_9">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Empty" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Empty" name="NonInterruptingBoundaryEvent_Empty" cancelActivity="false" attachedToRef="Task_10">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Empty" />
+    </bpmn:boundaryEvent>
+    <bpmn:task id="Task_11" />
+    <bpmn:startEvent id="StartEvent_Blank" name="StartEvent_Blank" />
+    <bpmn:boundaryEvent id="BoundaryEvent_Blank" name="BoundaryEvent_Blank" attachedToRef="Task_11" />
+    <bpmn:endEvent id="EndEvent_Blank" name="EndEvent_Blank" />
+    <bpmn:intermediateThrowEvent id="IntermediateCatchEvent_Blank" name="IntermediateCatchEvent_Blank" />
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Cycle" name="NonInterruptingBoundaryEvent_Cycle" cancelActivity="false" attachedToRef="Task_2">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_CycleCron" name="NonInterruptingBoundaryEvent_CycleCron" cancelActivity="false" attachedToRef="Task_4">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:group id="Group_Cycle" categoryValueRef="CategoryValue_Cycle" />
+    <bpmn:group id="Group_Date" categoryValueRef="CategoryValue_Date" />
+    <bpmn:group id="Group_Duration" categoryValueRef="CategoryValue_Duration" />
+    <bpmn:group id="Group_CycleCron" categoryValueRef="CategoryValue_CycleCron" />
+    <bpmn:group id="Group_Empty" categoryValueRef="CategoryValue_Empty" />
+    <bpmn:group id="Group_Blank" categoryValueRef="CategoryValue_1qnxo9z" />
   </bpmn:process>
-  <bpmn:category id="Category_050txki">
-    <bpmn:categoryValue id="CategoryValue_0vsifnx" value="Date" />
+  <bpmn:category id="Category_Cycle">
+    <bpmn:categoryValue id="CategoryValue_Cycle" value="Cycle" />
   </bpmn:category>
-  <bpmn:category id="Category_0g2gcxt">
-    <bpmn:categoryValue id="CategoryValue_03ljmd0" value="Cycle" />
+  <bpmn:category id="Category_Date">
+    <bpmn:categoryValue id="CategoryValue_Date" value="Date" />
   </bpmn:category>
-  <bpmn:category id="Category_1vf5mdy">
-    <bpmn:categoryValue id="CategoryValue_1lexm62" value="Duration" />
+  <bpmn:category id="Category_Duration">
+    <bpmn:categoryValue id="CategoryValue_Duration" value="Duration" />
+  </bpmn:category>
+  <bpmn:category id="Category_CycleCron">
+    <bpmn:categoryValue id="CategoryValue_CycleCron" value="Cycle (CRON)" />
+  </bpmn:category>
+  <bpmn:category id="Category_0eanx02">
+    <bpmn:categoryValue id="CategoryValue_Empty" value="Empty" />
+  </bpmn:category>
+  <bpmn:category id="Category_1v4a6vb">
+    <bpmn:categoryValue id="CategoryValue_1qnxo9z" value="Blank" />
   </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_033aedt">
-      <bpmndi:BPMNShape id="Event_1r3xl4t_di" bpmnElement="timerStartEventCycle">
-        <dc:Bounds x="492" y="132" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1a2aqqq_di" bpmnElement="StartEvent_Cycle">
+        <dc:Bounds x="202" y="852" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="468" y="175" width="84" height="27" />
+          <dc:Bounds x="179" y="895" width="85" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_18omnka_di" bpmnElement="timerStartEventDate">
-        <dc:Bounds x="492" y="212" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="468" y="255" width="84" height="27" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNShape id="Activity_158bxus_di" bpmnElement="Task_1">
+        <dc:Bounds x="440" y="830" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1alb6ws_di" bpmnElement="intermediateTimerCatchEventDuration">
-        <dc:Bounds x="982" y="212" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="959" y="255" width="88" height="40" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNShape id="Activity_1c7yu62_di" bpmnElement="Task_2">
+        <dc:Bounds x="620" y="830" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_02nwjbf_di" bpmnElement="Activity_02nwjbf">
-        <dc:Bounds x="710" y="246" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_06vbwdw_di" bpmnElement="Activity_06vbwdw">
-        <dc:Bounds x="950" y="370" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_16sp5dx_di" bpmnElement="timerStartEventEmpty">
-        <dc:Bounds x="602" y="672" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="578" y="715" width="84" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_02ht84m_di" bpmnElement="intermediateTimerCatchEventDurationEmpty">
-        <dc:Bounds x="832" y="512" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="811" y="555" width="85" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1q7eln8" bpmnElement="Activity_16tsjf9" isExpanded="true">
-        <dc:Bounds x="400" y="340" width="150" height="123" />
+      <bpmndi:BPMNShape id="Activity_0si6fbo_di" bpmnElement="SubProcess_Cycle" isExpanded="true">
+        <dc:Bounds x="810" y="780" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1gz0uqw_di" bpmnElement="nonInterruptingTimerStartEventCycle">
-        <dc:Bounds x="432" y="372" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1hvn2kh_di" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Cycle">
+        <dc:Bounds x="1012" y="862" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="408" y="415" width="87" height="40" />
+          <dc:Bounds x="990" y="905" width="86" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1cf5wox_di" bpmnElement="Activity_0pesngd" isExpanded="true">
-        <dc:Bounds x="190" y="500" width="290" height="123" />
+      <bpmndi:BPMNShape id="BPMNShape_1noobtj" bpmnElement="IntermediateCatchEvent_Date">
+        <dc:Bounds x="292" y="1172" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="272" y="1215" width="80" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1daj4e0" bpmnElement="StartEvent_Date">
+        <dc:Bounds x="202" y="1172" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="181" y="1215" width="81" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1godq1i" bpmnElement="Task_5">
+        <dc:Bounds x="440" y="1150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cqtk6t" bpmnElement="Task_6">
+        <dc:Bounds x="620" y="1150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nhun69" bpmnElement="SubProcess_Date" isExpanded="true">
+        <dc:Bounds x="810" y="1100" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1b2d0yw_di" bpmnElement="interruptingTimerStartEventDate">
-        <dc:Bounds x="222" y="532" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1679ksi" bpmnElement="EventSubProcess_StartEvent_Date">
+        <dc:Bounds x="922" y="1182" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="199" y="575" width="83" height="27" />
+          <dc:Bounds x="896" y="1225" width="88" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_07j7ht3" bpmnElement="nonInterruptingTimerStartEventDate">
-        <dc:Bounds x="362" y="532" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_0n27xdi" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Date">
+        <dc:Bounds x="1012" y="1182" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="338" y="575" width="87" height="40" />
+          <dc:Bounds x="989" y="1225" width="87" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Group_0evc7ip_di" bpmnElement="Group_0evc7ip">
-        <dc:Bounds x="160" y="120" width="450" height="520" />
+      <bpmndi:BPMNShape id="BPMNShape_0b7rl6t" bpmnElement="IntermediateCatchEvent_Duration">
+        <dc:Bounds x="292" y="1492" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="313" y="127" width="24" height="14" />
+          <dc:Bounds x="268" y="1535" width="85" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Group_0333nab_di" bpmnElement="Group_0333nab">
-        <dc:Bounds x="340" y="80" width="550" height="410" />
+      <bpmndi:BPMNShape id="BPMNShape_09h1dj0" bpmnElement="Task_7">
+        <dc:Bounds x="440" y="1470" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13qr05v" bpmnElement="Task_8">
+        <dc:Bounds x="620" y="1470" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sopxbu" bpmnElement="SubProcess_Duration" isExpanded="true">
+        <dc:Bounds x="810" y="1420" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n0geh0" bpmnElement="EventSubProcess_StartEvent_Duration">
+        <dc:Bounds x="922" y="1502" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="601" y="87" width="28" height="14" />
+          <dc:Bounds x="896" y="1545" width="88" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Group_08mza04_di" bpmnElement="Group_08mza04">
-        <dc:Bounds x="620" y="120" width="490" height="520" />
+      <bpmndi:BPMNShape id="BPMNShape_01typqg" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Duration">
+        <dc:Bounds x="1012" y="1502" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1040" y="133" width="42" height="14" />
+          <dc:Bounds x="987" y="1545" width="88" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1r5vs15_di" bpmnElement="interruptingBoundaryEventDuration">
-        <dc:Bounds x="952" y="432" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_114olyo" bpmnElement="StartEvent_CycleCron">
+        <dc:Bounds x="1272" y="852" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="928" y="475" width="85" height="40" />
+          <dc:Bounds x="1249" y="895" width="85" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0u6kxk1_di" bpmnElement="nonInterruptingBoundaryEventCycle">
-        <dc:Bounds x="792" y="238" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_0sp4b5v" bpmnElement="Task_3">
+        <dc:Bounds x="1510" y="830" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j20tgx" bpmnElement="Task_4">
+        <dc:Bounds x="1690" y="830" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gooim1" bpmnElement="SubProcess_CycleCron" isExpanded="true">
+        <dc:Bounds x="1880" y="780" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11c780k" bpmnElement="EventSubProcess_NonInterruptingStartEvent_CycleCron">
+        <dc:Bounds x="2082" y="862" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="767" y="196" width="87" height="40" />
+          <dc:Bounds x="2059" y="905" width="88" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_06kv99i_di" bpmnElement="nonInterruptingBoundaryEventDuration">
-        <dc:Bounds x="792" y="308" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1an1qwo" bpmnElement="IntermediateCatchEvent_Empty">
+        <dc:Bounds x="292" y="532" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="768" y="351" width="86" height="40" />
+          <dc:Bounds x="272" y="575" width="80" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gco7bn" bpmnElement="StartEvent_Empty">
+        <dc:Bounds x="202" y="532" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="177" y="575" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1xcb7zk" bpmnElement="Task_9">
+        <dc:Bounds x="440" y="510" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0et7d6j" bpmnElement="Task_10">
+        <dc:Bounds x="620" y="510" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_005r8np" bpmnElement="SubProcess_Empty" isExpanded="true">
+        <dc:Bounds x="810" y="460" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ff8e7y" bpmnElement="EventSubProcess_StartEvent_Empty">
+        <dc:Bounds x="922" y="542" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="585" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ucdpb8" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Empty">
+        <dc:Bounds x="1012" y="542" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="988" y="585" width="90" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_15o5nws" bpmnElement="Task_11">
+        <dc:Bounds x="440" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1tuz9gm_di" bpmnElement="StartEvent_Blank">
+        <dc:Bounds x="202" y="212" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="179" y="255" width="86" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1j05y35_di" bpmnElement="EndEvent_Blank">
+        <dc:Bounds x="967" y="212" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="944" y="255" width="82" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1aglcm1_di" bpmnElement="IntermediateCatchEvent_Blank">
+        <dc:Bounds x="292" y="212" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="270" y="255" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hdiole_di" bpmnElement="NonInterruptingBoundaryEvent_Cycle">
+        <dc:Bounds x="702" y="892" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="677" y="935" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0lzenly" bpmnElement="NonInterruptingBoundaryEvent_CycleCron">
+        <dc:Bounds x="1772" y="892" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1746" y="935" width="90" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0oqi537_di" bpmnElement="Group_Cycle">
+        <dc:Bounds x="160" y="720" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="672" y="727" width="28" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lmj4kq" bpmnElement="Group_Date">
+        <dc:Bounds x="160" y="1040" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="675" y="1047" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_100yato" bpmnElement="Group_Duration">
+        <dc:Bounds x="160" y="1360" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="664" y="1367" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8h7pu" bpmnElement="Group_CycleCron">
+        <dc:Bounds x="1230" y="720" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1721" y="727" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0h4cbzd" bpmnElement="Group_Empty">
+        <dc:Bounds x="160" y="400" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="671" y="407" width="32" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0p5q7tr" bpmnElement="Group_Blank">
+        <dc:Bounds x="160" y="80" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="673" y="87" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0p5bs30_di" bpmnElement="BoundaryEvent_Blank">
+        <dc:Bounds x="522" y="252" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="295" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1py9dkq" bpmnElement="NonInterruptingBoundaryEvent_Empty">
+        <dc:Bounds x="702" y="572" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="681" y="615" width="83" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0vsnq0p" bpmnElement="BoundaryEvent_Empty">
+        <dc:Bounds x="522" y="572" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="500" y="615" width="83" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwveo1" bpmnElement="NonInterruptingBoundaryEvent_Duration">
+        <dc:Bounds x="702" y="1532" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="1575" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1q4qstq" bpmnElement="BoundaryEvent_Duration">
+        <dc:Bounds x="522" y="1532" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="1575" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_02pg78j" bpmnElement="NonInterruptingBoundaryEvent_Date">
+        <dc:Bounds x="702" y="1212" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="681" y="1255" width="83" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ktlobl" bpmnElement="BoundaryEvent_Date">
+        <dc:Bounds x="522" y="1212" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="500" y="1255" width="83" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/spec/provider/zeebe/TimerProps.spec.js
+++ b/test/spec/provider/zeebe/TimerProps.spec.js
@@ -59,21 +59,22 @@ describe('provider/zeebe - TimerProps', function() {
   }));
 
 
-  describe('provider/zeebe - TimerEventDefinition', function() {
+  describe('provider/zeebe - TimerProps', function() {
 
-    describe('input entries', function() {
+    describe('Type entry', function() {
 
-      describe('select', function() {
+      describe('display', function() {
 
-        it('should display if multiple types are possible', inject(async function(elementRegistry, selection) {
+        it('should display', inject(async function(elementRegistry, selection) {
 
           // given
           const elements = [
-            elementRegistry.get('timerStartEventCycle'),
-            elementRegistry.get('nonInterruptingBoundaryEventCycle'),
-            elementRegistry.get('timerStartEventEmpty'),
-            elementRegistry.get('nonInterruptingTimerStartEventCycle'),
-            elementRegistry.get('nonInterruptingTimerStartEventDate')
+            elementRegistry.get('StartEvent_Empty'),
+            elementRegistry.get('IntermediateCatchEvent_Empty'),
+            elementRegistry.get('BoundaryEvent_Empty'),
+            elementRegistry.get('NonInterruptingBoundaryEvent_Empty'),
+            elementRegistry.get('EventSubProcess_StartEvent_Empty'),
+            elementRegistry.get('EventSubProcess_NonInterruptingStartEvent_Empty')
           ];
 
           for (const element of elements) {
@@ -91,13 +92,14 @@ describe('provider/zeebe - TimerProps', function() {
         }));
 
 
-        it('should NOT display if only one type is possible', inject(async function(elementRegistry, selection) {
+        it('should NOT display', inject(async function(elementRegistry, selection) {
 
           // given
           const elements = [
-            elementRegistry.get('intermediateTimerCatchEventDuration'),
-            elementRegistry.get('interruptingBoundaryEventDuration'),
-            elementRegistry.get('interruptingTimerStartEventDate')
+            elementRegistry.get('StartEvent_Blank'),
+            elementRegistry.get('IntermediateCatchEvent_Blank'),
+            elementRegistry.get('BoundaryEvent_Blank'),
+            elementRegistry.get('EndEvent_Blank')
           ];
 
           for (const element of elements) {
@@ -117,182 +119,25 @@ describe('provider/zeebe - TimerProps', function() {
       });
 
 
-      describe('generic textField', function() {
+      describe('behavior', function() {
 
-        it('should display if type is selected', inject(async function(elementRegistry, selection) {
-
-          // given
-          const elements = [
-            elementRegistry.get('timerStartEventDate'),
-            elementRegistry.get('nonInterruptingBoundaryEventDuration')
-          ];
-
-          for (const element of elements) {
-
-            // when
-            await act(() => {
-              selection.select(element);
-            });
-
-            const definitionTypeTextField = domQuery('#bio-properties-panel-timerEventDefinitionValue', container);
-
-            // then
-            expect(definitionTypeTextField).to.exist;
-          }
-        }));
-
-
-        it('should display if only one type is available', inject(async function(elementRegistry, selection) {
+        it('should set <do>', inject(async function(elementRegistry, selection) {
 
           // given
-          const element = elementRegistry.get('interruptingTimerStartEventDate');
-
-          // when
-          await act(() => {
-            selection.select(element);
-          });
-
-          const definitionTypeTextField = domQuery('#bio-properties-panel-timerEventDefinitionValue', container);
-
-          // then
-          expect(definitionTypeTextField).to.exist;
-        }));
-
-
-        it('should display correct label for only one type available', inject(async function(elementRegistry, selection) {
-
-          // given
-          const element = elementRegistry.get('interruptingTimerStartEventDate');
-
-          // when
-          await act(() => {
-            selection.select(element);
-          });
-
-          const label = domQuery('[data-entry-id="timerEventDefinitionValue"] label', container);
-
-          // then
-          expect(label).to.have.property('textContent', 'Date');
-        }));
-
-
-        it('should NOT display if only duration is available', inject(async function(elementRegistry, selection) {
-
-          // given
-          const elements = [
-            elementRegistry.get('intermediateTimerCatchEventDuration'),
-            elementRegistry.get('interruptingBoundaryEventDuration')
-          ];
-
-          for (const element of elements) {
-
-            // when
-            await act(() => {
-              selection.select(element);
-            });
-
-            const definitionTypeTextField = domQuery('#bio-properties-panel-timerEventDefinitionValue', container);
-
-            // then
-            expect(definitionTypeTextField).not.to.exist;
-          }
-        }));
-
-
-        it('should NOT display if no type was selected', inject(async function(elementRegistry, selection) {
-
-          // given
-          const elements = [
-            elementRegistry.get('timerStartEventEmpty')
-          ];
-
-          for (const element of elements) {
-
-            // when
-            await act(() => {
-              selection.select(element);
-            });
-
-            const definitionTypeTextField = domQuery('#bio-properties-panel-timerEventDefinitionValue', container);
-
-            // then
-            expect(definitionTypeTextField).not.to.exist;
-          }
-        }));
-
-      });
-
-
-      describe('specific duration textField', function() {
-
-        it('should display if only duration is available', inject(async function(elementRegistry, selection) {
-
-          // given
-          const elements = [
-            elementRegistry.get('intermediateTimerCatchEventDuration'),
-            elementRegistry.get('interruptingBoundaryEventDuration')
-          ];
-
-          for (const element of elements) {
-
-            // when
-            await act(() => {
-              selection.select(element);
-            });
-
-            const definitionTypeTextField = domQuery('#bio-properties-panel-timerEventDefinitionDurationValue', container);
-
-            // then
-            expect(definitionTypeTextField).to.exist;
-          }
-        }));
-
-
-        it('should NOT display if multiple types are available', inject(async function(elementRegistry, selection) {
-
-          // given
-          const elements = [
-            elementRegistry.get('timerStartEventDate'),
-            elementRegistry.get('nonInterruptingBoundaryEventDuration')
-          ];
-
-          for (const element of elements) {
-
-            // when
-            await act(() => {
-              selection.select(element);
-            });
-
-            const definitionTypeTextField = domQuery('#bio-properties-panel-timerEventDefinitionDurationValue', container);
-
-            // then
-            expect(definitionTypeTextField).not.to.exist;
-          }
-        }));
-
-      });
-
-    });
-
-
-    describe('update', function() {
-
-      describe('select', function() {
-
-        it('should execute', inject(async function(elementRegistry, selection) {
-
-          // given
-          const timerStartEvent = elementRegistry.get('timerStartEventDate');
+          const startEvent = elementRegistry.get('StartEvent_Date');
 
           await act(() => {
-            selection.select(timerStartEvent);
+            selection.select(startEvent);
           });
 
           // assume
-          const orginalTimer = getTimerEventDefinition(timerStartEvent);
-          expect(orginalTimer.timeCycle).not.to.exist;
-          expect(orginalTimer.timeDate).to.exist;
-          expect(orginalTimer.timeDate.body).to.equal('myDate');
+          const timerEventDefinition = getTimerEventDefinition(startEvent);
+
+          expect(timerEventDefinition.get('timeCycle')).not.to.exist;
+          expect(timerEventDefinition.get('timeDuration')).not.to.exist;
+
+          expect(timerEventDefinition.get('timeDate')).to.exist;
+          expect(timerEventDefinition.get('timeDate').get('body')).to.equal('2019-10-01T12:00:00Z');
 
           // when
           const select = domQuery('#bio-properties-panel-timerEventDefinitionType', container);
@@ -300,20 +145,20 @@ describe('provider/zeebe - TimerProps', function() {
           changeInput(select, 'timeCycle');
 
           // then
-          const newTimer = getTimerEventDefinition(timerStartEvent);
-          expect(newTimer.timeDate).not.to.exist;
-          expect(newTimer.timeCycle).to.exist;
-          expect(newTimer.timeCycle.body).to.be.undefined;
+          expect(timerEventDefinition.get('timeDate')).not.to.exist;
+          expect(timerEventDefinition.get('timeDuration')).not.to.exist;
+
+          expect(timerEventDefinition.get('timeCycle')).to.exist;
         }));
 
 
-        it('should execute on external change', inject(async function(elementRegistry, selection, commandStack) {
+        it('should set <undo>', inject(async function(elementRegistry, selection, commandStack) {
 
           // given
-          const timerStartEvent = elementRegistry.get('timerStartEventDate');
+          const startEvent = elementRegistry.get('StartEvent_Date');
 
           await act(() => {
-            selection.select(timerStartEvent);
+            selection.select(startEvent);
           });
 
           const select = domQuery('#bio-properties-panel-timerEventDefinitionType', container);
@@ -326,20 +171,23 @@ describe('provider/zeebe - TimerProps', function() {
           });
 
           // then
-          const orginalTimer = getTimerEventDefinition(timerStartEvent);
-          expect(orginalTimer.timeCycle).not.to.exist;
-          expect(orginalTimer.timeDate).to.exist;
-          expect(orginalTimer.timeDate.body).to.equal('myDate');
+          const timerEventDefinition = getTimerEventDefinition(startEvent);
+
+          expect(timerEventDefinition.get('timeCycle')).not.to.exist;
+          expect(timerEventDefinition.get('timeDuration')).not.to.exist;
+
+          expect(timerEventDefinition.get('timeDate')).to.exist;
+          expect(timerEventDefinition.get('timeDate').get('body')).to.equal('2019-10-01T12:00:00Z');
         }));
 
 
-        it('should not execute given no value change', inject(async function(elementRegistry, selection, eventBus) {
+        it('should not set (no change)', inject(async function(elementRegistry, selection, eventBus) {
 
           // given
-          const element = elementRegistry.get('timerStartEventDate');
+          const startEvent = elementRegistry.get('StartEvent_Date');
 
           await act(() => {
-            selection.select(element);
+            selection.select(startEvent);
           });
 
           const eventBusSpy = sinon.spy();
@@ -356,13 +204,13 @@ describe('provider/zeebe - TimerProps', function() {
         }));
 
 
-        it('should unset correctly', inject(async function(elementRegistry, selection, eventBus) {
+        it('should unset', inject(async function(elementRegistry, selection, eventBus) {
 
           // given
-          const element = elementRegistry.get('timerStartEventDate');
+          const startEvent = elementRegistry.get('StartEvent_Date');
 
           await act(() => {
-            selection.select(element);
+            selection.select(startEvent);
           });
 
           const eventBusSpy = sinon.spy();
@@ -372,60 +220,134 @@ describe('provider/zeebe - TimerProps', function() {
           // when
           const select = domQuery('#bio-properties-panel-timerEventDefinitionType', container);
 
-          changeInput(select, 'timeCycle');
           changeInput(select, '');
 
           // then
-          const timerEventDefiniton = getTimerEventDefinition(element);
+          const timerEventDefinition = getTimerEventDefinition(startEvent);
 
-          expect(Object.keys(timerEventDefiniton.$attrs)).to.be.empty;
+          expect(timerEventDefinition.get('timeCycle')).not.to.exist;
+          expect(timerEventDefinition.get('timeDuration')).not.to.exist;
+          expect(timerEventDefinition.get('timeDate')).not.to.exist;
+
+          expect(Object.keys(timerEventDefinition.$attrs)).to.be.empty;
+        }));
+
+      });
+
+    });
+
+
+    describe('Value entry', function() {
+
+      describe('display', function() {
+
+        it('should display if type set', inject(async function(elementRegistry, selection) {
+
+          // given
+          const elements = [
+            elementRegistry.get('StartEvent_Cycle'),
+            elementRegistry.get('EventSubProcess_NonInterruptingStartEvent_Cycle'),
+            elementRegistry.get('StartEvent_CycleCron'),
+            elementRegistry.get('EventSubProcess_NonInterruptingStartEvent_CycleCron'),
+            elementRegistry.get('StartEvent_Date'),
+            elementRegistry.get('IntermediateCatchEvent_Date'),
+            elementRegistry.get('BoundaryEvent_Date'),
+            elementRegistry.get('NonInterruptingBoundaryEvent_Date'),
+            elementRegistry.get('EventSubProcess_StartEvent_Date'),
+            elementRegistry.get('EventSubProcess_NonInterruptingStartEvent_Date'),
+            elementRegistry.get('IntermediateCatchEvent_Duration'),
+            elementRegistry.get('BoundaryEvent_Duration'),
+            elementRegistry.get('NonInterruptingBoundaryEvent_Duration'),
+            elementRegistry.get('EventSubProcess_StartEvent_Duration'),
+            elementRegistry.get('EventSubProcess_NonInterruptingStartEvent_Duration')
+          ];
+
+          for (const element of elements) {
+
+            // when
+            await act(() => {
+              selection.select(element);
+            });
+
+            const definitionTypeTextField = domQuery('#bio-properties-panel-timerEventDefinitionValue', container);
+
+            // then
+            expect(definitionTypeTextField).to.exist;
+          }
+        }));
+
+
+        it('should not display if no type set', inject(async function(elementRegistry, selection) {
+
+          // given
+          const elements = [
+            elementRegistry.get('StartEvent_Empty'),
+            elementRegistry.get('IntermediateCatchEvent_Empty'),
+            elementRegistry.get('BoundaryEvent_Empty'),
+            elementRegistry.get('NonInterruptingBoundaryEvent_Empty'),
+            elementRegistry.get('EventSubProcess_StartEvent_Empty'),
+            elementRegistry.get('EventSubProcess_NonInterruptingStartEvent_Empty')
+          ];
+
+          for (const element of elements) {
+
+            // when
+            await act(() => {
+              selection.select(element);
+            });
+
+            const definitionTypeTextField = domQuery('#bio-properties-panel-timerEventDefinitionValue', container);
+
+            // then
+            expect(definitionTypeTextField).not.to.exist;
+          }
         }));
 
       });
 
 
-      describe('generic textField', function() {
+      describe('behavior', function() {
 
-        describe('date', function() {
+        describe('cycle', function() {
 
-          it('should execute', inject(async function(elementRegistry, selection) {
+          it('should set <do>', inject(async function(elementRegistry, selection) {
 
             // given
-            const timerStartEvent = elementRegistry.get('timerStartEventDate');
+            const startEvent = elementRegistry.get('StartEvent_Cycle');
 
             await act(() => {
-              selection.select(timerStartEvent);
+              selection.select(startEvent);
             });
 
             // assume
-            const orginalTimer = getTimerEventDefinition(timerStartEvent);
-            expect(orginalTimer.timeDate).to.exist;
-            expect(orginalTimer.timeDate.body).to.equal('myDate');
+            const timerEventDefinition = getTimerEventDefinition(startEvent);
+
+            expect(timerEventDefinition.get('timeCycle')).to.exist;
+            expect(timerEventDefinition.get('timeCycle').get('body')).to.equal('R/P1D');
 
             // when
             const textField = domQuery('#bio-properties-panel-timerEventDefinitionValue', container);
 
-            changeInput(textField, 'fooBar');
+            changeInput(textField, 'foo');
 
             // then
-            const newTimer = getTimerEventDefinition(timerStartEvent);
-            expect(newTimer.timeDate).to.exist;
-            expect(newTimer.timeDate.body).to.equal('fooBar');
+            expect(timerEventDefinition.get('timeCycle')).to.exist;
+            expect(timerEventDefinition.get('timeCycle').get('body')).to.equal('foo');
           }));
 
 
-          it('should execute on external change', inject(async function(elementRegistry, selection, commandStack) {
+          it('should set <undo>', inject(async function(elementRegistry, selection, commandStack) {
 
             // given
-            const timerStartEvent = elementRegistry.get('timerStartEventDate');
+            const startEvent = elementRegistry.get('StartEvent_Cycle');
 
             await act(() => {
-              selection.select(timerStartEvent);
+              selection.select(startEvent);
             });
 
             const textField = domQuery('#bio-properties-panel-timerEventDefinitionValue', container);
 
-            changeInput(textField, 'fooBar');
+            changeInput(textField, 'foo');
 
             // when
             await act(() => {
@@ -433,54 +355,55 @@ describe('provider/zeebe - TimerProps', function() {
             });
 
             // then
-            const orginalTimer = getTimerEventDefinition(timerStartEvent);
-            expect(orginalTimer.timeDate).to.exist;
-            expect(orginalTimer.timeDate.body).to.equal('myDate');
+            const timerEventDefinition = getTimerEventDefinition(startEvent);
+
+            expect(timerEventDefinition.get('timeCycle')).to.exist;
+            expect(timerEventDefinition.get('timeCycle').get('body')).to.equal('R/P1D');
           }));
 
         });
 
 
-        describe('cycle', function() {
+        describe('date', function() {
 
-          it('should execute', inject(async function(elementRegistry, selection) {
+          it('should set <do>', inject(async function(elementRegistry, selection) {
 
             // given
-            const timerStartEvent = elementRegistry.get('timerStartEventCycle');
+            const startEvent = elementRegistry.get('StartEvent_Date');
 
             await act(() => {
-              selection.select(timerStartEvent);
+              selection.select(startEvent);
             });
 
             // assume
-            const orginalTimer = getTimerEventDefinition(timerStartEvent);
-            expect(orginalTimer.timeCycle).to.exist;
-            expect(orginalTimer.timeCycle.body).to.equal('myCycle');
+            const timerEventDefinition = getTimerEventDefinition(startEvent);
+
+            expect(timerEventDefinition.get('timeDate')).to.exist;
+            expect(timerEventDefinition.get('timeDate').get('body')).to.equal('2019-10-01T12:00:00Z');
 
             // when
             const textField = domQuery('#bio-properties-panel-timerEventDefinitionValue', container);
 
-            changeInput(textField, 'fooBar');
+            changeInput(textField, 'foo');
 
             // then
-            const newTimer = getTimerEventDefinition(timerStartEvent);
-            expect(newTimer.timeCycle).to.exist;
-            expect(newTimer.timeCycle.body).to.equal('fooBar');
+            expect(timerEventDefinition.get('timeDate')).to.exist;
+            expect(timerEventDefinition.get('timeDate').get('body')).to.equal('foo');
           }));
 
 
-          it('should execute on external change', inject(async function(elementRegistry, selection, commandStack) {
+          it('should set <undo>', inject(async function(elementRegistry, selection, commandStack) {
 
             // given
-            const timerStartEvent = elementRegistry.get('timerStartEventCycle');
+            const startEvent = elementRegistry.get('StartEvent_Date');
 
             await act(() => {
-              selection.select(timerStartEvent);
+              selection.select(startEvent);
             });
 
             const textField = domQuery('#bio-properties-panel-timerEventDefinitionValue', container);
 
-            changeInput(textField, 'fooBar');
+            changeInput(textField, 'foo');
 
             // when
             await act(() => {
@@ -488,9 +411,10 @@ describe('provider/zeebe - TimerProps', function() {
             });
 
             // then
-            const orginalTimer = getTimerEventDefinition(timerStartEvent);
-            expect(orginalTimer.timeCycle).to.exist;
-            expect(orginalTimer.timeCycle.body).to.equal('myCycle');
+            const timerEventDefinition = getTimerEventDefinition(startEvent);
+
+            expect(timerEventDefinition.get('timeDate')).to.exist;
+            expect(timerEventDefinition.get('timeDate').get('body')).to.equal('2019-10-01T12:00:00Z');
           }));
 
         });
@@ -498,44 +422,44 @@ describe('provider/zeebe - TimerProps', function() {
 
         describe('duration', function() {
 
-          it('should execute', inject(async function(elementRegistry, selection) {
+          it('should set <do>', inject(async function(elementRegistry, selection) {
 
             // given
-            const timerStartEvent = elementRegistry.get('nonInterruptingBoundaryEventDuration');
+            const intermediateCatchEvent = elementRegistry.get('IntermediateCatchEvent_Duration');
 
             await act(() => {
-              selection.select(timerStartEvent);
+              selection.select(intermediateCatchEvent);
             });
 
             // assume
-            const orginalTimer = getTimerEventDefinition(timerStartEvent);
-            expect(orginalTimer.timeDuration).to.exist;
-            expect(orginalTimer.timeDuration.body).to.equal('myDuration');
+            const timerEventDefinition = getTimerEventDefinition(intermediateCatchEvent);
+
+            expect(timerEventDefinition.get('timeDuration')).to.exist;
+            expect(timerEventDefinition.get('timeDuration').get('body')).to.equal('P14D');
 
             // when
             const textField = domQuery('#bio-properties-panel-timerEventDefinitionValue', container);
 
-            changeInput(textField, 'fooBar');
+            changeInput(textField, 'foo');
 
             // then
-            const newTimer = getTimerEventDefinition(timerStartEvent);
-            expect(newTimer.timeDuration).to.exist;
-            expect(newTimer.timeDuration.body).to.equal('fooBar');
+            expect(timerEventDefinition.get('timeDuration')).to.exist;
+            expect(timerEventDefinition.get('timeDuration').get('body')).to.equal('foo');
           }));
 
 
-          it('should execute on external change', inject(async function(elementRegistry, selection, commandStack) {
+          it('should set <undo>', inject(async function(elementRegistry, selection, commandStack) {
 
             // given
-            const timerStartEvent = elementRegistry.get('nonInterruptingBoundaryEventDuration');
+            const intermediateCatchEvent = elementRegistry.get('IntermediateCatchEvent_Duration');
 
             await act(() => {
-              selection.select(timerStartEvent);
+              selection.select(intermediateCatchEvent);
             });
 
             const textField = domQuery('#bio-properties-panel-timerEventDefinitionValue', container);
 
-            changeInput(textField, 'fooBar');
+            changeInput(textField, 'foo');
 
             // when
             await act(() => {
@@ -543,92 +467,13 @@ describe('provider/zeebe - TimerProps', function() {
             });
 
             // then
-            const orginalTimer = getTimerEventDefinition(timerStartEvent);
-            expect(orginalTimer.timeDuration).to.exist;
-            expect(orginalTimer.timeDuration.body).to.equal('myDuration');
+            const timerEventDefinition = getTimerEventDefinition(intermediateCatchEvent);
+
+            expect(timerEventDefinition.get('timeDuration')).to.exist;
+            expect(timerEventDefinition.get('timeDuration').get('body')).to.equal('P14D');
           }));
 
         });
-
-      });
-
-
-      describe('specific duration textField', function() {
-
-        it('should execute', inject(async function(elementRegistry, selection) {
-
-          // given
-          const timerStartEvent = elementRegistry.get('intermediateTimerCatchEventDuration');
-
-          await act(() => {
-            selection.select(timerStartEvent);
-          });
-
-          // assume
-          const orginalTimer = getTimerEventDefinition(timerStartEvent);
-          expect(orginalTimer.timeDuration).to.exist;
-          expect(orginalTimer.timeDuration.body).to.equal('myDuration');
-
-          // when
-          const textField = domQuery('#bio-properties-panel-timerEventDefinitionDurationValue', container);
-
-          changeInput(textField, 'fooBar');
-
-          // then
-          const newTimer = getTimerEventDefinition(timerStartEvent);
-          expect(newTimer.timeDuration).to.exist;
-          expect(newTimer.timeDuration.body).to.equal('fooBar');
-        }));
-
-
-        it('should execute on external change', inject(async function(elementRegistry, selection, commandStack) {
-
-          // given
-          const timerStartEvent = elementRegistry.get('intermediateTimerCatchEventDuration');
-
-          await act(() => {
-            selection.select(timerStartEvent);
-          });
-
-          const textField = domQuery('#bio-properties-panel-timerEventDefinitionDurationValue', container);
-
-          changeInput(textField, 'fooBar');
-
-          // when
-          await act(() => {
-            commandStack.undo();
-          });
-
-          // then
-          const orginalTimer = getTimerEventDefinition(timerStartEvent);
-          expect(orginalTimer.timeDuration).to.exist;
-          expect(orginalTimer.timeDuration.body).to.equal('myDuration');
-        }));
-
-
-        it('should create new formalExpression', inject(async function(elementRegistry, selection) {
-
-          // given
-          const timerStartEvent = elementRegistry.get('intermediateTimerCatchEventDurationEmpty');
-
-          await act(() => {
-            selection.select(timerStartEvent);
-          });
-
-          // assume
-          const orginalTimer = getTimerEventDefinition(timerStartEvent);
-          expect(orginalTimer.timeDuration).not.to.exist;
-
-          // when
-          const textField = domQuery('#bio-properties-panel-timerEventDefinitionDurationValue', container);
-
-          changeInput(textField, 'fooBar');
-
-          // then
-          const newTimer = getTimerEventDefinition(timerStartEvent);
-          expect(newTimer.timeDuration).to.exist;
-          expect(newTimer.timeDuration.body).to.equal('fooBar');
-        }));
 
       });
 

--- a/test/spec/utils/TimerUtil.bpmn
+++ b/test/spec/utils/TimerUtil.bpmn
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_148ykk6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.10.0">
+  <bpmn:process id="Process" isExecutable="true">
+    <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+      <bpmn:startEvent id="NonInterruptingTimerStartEvent_1" name="NonInterruptingTimerStartEvent_1" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_12hnz11" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="TimerStartEvent_2" name="TimerStartEvent_2">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1tmzr4x" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:startEvent id="TimerStartEvent_1" name="TimerStartEvent_1">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1jdd0zz" />
+    </bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="TimerIntermediateCatchEvent_1" name="TimerIntermediateCatchEvent_1">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_003tksl" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:task id="Activity_0yefou8" />
+    <bpmn:boundaryEvent id="NonInterruptingTimerBoundaryEvent_1" name="NonInterruptingTimerBoundaryEvent_1" cancelActivity="false" attachedToRef="Activity_0yefou8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1rr0otz" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="TimerBoundaryEvent_1" name="TimerBoundaryEvent_1" attachedToRef="Activity_0yefou8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1lh0hht" />
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
+      <bpmndi:BPMNShape id="Event_1qm1iz0_di" bpmnElement="TimerStartEvent_1">
+        <dc:Bounds x="200" y="122" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="175" y="165" width="86" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0f4939x_di" bpmnElement="TimerIntermediateCatchEvent_1">
+        <dc:Bounds x="312" y="122" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="289" y="165" width="83" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0yefou8_di" bpmnElement="Activity_0yefou8">
+        <dc:Bounds x="410" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_00mfr14_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="580" y="40" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_08qjo26_di" bpmnElement="TimerStartEvent_2">
+        <dc:Bounds x="782" y="122" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="757" y="165" width="86" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_16avx57_di" bpmnElement="NonInterruptingTimerStartEvent_1">
+        <dc:Bounds x="672" y="122" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="648" y="165" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_06vkmfr_di" bpmnElement="TimerBoundaryEvent_1">
+        <dc:Bounds x="492" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="466" y="205" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_08bhvkv_di" bpmnElement="NonInterruptingTimerBoundaryEvent_1">
+        <dc:Bounds x="392" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="369" y="205" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/utils/TimerUtilSpec.js
+++ b/test/spec/utils/TimerUtilSpec.js
@@ -1,0 +1,71 @@
+import {
+  bootstrapCamundaCloudModeler,
+  inject
+} from 'test/TestHelper';
+
+import { isTimerExpressionTypeSupported } from '../../../src/provider/zeebe/utils/TimerUtil';
+
+import diagramXML from './TimerUtil.bpmn';
+
+
+describe('camunda-cloud/util - TimerUtil', function() {
+
+  beforeEach(bootstrapCamundaCloudModeler(diagramXML));
+
+
+  expectTimerExpressionTypesSupported('timer start event', 'TimerStartEvent_1', {
+    timeCycle: true,
+    timeDate: true,
+    timeDuration: false
+  });
+
+
+  expectTimerExpressionTypesSupported('timer intermediate catch event', 'TimerIntermediateCatchEvent_1', {
+    timeCycle: false,
+    timeDate: true,
+    timeDuration: true
+  });
+
+
+  expectTimerExpressionTypesSupported('non-interrupting timer boundary event', 'NonInterruptingTimerBoundaryEvent_1', {
+    timeCycle: true,
+    timeDate: true,
+    timeDuration: true
+  });
+
+
+  expectTimerExpressionTypesSupported('timer boundary event', 'TimerBoundaryEvent_1', {
+    timeCycle: false,
+    timeDate: true,
+    timeDuration: true
+  });
+
+
+  expectTimerExpressionTypesSupported('non-interrupting timer start event (event sub-process)', 'NonInterruptingTimerStartEvent_1', {
+    timeCycle: true,
+    timeDate: true,
+    timeDuration: true
+  });
+
+
+  expectTimerExpressionTypesSupported('timer start event (event sub-process)', 'TimerStartEvent_2', {
+    timeCycle: false,
+    timeDate: true,
+    timeDuration: true
+  });
+
+});
+
+
+
+// helpers //////////
+
+function expectTimerExpressionTypesSupported(elementType, elementId, expressionTypes) {
+  it(`should support expression types for ${ elementType }`, inject(function(elementRegistry) {
+    const element = elementRegistry.get(elementId);
+
+    for (const expressionType in expressionTypes) {
+      expect(isTimerExpressionTypeSupported(expressionType, element)).to.equal(expressionTypes[ expressionType ]);
+    }
+  }));
+}


### PR DESCRIPTION
* adds support for time duration for timer start events in event sub-processes (supported by Zeebe)
* adds support for time date for timer intermediate catch and boundary events (supported by Zeebe 8.3)
* removes handling cases of only one timer expression type available (and removes legacy IDs)
* refactors tests

---

Depends on https://github.com/camunda/camunda-bpmn-js-behaviors/pull/36
Related to https://github.com/camunda/camunda-modeler/issues/3516
