### PR TITLE
chore: export module using `mjs` extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node": "*"
   },
   "main": "dist/index.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/index.mjs",
   "umd:main": "dist/bpmn-js-properties-panel.umd.js",
   "author": {
     "name": "Nico Rehwaldt",


### PR DESCRIPTION
Following up on https://github.com/bpmn-io/properties-panel/pull/303.

This allows module bundlers to properly interpret the file.