### PR TITLE
fix: do not unset form type when setting value to empty

### DIFF
--- a/src/provider/camunda-platform/properties/FormProps.js
+++ b/src/provider/camunda-platform/properties/FormProps.js
@@ -1,3 +1,5 @@
+import { isUndefined } from 'min-dash';
+
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
 import { TextFieldEntry, isTextFieldEntryEdited, SelectEntry, isSelectEntryEdited } from '@bpmn-io/properties-panel';
@@ -77,7 +79,7 @@ function FormKey(props) {
 
   const setValue = (value) => {
     modeling.updateProperties(element, {
-      'camunda:formKey': value
+      'camunda:formKey': isUndefined(value) ? '' : value
     });
   };
 
@@ -106,7 +108,7 @@ function FormRef(props) {
 
   const setValue = (value) => {
     modeling.updateProperties(element, {
-      'camunda:formRef': value
+      'camunda:formRef': isUndefined(value) ? '' : value
     });
   };
 

--- a/src/provider/zeebe/properties/FormProps.js
+++ b/src/provider/zeebe/properties/FormProps.js
@@ -1,4 +1,7 @@
-import { without } from 'min-dash';
+import {
+  isUndefined,
+  without
+} from 'min-dash';
 
 import {
   getBusinessObject,
@@ -122,7 +125,7 @@ function FormConfiguration(props) {
   };
 
   const setValue = (value) => {
-    setUserTaskForm(injector, element, value);
+    setUserTaskForm(injector, element, isUndefined(value) ? '' : value);
   };
 
   return TextAreaEntry({
@@ -149,7 +152,7 @@ function FormId(props) {
   };
 
   const setValue = (value) => {
-    setFormId(injector, element, value);
+    setFormId(injector, element, isUndefined(value) ? '' : value);
   };
 
   return TextFieldEntry({
@@ -175,7 +178,7 @@ function CustomFormKey(props) {
   };
 
   const setValue = (value) => {
-    setCustomFormKey(injector, element, value);
+    setCustomFormKey(injector, element, isUndefined(value) ? '' : value);
   };
 
   return TextFieldEntry({

--- a/test/spec/provider/camunda-platform/FormProps.spec.js
+++ b/test/spec/provider/camunda-platform/FormProps.spec.js
@@ -116,6 +116,27 @@ describe('provider/camunda-platform - FormProps', function() {
     }));
 
 
+    it('should not delete if empty', inject(async function(elementRegistry, selection) {
+
+      // given
+      const task = elementRegistry.get('UserTask_FormKey');
+
+      await act(() => {
+        selection.select(task);
+      });
+
+      // when
+      const input = domQuery('input[name=formKey]', container);
+
+      changeInput(input, '');
+
+      // then
+      expect(getBusinessObject(task).get('camunda:formKey')).to.equal('');
+
+      expect(input.value).to.equal('');
+    }));
+
+
     it('should update on external change', inject(async function(commandStack, elementRegistry, selection) {
 
       // given
@@ -200,6 +221,27 @@ describe('provider/camunda-platform - FormProps', function() {
       expect(getBusinessObject(task).get('camunda:formRef')).to.equal('newValue');
 
       expect(input.value).to.equal('newValue');
+    }));
+
+
+    it('should not delete if empty', inject(async function(elementRegistry, selection) {
+
+      // given
+      const task = elementRegistry.get('UserTask_FormRef');
+
+      await act(() => {
+        selection.select(task);
+      });
+
+      // when
+      const input = domQuery('input[name=formRef]', container);
+
+      changeInput(input, '');
+
+      // then
+      expect(getBusinessObject(task).get('camunda:formRef')).to.equal('');
+
+      expect(input.value).to.equal('');
     }));
 
 

--- a/test/spec/provider/zeebe/Forms.spec.js
+++ b/test/spec/provider/zeebe/Forms.spec.js
@@ -296,6 +296,25 @@ describe('provider/zeebe - Forms', function() {
     }));
 
 
+    it('should not delete if empty', inject(async function(elementRegistry, selection) {
+
+      // given
+      const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
+
+      await act(() => {
+        selection.select(userTask);
+      });
+
+      const formConfigurationTextarea = getFormConfigurationTextarea(container);
+
+      // when
+      changeInput(formConfigurationTextarea, '');
+
+      // then
+      expectUserTaskForm(userTask, '');
+    }));
+
+
     it('should update on external change', inject(async function(commandStack, elementRegistry, selection) {
 
       // given
@@ -360,6 +379,25 @@ describe('provider/zeebe - Forms', function() {
     }));
 
 
+    it('should not delete if empty', inject(async function(elementRegistry, selection) {
+
+      // given
+      const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+      await act(() => {
+        selection.select(userTask);
+      });
+
+      const formIdInput = getFormIdInput(container);
+
+      // when
+      changeInput(formIdInput, '');
+
+      // then
+      expectFormId(userTask, '');
+    }));
+
+
     it('should update on external change', inject(async function(commandStack, elementRegistry, selection) {
 
       // given
@@ -421,6 +459,25 @@ describe('provider/zeebe - Forms', function() {
 
       // then
       expectFormKey(userTask, 'foo');
+    }));
+
+
+    it('should not delete if empty', inject(async function(elementRegistry, selection) {
+
+      // given
+      const userTask = elementRegistry.get('CUSTOM_FORM');
+
+      await act(() => {
+        selection.select(userTask);
+      });
+
+      const customFormKeyInput = getCustomFormKeyInput(container);
+
+      // when
+      changeInput(customFormKeyInput, '');
+
+      // then
+      expectFormKey(userTask, '');
     }));
 
 


### PR DESCRIPTION
![brave_ovznq5KARU](https://github.com/bpmn-io/bpmn-js-properties-panel/assets/7633572/36b36fc2-ffcd-40cd-b9d6-26bf9e16951d)


Related to https://github.com/camunda/camunda-modeler/issues/3963

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
