### PR TITLE
fix(zeebe): correct retries tooltip

### DIFF
--- a/src/contextProvider/zeebe/TooltipProvider.js
+++ b/src/contextProvider/zeebe/TooltipProvider.js
@@ -234,7 +234,7 @@ const TooltipProvider = {
     return (
       <div>
         <p>
-          { translate('The amount of times the engine tries to execute this activity if a worker signals a failure. The default is three.') } { ' ' }
+          { translate('The number of times the engine tries executing this activity if a worker signals a failure. The default is three.') } { ' ' }
           <a href="https://docs.camunda.io/docs/next/components/best-practices/development/dealing-with-problems-and-exceptions/#leveraging-retries" target="_blank" rel="noopener">{ translate('Learn more.') }</a>
         </p>
       </div>

--- a/src/contextProvider/zeebe/TooltipProvider.js
+++ b/src/contextProvider/zeebe/TooltipProvider.js
@@ -226,6 +226,19 @@ const TooltipProvider = {
         </a>
       </div>
     );
+  },
+  'taskDefinitionRetries': (element) => {
+
+    const translate = useService('translate');
+
+    return (
+      <div>
+        <p>
+          { translate('The amount of times the engine tries to execute this activity if a worker signals a failure. The default is three.') } { ' ' }
+          <a href="https://docs.camunda.io/docs/next/components/best-practices/development/dealing-with-problems-and-exceptions/#leveraging-retries" target="_blank" rel="noopener">{ translate('Learn more.') }</a>
+        </p>
+      </div>
+    );
   }
 };
 

--- a/src/provider/zeebe/properties/TaskDefinitionProps.js
+++ b/src/provider/zeebe/properties/TaskDefinitionProps.js
@@ -217,8 +217,7 @@ function TaskDefinitionRetries(props) {
     feel: 'optional',
     getValue,
     setValue,
-    debounce,
-    tooltip: translate('Specifies the number of times the job is retried when a worker signals failure. The default is three.')
+    debounce
   });
 }
 


### PR DESCRIPTION
Improves the retries tooltip to more closely resemble reality (total number of times an activity is attempted to be executed, rather than 1 + retriesCount.

![capture 0sVNgu_optimized](https://github.com/bpmn-io/bpmn-js-properties-panel/assets/58601/50fdfb5d-cb8b-4bb1-9b6a-65f624b7ae9b)

Documentation ("Learn more") links to [this page](https://docs.camunda.io/docs/next/components/best-practices/development/dealing-with-problems-and-exceptions/#leveraging-retries).

----

Related to https://github.com/camunda/camunda-modeler/issues/4148