### PR TITLE
chore: adjust `Forms` group tooltip

### DIFF
--- a/src/contextProvider/zeebe/TooltipProvider.js
+++ b/src/contextProvider/zeebe/TooltipProvider.js
@@ -67,7 +67,7 @@ const TooltipProvider = {
 
     return (
       <div>
-        { translate('Embed a form created with the Camunda Forms editor. To associate a custom form, application, or URL to the user task, specify a form key. ')}
+        { translate('Link or embed a form created with the Camunda Forms editor. To associate a custom form, application, or URL to the user task, specify a form key. ')}
         <a href="https://docs.camunda.io/docs/guides/utilizing-forms/#connect-your-form-to-a-bpmn-diagram" target="_blank" rel="noopener" title={ translate('User task form documentation') }>
           { translate('Learn more.') }
         </a>


### PR DESCRIPTION
The docs themselves still need to be updated to reflect form linking.

![image](https://github.com/bpmn-io/bpmn-js-properties-panel/assets/7633572/54ee1f7e-f2e9-440d-acc2-bca4146f74d5)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
