### PR TITLE
feat: remove templated message if no message bindings are active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: remove templated `bpmn:Message` if no message bindings are active ([#915](https://github.com/bpmn-io/bpmn-js-properties-panel/issues/915))
 * `FEAT`: allow time date in boundary and intermediate catch events ([#931](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/931))
 
 ### Breaking Changes

--- a/src/provider/cloud-element-templates/util/rootElementUtil.js
+++ b/src/provider/cloud-element-templates/util/rootElementUtil.js
@@ -1,0 +1,60 @@
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+import { findMessage } from '../Helper';
+
+export function removeRootElement(rootElement, injector) {
+  const modeling = injector.get('modeling'),
+        canvas = injector.get('canvas'),
+        bpmnjs = injector.get('bpmnjs');
+
+  const element = canvas.getRootElement(),
+        definitions = bpmnjs.getDefinitions(),
+        rootElements = definitions.get('rootElements');
+
+  const newRootElements = rootElements.filter(e => e !== rootElement);
+
+  // short-circuit to prevent unnecessary updates
+  if (newRootElements.length === rootElements.length) {
+    return;
+  }
+
+  modeling.updateModdleProperties(element, definitions, {
+    rootElements: newRootElements
+  });
+}
+
+/**
+ * Remove message from element and the diagram.
+ *
+ * @param {import('bpmn-js/lib/model/Types').Element} element
+ * @param {import('didi').Injector} injector
+ */
+export function removeMessage(element, injector) {
+  const modeling = injector.get('modeling');
+
+  const bo = getReferringElement(element);
+
+  const message = findMessage(bo);
+
+  if (!message) {
+    return;
+  }
+
+  modeling.updateModdleProperties(element, bo, {
+    messageRef: undefined
+  });
+  removeRootElement(message, injector);
+}
+
+
+export function getReferringElement(element) {
+  const bo = getBusinessObject(element);
+
+  if (is(bo, 'bpmn:Event')) {
+    return bo.get('eventDefinitions')[0];
+  }
+
+  return bo;
+}

--- a/test/spec/provider/cloud-element-templates/fixtures/condition-message.bpmn
+++ b/test/spec/provider/cloud-element-templates/fixtures/condition-message.bpmn
@@ -20,6 +20,14 @@
     <bpmn:intermediateCatchEvent id="Event_3" name="foo">
       <bpmn:messageEventDefinition messageRef="Message_3" />
     </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_4" name="four" zeebe:modelerTemplate="example.com.condition-short">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="select" value="one" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:messageEventDefinition messageRef="Message_4" />
+    </bpmn:intermediateCatchEvent>
     <bpmn:intermediateCatchEvent id="SubscriptionEvent_1" name="one" zeebe:modelerTemplate="example.com.condition-1">
       <bpmn:extensionElements>
         <zeebe:properties>
@@ -43,6 +51,7 @@
   <bpmn:message id="Message_1" name="one"></bpmn:message>
   <bpmn:message id="Message_2" name="two"></bpmn:message>
   <bpmn:message id="Message_3"></bpmn:message>
+  <bpmn:message id="Message_4" name="one"></bpmn:message>
   <bpmn:message id="SubscriptionMessage_1" name="one">
     <bpmn:extensionElements>
       <zeebe:subscription correlationKey="one"/>
@@ -66,6 +75,10 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0warlfb_di" bpmnElement="Event_3">
         <dc:Bounds x="440" y="120" width="36" height="36" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_4_di" bpmnElement="Event_4">
+        <dc:Bounds x="180" y="220" width="36" height="36" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="SubscriptionEvent_1_di" bpmnElement="SubscriptionEvent_1">

--- a/test/spec/provider/cloud-element-templates/fixtures/condition-message.json
+++ b/test/spec/provider/cloud-element-templates/fixtures/condition-message.json
@@ -60,6 +60,15 @@
           "property": "select",
           "equals": "two"
         }
+      },
+      {
+        "label": "unconditional - to prevent message removal",
+        "type": "Hidden",
+        "value": "two",
+        "binding": {
+          "type": "bpmn:Message#property",
+          "name": "foo"
+        }
       }
     ]
   },
@@ -119,6 +128,80 @@
         "binding": {
           "type": "bpmn:Message#zeebe:subscription#property",
           "name": "correlationKey"
+        },
+        "condition": {
+          "property": "select",
+          "equals": "two"
+        }
+      },
+      {
+        "label": "unconditional - to prevent message removal",
+        "type": "Hidden",
+        "value": "two",
+        "binding": {
+          "type": "bpmn:Message#property",
+          "name": "foo"
+        }
+      }
+    ]
+  },
+
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Message Property (limited props)",
+    "id": "example.com.condition-short",
+    "description": "A conditional template.",
+    "appliesTo": [
+      "bpmn:Event"
+    ],
+    "elementType": {
+      "value": "bpmn:IntermediateCatchEvent",
+      "eventDefinition": "bpmn:MessageEventDefinition"
+    },
+    "properties": [
+      {
+        "id": "select",
+        "type": "Dropdown",
+        "value": "one",
+        "choices": [
+          {
+            "name": "one",
+            "value": "one"
+          },
+          {
+            "name": "two",
+            "value": "two"
+          },
+          {
+            "name": "three",
+            "value": "three"
+          }
+        ],
+        "binding": {
+          "type": "zeebe:property",
+          "name": "select"
+        }
+      },
+      {
+        "label": "name",
+        "type": "Hidden",
+        "value": "one",
+        "binding": {
+          "type": "bpmn:Message#property",
+          "name": "name"
+        },
+        "condition": {
+          "property": "select",
+          "equals": "one"
+        }
+      },
+      {
+        "label": "name",
+        "type": "Hidden",
+        "value": "two",
+        "binding": {
+          "type": "bpmn:Message#property",
+          "name": "name"
         },
         "condition": {
           "property": "select",


### PR DESCRIPTION
If a conditional template deactivates all of the `bpmn:Message` bindings, the message is removed altogether. This feature will be important especially for templating catch-all events, i.e. error and escalation.

Closes #915
