### PR TITLE
feat(FEEL): use moddle element to filter for variables 

### DIFF
--- a/src/provider/HOCs/withVariableContext.js
+++ b/src/provider/HOCs/withVariableContext.js
@@ -2,15 +2,9 @@ import { getVariablesForElement } from '@bpmn-io/extract-process-variables/zeebe
 import { useEffect, useState } from '@bpmn-io/properties-panel/preact/hooks';
 import { useService } from '../../hooks';
 
-function useServiceIfAvailable(service, fallback) {
-  const resolved = useService(service, false);
-
-  if (!resolved) {
-    return fallback;
-  }
-
-  return resolved;
-}
+const fallbackResolver = {
+  getVariablesForElement: bo => getVariablesForElement(bo)
+};
 
 export function withVariableContext(Component) {
   return props => {
@@ -21,12 +15,12 @@ export function withVariableContext(Component) {
     const [ variables, setVariables ] = useState([]);
     const eventBus = useService('eventBus');
 
-    const variableResolver = useServiceIfAvailable('variableResolver', { getVariablesForElement });
+    const variableResolver = useServiceIfAvailable('variableResolver', fallbackResolver);
 
     useEffect(() => {
       const extractVariables = async () => {
 
-        const variables = await variableResolver.getVariablesForElement(bo);
+        const variables = await variableResolver.getVariablesForElement(bo, element);
 
         setVariables(variables.map(variable => {
           return {
@@ -53,4 +47,16 @@ export function withVariableContext(Component) {
 
     return <Component { ...props } variables={ variables }></Component>;
   };
+}
+
+// helpers //////////
+
+function useServiceIfAvailable(service, fallback) {
+  const resolved = useService(service, false);
+
+  if (!resolved) {
+    return fallback;
+  }
+
+  return resolved;
 }

--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -36,6 +36,10 @@ import {
   CreateAppendAnythingModule
 } from 'bpmn-js-create-append-anything';
 
+import {
+  ZeebeVariableResolverModule
+} from '@bpmn-io/variable-resolver';
+
 import CamundaBehaviorsModule from 'camunda-bpmn-js-behaviors/lib/camunda-platform';
 import ZeebeBehaviorsModule from 'camunda-bpmn-js-behaviors/lib/camunda-cloud';
 
@@ -144,7 +148,8 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
           BpmnPropertiesPanel,
           BpmnPropertiesProvider,
           ZeebePropertiesProvider,
-          CreateAppendAnythingModule
+          CreateAppendAnythingModule,
+          ZeebeVariableResolverModule
         ],
         moddleExtensions: {
           zeebe: ZeebeModdle

--- a/test/spec/provider/HOCs/withVariableContext.bpmn
+++ b/test/spec/provider/HOCs/withVariableContext.bpmn
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_17tkbpr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_17tkbpr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.16.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
   <bpmn:process id="Process_1i2l690" isExecutable="true">
     <bpmn:serviceTask id="Task_2">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="= source" target="OutputVariable_0svilsd" />
+          <zeebe:input source="" target="InputVariable_1" />
+          <zeebe:output source="" target="OutputVariable_1" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
     </bpmn:serviceTask>

--- a/test/spec/provider/HOCs/withVariableContext.spec.js
+++ b/test/spec/provider/HOCs/withVariableContext.spec.js
@@ -76,7 +76,7 @@ describe('HOCs - withVariableContext.js', function() {
         expect(mockComponent).to.have.been.calledWith(
           matchesVariables([
             {
-              name: 'OutputVariable_0svilsd',
+              name: 'OutputVariable_1',
               info: 'Written in Task_2'
             }
           ])
@@ -111,7 +111,11 @@ describe('HOCs - withVariableContext.js', function() {
         expect(mockComponent).to.have.been.calledWith(
           matchesVariables([
             {
-              name: 'OutputVariable_0svilsd',
+              name: 'InputVariable_1',
+              info: 'Written in Task_2'
+            },
+            {
+              name: 'OutputVariable_1',
               info: 'Written in Task_2'
             }
           ])
@@ -160,6 +164,10 @@ describe('HOCs - withVariableContext.js', function() {
       await waitFor(() => {
         expect(mockComponent.lastCall).to.have.been.calledWith(
           matchesVariables([
+            {
+              name: 'InputVariable_1',
+              info: 'Written in Task_2'
+            },
             {
               name: 'newVariable',
               info: 'Written in Task_2'
@@ -234,7 +242,7 @@ describe('HOCs - withVariableContext.js', function() {
         expect(mockComponent).to.have.been.calledWith(
           matchesVariables([
             {
-              name: 'OutputVariable_0svilsd',
+              name: 'OutputVariable_1',
               info: 'Written in Task_2'
             },
             {
@@ -248,7 +256,7 @@ describe('HOCs - withVariableContext.js', function() {
     }));
 
 
-    it('should supply variables to extension element', inject(async function(elementRegistry, injector) {
+    it('should supply and filter variables to extension element', inject(async function(elementRegistry, injector) {
 
       // given
       const mockComponent = sinon.spy();
@@ -274,7 +282,7 @@ describe('HOCs - withVariableContext.js', function() {
         expect(mockComponent).to.have.been.calledWith(
           matchesVariables([
             {
-              name: 'OutputVariable_0svilsd',
+              name: 'InputVariable_1',
               info: 'Written in Task_2'
             },
             {
@@ -311,7 +319,7 @@ describe('HOCs - withVariableContext.js', function() {
         container
       });
 
-      const ioMapping = ioMappings.outputParameters[0];
+      const ioMapping = ioMappings.inputParameters[0];
 
       // when
       await act(() => {


### PR DESCRIPTION
We added this functionality to the variable resolver a while back but never properly integrated it. Ooops. Better late than never I guess. 

![image](https://github.com/bpmn-io/bpmn-js-properties-panel/assets/21984219/2bbe0e3a-62b8-4fa6-82fd-6d021aa9e0e0)

related to https://github.com/camunda/camunda-modeler/issues/3510

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
