### PR TITLE
feat(feel-popup): include feel popup module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: allow listen to `feelPopup.opened` and `feelPopup.closed` events ([#974](https://github.com/bpmn-io/bpmn-js-properties-panel/issues/974))
+* `FEAT`: provide `feelPopup` module to interact with FEEL popup ([#974](https://github.com/bpmn-io/bpmn-js-properties-panel/issues/974))
+* `DEPS`: update to `@bpmn-io/properties-panel@3.7.0`
+
 ## 5.3.0
 
 * `FEAT`: prioritize externally provided errors ([bpmn-io/properties-panel@`375838b7`](https://github.com/bpmn-io/properties-panel/commit/375838b7c82b559a579792a46479592efcd5f500))

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@babel/plugin-transform-react-jsx": "^7.14.3",
         "@bpmn-io/element-template-chooser": "^1.0.0",
         "@bpmn-io/element-templates-icons-renderer": "^0.3.0",
-        "@bpmn-io/properties-panel": "^3.6.0",
+        "@bpmn-io/properties-panel": "^3.7.0",
         "@bpmn-io/variable-resolver": "^1.2.0",
         "@rollup/plugin-alias": "^5.0.0",
         "@rollup/plugin-babel": "^6.0.3",
@@ -73,8 +73,11 @@
         "webpack": "^5.74.0",
         "zeebe-bpmn-moddle": "^1.0.0"
       },
+      "engines": {
+        "node": "*"
+      },
       "peerDependencies": {
-        "@bpmn-io/properties-panel": ">= 3.5",
+        "@bpmn-io/properties-panel": ">= 3.7",
         "bpmn-js": ">= 11.5",
         "camunda-bpmn-js-behaviors": ">= 0.4",
         "diagram-js": ">= 11.9"
@@ -626,9 +629,9 @@
       }
     },
     "node_modules/@bpmn-io/properties-panel": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.6.0.tgz",
-      "integrity": "sha512-ooe+y3wDYU8w8SXiXsXuFrlY8uEhWNOGkqSWlz/BSbYMSrvNwFu4Jxkii5UoJ3gjdPqq8kr3hOKa1gjQn+qRtA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.7.0.tgz",
+      "integrity": "sha512-379nFK4iWxwsjJOc6ShhNWo8heK76PlZAHutmWpy48mba7SiDb8PLSbPkTa+KFcWb9AiRlvpDcLFIiIJzopkDA==",
       "dev": true,
       "dependencies": {
         "@bpmn-io/feel-editor": "^0.9.0",
@@ -9609,9 +9612,9 @@
       }
     },
     "@bpmn-io/properties-panel": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.6.0.tgz",
-      "integrity": "sha512-ooe+y3wDYU8w8SXiXsXuFrlY8uEhWNOGkqSWlz/BSbYMSrvNwFu4Jxkii5UoJ3gjdPqq8kr3hOKa1gjQn+qRtA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.7.0.tgz",
+      "integrity": "sha512-379nFK4iWxwsjJOc6ShhNWo8heK76PlZAHutmWpy48mba7SiDb8PLSbPkTa+KFcWb9AiRlvpDcLFIiIJzopkDA==",
       "dev": true,
       "requires": {
         "@bpmn-io/feel-editor": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@babel/plugin-transform-react-jsx": "^7.14.3",
     "@bpmn-io/element-template-chooser": "^1.0.0",
     "@bpmn-io/element-templates-icons-renderer": "^0.3.0",
-    "@bpmn-io/properties-panel": "^3.6.0",
+    "@bpmn-io/properties-panel": "^3.7.0",
     "@bpmn-io/variable-resolver": "^1.2.0",
     "@rollup/plugin-alias": "^5.0.0",
     "@rollup/plugin-babel": "^6.0.3",
@@ -116,7 +116,7 @@
     "zeebe-bpmn-moddle": "^1.0.0"
   },
   "peerDependencies": {
-    "@bpmn-io/properties-panel": ">= 3.5",
+    "@bpmn-io/properties-panel": ">= 3.7",
     "bpmn-js": ">= 11.5",
     "camunda-bpmn-js-behaviors": ">= 0.4",
     "diagram-js": ">= 11.9"

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -1,12 +1,13 @@
 import BpmnPropertiesPanelRenderer from './BpmnPropertiesPanelRenderer';
 
 import Commands from '../cmd';
-import { DebounceInputModule } from '@bpmn-io/properties-panel';
+import { DebounceInputModule, FeelPopupModule } from '@bpmn-io/properties-panel';
 
 export default {
   __depends__: [
     Commands,
-    DebounceInputModule
+    DebounceInputModule,
+    FeelPopupModule
   ],
   __init__: [
     'propertiesPanel'


### PR DESCRIPTION
Closes #974

Adds the core `feelPopup` module to interact with the FEEL popup editor in a non-UI manner.
