### PR TITLE
feat: add support for `CalledElement#propagateAllParentVariables`

### DIFF
--- a/src/provider/zeebe/ZeebePropertiesProvider.js
+++ b/src/provider/zeebe/ZeebePropertiesProvider.js
@@ -9,6 +9,7 @@ import {
   EscalationProps,
   FormProps,
   HeaderProps,
+  InputPropagationProps,
   InputProps,
   MessageProps,
   MultiInstanceProps,
@@ -43,6 +44,7 @@ const ZEEBE_GROUPS = [
   FormGroup,
   ConditionGroup,
   TargetGroup,
+  InputPropagationGroup,
   InputGroup,
   OutputPropagationGroup,
   OutputGroup,
@@ -207,6 +209,19 @@ function OutputPropagationGroup(element) {
     label: 'Output propagation',
     entries: [
       ...OutputPropagationProps({ element })
+    ],
+    component: Group
+  };
+
+  return group.entries.length ? group : null;
+}
+
+function InputPropagationGroup(element) {
+  const group = {
+    id: 'inputPropagation',
+    label: 'Input propagation',
+    entries: [
+      ...InputPropagationProps({ element })
     ],
     component: Group
   };

--- a/src/provider/zeebe/properties/InputPropagationProps.js
+++ b/src/provider/zeebe/properties/InputPropagationProps.js
@@ -1,0 +1,158 @@
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  getCalledElement
+} from '../utils/CalledElementUtil.js';
+
+import {
+  has
+} from 'min-dash';
+
+import {
+  createElement
+} from '../../../utils/ElementUtil';
+
+import {
+  useService
+} from '../../../hooks';
+
+import { ToggleSwitchEntry, isToggleSwitchEntryEdited } from '@bpmn-io/properties-panel';
+
+
+export function InputPropagationProps(props) {
+  const {
+    element
+  } = props;
+
+  if (!is(element, 'bpmn:CallActivity')) {
+    return [];
+  }
+
+  return [
+    {
+      id: 'propagateAllParentVariables',
+      component: PropagateAllParentVariables,
+      isEdited: isToggleSwitchEntryEdited
+    }
+  ];
+}
+
+function PropagateAllParentVariables(props) {
+  const {
+    element
+  } = props;
+
+  const commandStack = useService('commandStack'),
+        bpmnFactory = useService('bpmnFactory'),
+        translate = useService('translate');
+
+  const propagateAllParentVariables = isPropagateAllParentVariables(element);
+
+  const getValue = () => {
+    return propagateAllParentVariables;
+  };
+
+  const setValue = (value) => {
+    const commands = [];
+
+    const businessObject = getBusinessObject(element);
+
+    // (1) ensure extension elements
+    let extensionElements = businessObject.get('extensionElements');
+
+    if (!extensionElements) {
+      extensionElements = createElement(
+        'bpmn:ExtensionElements',
+        { values: [] },
+        businessObject,
+        bpmnFactory
+      );
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: businessObject,
+          properties: { extensionElements }
+        }
+      });
+    }
+
+    // (2) ensure zeebe:calledElement
+    let calledElement = getCalledElement(businessObject);
+
+    if (!calledElement) {
+      calledElement = createElement(
+        'zeebe:CalledElement',
+        { },
+        extensionElements,
+        bpmnFactory);
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: extensionElements,
+          properties: {
+            values: [ ...extensionElements.get('values'), calledElement ]
+          }
+        }
+      });
+
+    }
+
+    // (3) Update propagateAllParentVariables attribute
+    commands.push({
+      cmd: 'element.updateModdleProperties',
+      context: {
+        element,
+        moddleElement: calledElement,
+        properties: {
+          propagateAllParentVariables: value
+        }
+      }
+    });
+
+    // (4) Execute the commands
+    commandStack.execute('properties-panel.multi-command-executor', commands);
+  };
+
+  return ToggleSwitchEntry({
+    id: 'propagateAllParentVariables',
+    label: translate('Propagate all variables'),
+    switcherLabel: propagateAllParentVariables ?
+      translate('On') :
+      translate('Off'),
+    tooltip: <div>
+      <p>{translate('If turned on, all variables from this process instance will be propagated to the child process instance.')}</p>
+      <p>{translate('Otherwise, only variables defined via input mappings will be propagated.')}</p>
+    </div>,
+    getValue,
+    setValue
+  });
+}
+
+
+// helper //////////////////////////
+
+/**
+  * Check whether the propagateAllParentVariables attribute is set on an element.
+  * @param {Object} element
+  *
+  * @returns {boolean}
+  */
+export function isPropagateAllParentVariables(element) {
+  if (!is(element, 'bpmn:CallActivity')) {
+    return undefined;
+  }
+
+  const bo = getBusinessObject(element),
+        calledElement = getCalledElement(bo);
+
+  return calledElement && has(calledElement, 'propagateAllParentVariables') ?
+    calledElement.get('propagateAllParentVariables') :
+    /* default value */ true;
+}

--- a/src/provider/zeebe/properties/index.js
+++ b/src/provider/zeebe/properties/index.js
@@ -6,6 +6,7 @@ export { ErrorProps } from './ErrorProps';
 export { EscalationProps } from './EscalationProps';
 export { FormProps } from './FormProps';
 export { HeaderProps } from './HeaderProps';
+export { InputPropagationProps } from './InputPropagationProps';
 export { InputProps } from './InputProps';
 export { MessageProps } from './MessageProps';
 export { MultiInstanceProps } from './MultiInstanceProps';

--- a/src/provider/zeebe/utils/CalledElementUtil.js
+++ b/src/provider/zeebe/utils/CalledElementUtil.js
@@ -13,6 +13,12 @@ export function getPropagateAllChildVariables(element) {
   return calledElement ? calledElement.get('propagateAllChildVariables') : undefined;
 }
 
+export function getPropagateAllParentVariables(element) {
+  const calledElement = getCalledElement(element);
+
+  return calledElement ? calledElement.get('propagateAllParentVariables') : undefined;
+}
+
 export function getProcessId(element) {
   const calledElement = getCalledElement(element);
 

--- a/test/spec/provider/zeebe/InputPropagationProps.bpmn
+++ b/test/spec/provider/zeebe/InputPropagationProps.bpmn
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0xepdnf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+  <bpmn:process id="Process_1ca0499" isExecutable="true">
+    <bpmn:callActivity id="CallActivity_1" name="CallActivity_1">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllParentVariables="false" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="CallActivity_2" name="CallActivity_2">
+      <bpmn:extensionElements>
+        <zeebe:calledElement />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="CallActivity_3" name="CallActivity_3" />
+    <bpmn:callActivity id="CallActivity_4" name="CallActivity_4">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="someProcessId" />
+        <zeebe:ioMapping>
+          <zeebe:output source="= source" target="target" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:task id="Task_1" name="Task_1" />
+    <bpmn:callActivity id="CallActivity_5" name="CallActivity_5">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="= source" target="target" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="CallActivity_6" name="CallActivity_6">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllParentVariables="false" />
+        <zeebe:ioMapping>
+          <zeebe:output source="= source" target="target" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:group id="Group_0g7mvor" categoryValueRef="CategoryValue_0i5rzi3" />
+  </bpmn:process>
+  <bpmn:category id="Category_028vbmh">
+    <bpmn:categoryValue id="CategoryValue_0i5rzi3" value="Legacy Formats" />
+  </bpmn:category>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1ca0499">
+      <bpmndi:BPMNShape id="Activity_148gene_di" bpmnElement="CallActivity_1">
+        <dc:Bounds x="160" y="230" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_17u01kh_di" bpmnElement="CallActivity_2">
+        <dc:Bounds x="160" y="360" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_04g6ntf_di" bpmnElement="CallActivity_3">
+        <dc:Bounds x="490" y="230" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09v4buk_di" bpmnElement="CallActivity_4">
+        <dc:Bounds x="490" y="350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1qlrc91_di" bpmnElement="Task_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ucjhow_di" bpmnElement="CallActivity_5">
+        <dc:Bounds x="160" y="490" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ax67yw_di" bpmnElement="CallActivity_6">
+        <dc:Bounds x="160" y="620" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0g7mvor_di" bpmnElement="Group_0g7mvor">
+        <dc:Bounds x="390" y="180" width="300" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="500" y="187" width="80" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/zeebe/InputPropagationProps.spec.js
+++ b/test/spec/provider/zeebe/InputPropagationProps.spec.js
@@ -1,0 +1,306 @@
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  act
+} from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  clickInput,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import {
+  getCalledElement,
+  getPropagateAllParentVariables
+} from 'src/provider/zeebe/utils/CalledElementUtil.js';
+
+import {
+  getExtensionElementsList
+} from 'src/utils/ExtensionElementsUtil.js';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import BpmnPropertiesPanel from 'src/render';
+import CoreModule from 'bpmn-js/lib/core';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ZeebePropertiesProvider from 'src/provider/zeebe';
+
+import BehaviorsModule from 'camunda-bpmn-js-behaviors/lib/camunda-cloud';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import diagramXML from './InputPropagationProps.bpmn';
+
+
+describe('provider/zeebe - InputPropagationProps', function() {
+
+  const testModules = [
+    BpmnPropertiesPanel,
+    CoreModule,
+    ModelingModule,
+    SelectionModule,
+    ZeebePropertiesProvider,
+    BehaviorsModule
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    modules: testModules,
+    moddleExtensions,
+    debounceInput: false
+  }));
+
+
+  describe('bpmn:CallActivity#calledElement.propagateAllParentVariables', function() {
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_1');
+
+      // when
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      const propagateAllParentVariablesToggle = domQuery('[data-entry-id=propagateAllParentVariables]', container);
+
+      // then
+      expect(propagateAllParentVariablesToggle).to.exist;
+    }));
+
+
+    it('should not display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('Task_1');
+
+      // when
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      const propagateAllParentVariablesToggle = domQuery('[data-entry-id=propagateAllParentVariables]', container);
+
+      // then
+      expect(propagateAllParentVariablesToggle).to.not.exist;
+    }));
+
+
+    describe('toggle state', function() {
+
+      it('should show value if set to false', inject(async function(elementRegistry, selection) {
+
+        // given
+        const callActivity = elementRegistry.get('CallActivity_1');
+
+        await act(() => {
+          selection.select(callActivity);
+        });
+
+        // then
+        const input = domQuery('#bio-properties-panel-propagateAllParentVariables', container);
+
+        expect(input.checked).to.be.false;
+      }));
+
+
+      it('should show value if set to true', inject(async function(elementRegistry, selection) {
+
+        // given
+        const callActivity = elementRegistry.get('CallActivity_2');
+
+        await act(() => {
+          selection.select(callActivity);
+        });
+
+        // then
+        const input = domQuery('#bio-properties-panel-propagateAllParentVariables', container);
+
+        expect(input.checked).to.be.true;
+      }));
+
+
+      it('should show default value true if not set', inject(async function(elementRegistry, selection) {
+
+        // given
+        const callActivity = elementRegistry.get('CallActivity_3');
+
+        await act(() => {
+          selection.select(callActivity);
+        });
+
+        // then
+        const input = domQuery('#bio-properties-panel-propagateAllParentVariables', container);
+
+        expect(input.checked).to.be.true;
+      }));
+
+    });
+
+
+    it('should update to true', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_1');
+
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      // assume
+      const originalValue = getPropagateAllParentVariables(callActivity);
+      expect(originalValue).to.be.false;
+
+      // when
+      const slider = domQuery('[data-entry-id=propagateAllParentVariables] .bio-properties-panel-toggle-switch__slider', container);
+
+      // when
+      clickInput(slider);
+
+      // then
+      const input = domQuery('#bio-properties-panel-propagateAllParentVariables', container);
+      expect(input.checked).to.be.true;
+
+      const newValue = getPropagateAllParentVariables(callActivity);
+      expect(newValue).to.be.true;
+    }));
+
+
+    it('should update to false', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_2');
+
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      // assume
+      const originalValue = getPropagateAllParentVariables(callActivity);
+      expect(originalValue).to.be.true;
+
+      // when
+      const slider = domQuery('[data-entry-id=propagateAllParentVariables] .bio-properties-panel-toggle-switch__slider', container);
+      clickInput(slider);
+
+      // then
+      const input = domQuery('#bio-properties-panel-propagateAllParentVariables', container);
+      expect(input.checked).to.be.false;
+
+      const newValue = getPropagateAllParentVariables(callActivity);
+      expect(newValue).to.be.false;
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const callActivity = elementRegistry.get('CallActivity_1'),
+              originalValue = getPropagateAllParentVariables(callActivity);
+
+        await act(() => {
+          selection.select(callActivity);
+        });
+
+        const slider = domQuery('[data-entry-id=propagateAllParentVariables] .bio-properties-panel-toggle-switch__slider', container);
+        clickInput(slider);
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        const input = domQuery('#bio-properties-panel-propagateAllParentVariables', container);
+        expect(input.checked).to.equal(originalValue);
+      })
+    );
+
+
+    it('should re-use calledElement', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_4');
+
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      // when
+      const slider = domQuery('[data-entry-id=propagateAllParentVariables] .bio-properties-panel-toggle-switch__slider', container);
+      clickInput(slider);
+
+      // then
+      const calledElement = getCalledElement(callActivity),
+            processId = calledElement.get('processId');
+
+      expect(processId).to.equal('someProcessId');
+    }));
+
+
+    it('should re-use extensionElements', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_5'),
+            businessObject = getBusinessObject(callActivity);
+
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      // assume
+      expect(getExtensionElementsList(businessObject, 'zeebe:IoMapping')).to.have.length(1);
+
+      // when
+      const slider = domQuery('[data-entry-id=propagateAllParentVariables] .bio-properties-panel-toggle-switch__slider', container);
+      clickInput(slider);
+
+      // then
+      const ioMapping = getExtensionElementsList(businessObject, 'zeebe:IoMapping');
+
+      expect(ioMapping).to.have.length(1);
+    }));
+
+
+    it('should create called element extension element', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_3');
+
+      // assume
+      expect(getCalledElement(callActivity)).not.to.exist;
+
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      // when
+      const slider = domQuery('[data-entry-id=propagateAllParentVariables] .bio-properties-panel-toggle-switch__slider', container);
+      clickInput(slider);
+
+      // then
+      expect(getCalledElement(callActivity)).to.exist;
+    }));
+
+  });
+
+});

--- a/test/spec/provider/zeebe/OutputPropagationProps.spec.js
+++ b/test/spec/provider/zeebe/OutputPropagationProps.spec.js
@@ -190,7 +190,7 @@ describe('provider/zeebe - OutputPropagationProps', function() {
       expect(originalValue).to.be.false;
 
       // when
-      const slider = domQuery('.bio-properties-panel-toggle-switch__slider', container);
+      const slider = domQuery('[data-entry-id=propagateAllChildVariables] .bio-properties-panel-toggle-switch__slider', container);
 
       // when
       clickInput(slider);
@@ -218,7 +218,7 @@ describe('provider/zeebe - OutputPropagationProps', function() {
       expect(originalValue).to.be.true;
 
       // when
-      const slider = domQuery('.bio-properties-panel-toggle-switch__slider', container);
+      const slider = domQuery('[data-entry-id=propagateAllChildVariables] .bio-properties-panel-toggle-switch__slider', container);
 
       clickInput(slider);
 
@@ -242,7 +242,7 @@ describe('provider/zeebe - OutputPropagationProps', function() {
           selection.select(callActivity);
         });
 
-        const slider = domQuery('.bio-properties-panel-toggle-switch__slider', container);
+        const slider = domQuery('[data-entry-id=propagateAllChildVariables] .bio-properties-panel-toggle-switch__slider', container);
         clickInput(slider);
 
         // when
@@ -267,7 +267,7 @@ describe('provider/zeebe - OutputPropagationProps', function() {
       });
 
       // when
-      const slider = domQuery('.bio-properties-panel-toggle-switch__slider', container);
+      const slider = domQuery('[data-entry-id=propagateAllChildVariables] .bio-properties-panel-toggle-switch__slider', container);
       clickInput(slider);
 
       // then
@@ -292,7 +292,7 @@ describe('provider/zeebe - OutputPropagationProps', function() {
       expect(getExtensionElementsList(businessObject, 'zeebe:IoMapping')).to.have.length(1);
 
       // when
-      const slider = domQuery('.bio-properties-panel-toggle-switch__slider', container);
+      const slider = domQuery('[data-entry-id=propagateAllChildVariables] .bio-properties-panel-toggle-switch__slider', container);
       clickInput(slider);
 
       // then
@@ -315,7 +315,7 @@ describe('provider/zeebe - OutputPropagationProps', function() {
       });
 
       // when
-      const slider = domQuery('.bio-properties-panel-toggle-switch__slider', container);
+      const slider = domQuery('[data-entry-id=propagateAllChildVariables] .bio-properties-panel-toggle-switch__slider', container);
       clickInput(slider);
 
       // then
@@ -344,7 +344,7 @@ describe('provider/zeebe - OutputPropagationProps', function() {
                 selection.select(callActivity);
               });
 
-              const slider = domQuery('.bio-properties-panel-toggle-switch__slider', container);
+              const slider = domQuery('[data-entry-id=propagateAllChildVariables] .bio-properties-panel-toggle-switch__slider', container);
 
               clickInput(slider);
             }));
@@ -399,7 +399,7 @@ describe('provider/zeebe - OutputPropagationProps', function() {
                 selection.select(callActivity);
               });
 
-              const slider = domQuery('.bio-properties-panel-toggle-switch__slider', container);
+              const slider = domQuery('[data-entry-id=propagateAllChildVariables] .bio-properties-panel-toggle-switch__slider', container);
 
               clickInput(slider);
             }));
@@ -464,7 +464,7 @@ describe('provider/zeebe - OutputPropagationProps', function() {
                 selection.select(shape);
               });
 
-              const slider = domQuery('.bio-properties-panel-toggle-switch__slider', container);
+              const slider = domQuery('[data-entry-id=propagateAllChildVariables] .bio-properties-panel-toggle-switch__slider', container);
 
               clickInput(slider);
             }));
@@ -519,7 +519,7 @@ describe('provider/zeebe - OutputPropagationProps', function() {
                 selection.select(shape);
               });
 
-              const slider = domQuery('.bio-properties-panel-toggle-switch__slider', container);
+              const slider = domQuery('[data-entry-id=propagateAllChildVariables] .bio-properties-panel-toggle-switch__slider', container);
 
               clickInput(slider);
             }));
@@ -588,7 +588,7 @@ describe('provider/zeebe - OutputPropagationProps', function() {
               selection.select(shape);
             });
 
-            const slider = domQuery('.bio-properties-panel-toggle-switch__slider', container);
+            const slider = domQuery('[data-entry-id=propagateAllChildVariables] .bio-properties-panel-toggle-switch__slider', container);
 
             clickInput(slider);
           }));


### PR DESCRIPTION
Adds a option to configure the
`CalledElement#propagateAllParentVariables` when modeling a Call Activity.

closes #953 
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
