### PR TITLE
fix(Input/Output): keep undo/redo stack

### DIFF
--- a/src/provider/zeebe/properties/InputProps.js
+++ b/src/provider/zeebe/properties/InputProps.js
@@ -152,7 +152,6 @@ function addFactory({ element, bpmnFactory, commandStack }) {
 
     // (3) create parameter
     const newParameter = createElement('zeebe:Input', {
-      source: '',
       target: nextId('InputVariable_')
     }, ioMapping, bpmnFactory);
 

--- a/src/provider/zeebe/properties/OutputProps.js
+++ b/src/provider/zeebe/properties/OutputProps.js
@@ -154,7 +154,6 @@ function addFactory({ element, bpmnFactory, commandStack }) {
 
     // (3) create parameter
     const newParameter = createElement('zeebe:Output', {
-      source: '',
       target: nextId('OutputVariable_')
     }, ioMapping, bpmnFactory);
 

--- a/test/spec/provider/zeebe/InputOutputParameter.spec.js
+++ b/test/spec/provider/zeebe/InputOutputParameter.spec.js
@@ -79,6 +79,7 @@ describe('provider/zeebe - InputOutputParameter', function() {
       })
     );
 
+
     it('should display', inject(async function(elementRegistry, selection) {
 
       // given
@@ -163,6 +164,7 @@ describe('provider/zeebe - InputOutputParameter', function() {
       })
     );
 
+
     it('should display', inject(async function(elementRegistry, selection) {
 
       // given
@@ -223,6 +225,81 @@ describe('provider/zeebe - InputOutputParameter', function() {
       })
     );
 
+
+    describe('integration', function() {
+
+      // Test for undo/redo integration with newly created input/output parameters
+      // cf. https://github.com/bpmn-io/bpmn-js-properties-panel/issues/981
+      it('should undo',
+        inject(async function(elementRegistry, selection, commandStack) {
+
+          // given
+          const serviceTask = elementRegistry.get('ServiceTask_empty');
+
+          await act(() => {
+            selection.select(serviceTask);
+          });
+
+          const inputGroup = getGroup(container, 'inputs');
+          const addEntry = domQuery('.bio-properties-panel-add-entry', inputGroup);
+
+          await act(() => {
+            addEntry.click();
+          });
+
+          const sourceInput = domQuery('[name=ServiceTask_empty-input-0-source] [role="textbox"]', inputGroup);
+          await setEditorValue(sourceInput, 'newValue');
+
+          // assume
+          expect(getInput(serviceTask, 0).get('source')).to.eql('=newValue');
+
+          // when
+          commandStack.undo();
+          await nextTick(); // propagate value to editor and await change handler
+
+          // then
+          expect(getInput(serviceTask, 0).get('source')).to.be.undefined;
+        })
+      );
+
+
+      it('should redo',
+        inject(async function(elementRegistry, selection, commandStack) {
+
+          // given
+          const serviceTask = elementRegistry.get('ServiceTask_empty');
+
+          await act(() => {
+            selection.select(serviceTask);
+          });
+
+          const inputGroup = getGroup(container, 'inputs');
+          const addEntry = domQuery('.bio-properties-panel-add-entry', inputGroup);
+
+          await act(() => {
+            addEntry.click();
+          });
+
+          const sourceInput = domQuery('[name=ServiceTask_empty-input-0-source] [role="textbox"]', inputGroup);
+
+          await setEditorValue(sourceInput, 'newValue');
+
+          // assume
+          expect(getInput(serviceTask, 0).get('source')).to.eql('=newValue');
+
+          // when
+          commandStack.undo();
+          await nextTick();
+          commandStack.redo();
+          await nextTick();
+
+          // then
+          expect(getInput(serviceTask, 0).get('source')).to.eql('=newValue');
+
+        })
+      );
+    });
+
   });
 
 
@@ -246,6 +323,7 @@ describe('provider/zeebe - InputOutputParameter', function() {
         expect(targetInput).to.not.exist;
       })
     );
+
 
     it('should display', inject(async function(elementRegistry, selection) {
 
@@ -331,6 +409,7 @@ describe('provider/zeebe - InputOutputParameter', function() {
       })
     );
 
+
     it('should display', inject(async function(elementRegistry, selection) {
 
       // given
@@ -391,6 +470,80 @@ describe('provider/zeebe - InputOutputParameter', function() {
       })
     );
 
+
+    describe('integration', function() {
+
+      // Test for undo/redo integration with newly created input/output parameters
+      // Cf. https://github.com/bpmn-io/bpmn-js-properties-panel/issues/981
+      it('should undo',
+        inject(async function(elementRegistry, selection, commandStack) {
+
+          // given
+          const serviceTask = elementRegistry.get('ServiceTask_empty');
+
+          await act(() => {
+            selection.select(serviceTask);
+          });
+
+          const outputGroup = getGroup(container, 'outputs');
+          const addEntry = domQuery('.bio-properties-panel-add-entry', outputGroup);
+
+          await act(() => {
+            addEntry.click();
+          });
+
+          const sourceInput = domQuery('[name=ServiceTask_empty-output-0-source] [role="textbox"]', outputGroup);
+          await setEditorValue(sourceInput, 'newValue');
+
+          // assume
+          expect(getOutput(serviceTask, 0).get('source')).to.eql('=newValue');
+
+          // when
+          commandStack.undo();
+          await nextTick(); // propagate value to editor and await change handler
+
+          // then
+          expect(getOutput(serviceTask, 0).get('source')).to.be.undefined;
+        })
+      );
+
+
+      it('should redo',
+        inject(async function(elementRegistry, selection, commandStack) {
+
+          // given
+          const serviceTask = elementRegistry.get('ServiceTask_empty');
+
+          await act(() => {
+            selection.select(serviceTask);
+          });
+
+          const outputGroup = getGroup(container, 'outputs');
+          const addEntry = domQuery('.bio-properties-panel-add-entry', outputGroup);
+
+          await act(() => {
+            addEntry.click();
+          });
+
+          const sourceInput = domQuery('[name=ServiceTask_empty-output-0-source] [role="textbox"]', outputGroup);
+          await setEditorValue(sourceInput, 'newValue');
+
+          // assume
+          expect(getOutput(serviceTask, 0).get('source')).to.eql('=newValue');
+
+          // when
+          commandStack.undo();
+          await nextTick();
+          commandStack.redo();
+          await nextTick();
+
+          // then
+          expect(getOutput(serviceTask, 0).get('source')).to.eql('=newValue');
+
+        })
+      );
+    });
+
   });
 
 });
@@ -410,3 +563,6 @@ function getOutput(element, idx) {
   return (getOutputParameters(element) || [])[idx];
 }
 
+function nextTick() {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}


### PR DESCRIPTION
This PR removes the empty `source` value for newly created Input/Output parameters. I decided to go with the convention "no value => remove property" that we use in other places, such as Task definition type. I verified that the deployment error in zeebe is the same for empty value and missing property.

I added integration tests to verify the scenario described in #981.

![Recording 2023-10-10 at 10 59 16](https://github.com/bpmn-io/bpmn-js-properties-panel/assets/21984219/81b9c2f5-f73d-452f-b0e5-c301a9a1345d)


<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
