### PR TITLE
fix(zeebe): remove output group from error end events

### DIFF
--- a/src/provider/zeebe/utils/InputOutputUtil.js
+++ b/src/provider/zeebe/utils/InputOutputUtil.js
@@ -3,7 +3,8 @@ import {
 } from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
 
 import {
-  getBusinessObject
+  getBusinessObject,
+  is
 } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
@@ -15,7 +16,10 @@ import {
 } from '../../../utils/ElementUtil';
 import { isZeebeServiceTask } from './ZeebeServiceTaskUtil';
 
-import { getEventDefinition } from '../../bpmn/utils/EventDefinitionUtil';
+import {
+  getErrorEventDefinition,
+  getEventDefinition
+} from '../../bpmn/utils/EventDefinitionUtil';
 
 function getElements(bo, type, prop) {
   const elems = getExtensionElementsList(bo, type);
@@ -75,6 +79,11 @@ export function areInputParametersSupported(element) {
 }
 
 export function areOutputParametersSupported(element) {
+
+  if (is(element, 'bpmn:EndEvent') && getErrorEventDefinition(element)) {
+    return false;
+  }
+
   return isAny(element, [
     'zeebe:ZeebeServiceTask',
     'bpmn:UserTask',

--- a/test/spec/provider/zeebe/ZeebePropertiesProvider.bpmn
+++ b/test/spec/provider/zeebe/ZeebePropertiesProvider.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_169thxk" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.6.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_169thxk" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.15.0-nightly.20230815" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Start Event">
       <bpmn:extensionElements>
@@ -111,6 +111,9 @@
     <bpmn:endEvent id="EscalationEvent" name="EscalationEvent">
       <bpmn:escalationEventDefinition id="EscalationEventDefinition_1i8kp4g" />
     </bpmn:endEvent>
+    <bpmn:endEvent id="ErrorEndEvent_1" name="ErrorEndEvent_1">
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_1uh9zpu" />
+    </bpmn:endEvent>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -205,6 +208,12 @@
         <dc:Bounds x="562" y="662" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="541" y="705" width="79" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1jg6chy_di" bpmnElement="ErrorEndEvent_1">
+        <dc:Bounds x="652" y="662" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="628" y="705" width="85" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0ii3c12_di" bpmnElement="InterruptingTimerBoundaryEvent_1">

--- a/test/spec/provider/zeebe/ZeebePropertiesProvider.spec.js
+++ b/test/spec/provider/zeebe/ZeebePropertiesProvider.spec.js
@@ -141,17 +141,22 @@ describe('<ZeebePropertiesProvider>', function() {
     it('should NOT show output group', inject(async function(elementRegistry, selection) {
 
       // given
-      const task = elementRegistry.get('Task_1');
+      const elements = [
+        elementRegistry.get('Task_1'),
+        elementRegistry.get('ErrorEndEvent_1')
+      ];
 
-      await act(() => {
-        selection.select(task);
-      });
+      for (const ele of elements) {
+        await act(() => {
+          selection.select(ele);
+        });
 
-      // when
-      const outputGroup = getGroup(container, 'outputs');
+        // when
+        const outputGroup = getGroup(container, 'outputs');
 
-      // then
-      expect(outputGroup).to.not.exist;
+        // then
+        expect(outputGroup).to.not.exist;
+      }
     }));
 
 


### PR DESCRIPTION
related to https://github.com/camunda/camunda-modeler/issues/3782

Removal of output mappings already present is a follow-up action and is done in https://github.com/camunda/camunda-bpmn-js-behaviors/tree/master/test/camunda-cloud

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
