### PR TITLE
Fix missing translation capabilities

### DIFF
--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -213,6 +213,42 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
   });
 
 
+  it.only('should translate', async function() {
+
+    // given
+    const diagramXml = require('test/fixtures/simple.bpmn').default;
+
+    const CustomTranslateModule = {
+      translate: [ 'value', function customTranslate(template, replacements) {
+        return '🙂';
+      } ]
+    };
+
+    // when
+    const result = await createModeler(
+      diagramXml,
+      {
+        additionalModules: [
+          ZeebeBehaviorsModule,
+          BpmnPropertiesPanel,
+          BpmnPropertiesProvider,
+          ZeebePropertiesProvider,
+          CreateAppendAnythingModule,
+          ZeebeVariableResolverModule,
+          CustomTranslateModule
+        ],
+        moddleExtensions: {
+          zeebe: ZeebeModdle
+        },
+        tooltip: TooltipProvider
+      }
+    );
+
+    // then
+    expect(result.error).not.to.exist;
+  });
+
+
   it('should attach on diagram.init', async function() {
 
     // given


### PR DESCRIPTION
This asserts our current level of translation within the properties panel:

![capture eijY6T_optimized](https://github.com/bpmn-io/bpmn-js-properties-panel/assets/58601/1c848943-2831-436c-83d8-2ad4ff3952df)
