### PR TITLE
Refactor PanelHeaderProvider to accept a translate function

### DIFF
--- a/src/render/BpmnPropertiesPanel.js
+++ b/src/render/BpmnPropertiesPanel.js
@@ -228,7 +228,7 @@ export default function BpmnPropertiesPanel(props) {
   return <BpmnPropertiesPanelContext.Provider value={ bpmnPropertiesPanelContext }>
     <PropertiesPanel
       element={ selectedElement }
-      headerProvider={ PanelHeaderProvider }
+      headerProvider={ PanelHeaderProvider(translate) }
       placeholderProvider={ PanelPlaceholderProvider(translate) }
       groups={ groups }
       layoutConfig={ layoutConfig }

--- a/src/render/PanelHeaderProvider.js
+++ b/src/render/PanelHeaderProvider.js
@@ -66,58 +66,60 @@ export function getConcreteType(element) {
   return type;
 }
 
-export const PanelHeaderProvider = {
+export const PanelHeaderProvider = (translate) => {
+  if (!translate) translate = (text) => text;
+  return {
+    getDocumentationRef: (element) => {
+      const elementTemplates = getTemplatesService();
 
-  getDocumentationRef: (element) => {
-    const elementTemplates = getTemplatesService();
-
-    if (elementTemplates) {
-      return getTemplateDocumentation(element, elementTemplates);
-    }
-  },
-
-  getElementLabel: (element) => {
-    if (is(element, 'bpmn:Process')) {
-      return getBusinessObject(element).name;
-    }
-
-    return getLabel(element);
-  },
-
-  getElementIcon: (element) => {
-    const concreteType = getConcreteType(element);
-
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const config = useService('config.elementTemplateIconRenderer', false);
-
-    const { iconProperty = 'zeebe:modelerTemplateIcon' } = config || {};
-
-    const templateIcon = getBusinessObject(element).get(iconProperty);
-
-    if (templateIcon) {
-      return () => <img class="bio-properties-panel-header-template-icon" width="32" height="32" src={ templateIcon } />;
-    }
-
-    return iconsByType[ concreteType ];
-  },
-
-  getTypeLabel: (element) => {
-    const elementTemplates = getTemplatesService();
-
-    if (elementTemplates) {
-      const template = getTemplate(element, elementTemplates);
-
-      if (template && template.name) {
-        return template.name;
+      if (elementTemplates) {
+        return getTemplateDocumentation(element, elementTemplates);
       }
+    },
+
+    getElementLabel: (element) => {
+      if (is(element, 'bpmn:Process')) {
+        return getBusinessObject(element).name;
+      }
+
+      return getLabel(element);
+    },
+
+    getElementIcon: (element) => {
+      const concreteType = getConcreteType(element);
+
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      const config = useService('config.elementTemplateIconRenderer', false);
+
+      const { iconProperty = 'zeebe:modelerTemplateIcon' } = config || {};
+
+      const templateIcon = getBusinessObject(element).get(iconProperty);
+
+      if (templateIcon) {
+        return () => <img class="bio-properties-panel-header-template-icon" width="32" height="32" src={ templateIcon } />;
+      }
+
+      return iconsByType[concreteType];
+    },
+
+    getTypeLabel: (element) => {
+      const elementTemplates = getTemplatesService();
+
+      if (elementTemplates) {
+        const template = getTemplate(element, elementTemplates);
+
+        if (template && template.name) {
+          return translate(template.name);
+        }
+      }
+
+      const concreteType = getConcreteType(element);
+
+      return translate(concreteType
+        .replace(/(\B[A-Z])/g, ' $1')
+        .replace(/(\bNon Interrupting)/g, '($1)'));
     }
-
-    const concreteType = getConcreteType(element);
-
-    return concreteType
-      .replace(/(\B[A-Z])/g, ' $1')
-      .replace(/(\bNon Interrupting)/g, '($1)');
-  }
+  };
 };
 
 

--- a/test/spec/PanelHeaderProvider.spec.js
+++ b/test/spec/PanelHeaderProvider.spec.js
@@ -128,7 +128,8 @@ describe('<PanelHeaderProvider>', function() {
       });
 
       // when
-      const elementLabel = PanelHeaderProvider.getElementLabel(element);
+      const { getElementLabel } = PanelHeaderProvider(translateMock);
+      const elementLabel = getElementLabel(element);
 
       // then
       expect(elementLabel).to.equal('foo');
@@ -143,7 +144,8 @@ describe('<PanelHeaderProvider>', function() {
       });
 
       // when
-      const elementLabel = PanelHeaderProvider.getElementLabel(element);
+      const { getElementLabel } = PanelHeaderProvider(translateMock);
+      const elementLabel = getElementLabel(element);
 
       // then
       expect(elementLabel).to.equal('foo');
@@ -162,7 +164,8 @@ describe('<PanelHeaderProvider>', function() {
       });
 
       // when
-      const elementLabel = PanelHeaderProvider.getElementLabel(element);
+      const { getElementLabel } = PanelHeaderProvider(translateMock);
+      const elementLabel = getElementLabel(element);
 
       // then
       expect(elementLabel).to.equal('foo');
@@ -177,7 +180,8 @@ describe('<PanelHeaderProvider>', function() {
       });
 
       // when
-      const elementLabel = PanelHeaderProvider.getElementLabel(element);
+      const { getElementLabel } = PanelHeaderProvider(translateMock);
+      const elementLabel = getElementLabel(element);
 
       // then
       expect(elementLabel).to.equal('foo');
@@ -905,7 +909,7 @@ class ElementTemplates {
 function createHeader(options = {}) {
   const {
     element = noopElement,
-    headerProvider = PanelHeaderProvider,
+    headerProvider = PanelHeaderProvider(translateMock),
     context = { getService: noop },
     container
   } = options;
@@ -931,4 +935,9 @@ function createElement(type, attrs) {
   };
 
   return element;
+}
+
+// Mock translate function for testing
+function translateMock(text) {
+  return text;
 }


### PR DESCRIPTION
[Closes #813](https://github.com/bpmn-io/bpmn-js-properties-panel/issues/813)

PanelHeaderProvider has been refactored into a higher-order function that requires a translate function as its input. This change enables dynamic translation support within the provider, allowing for localization of type labels in the panel header. The function now returns the configured PanelHeaderProvider object, ready for use with the supplied translate function.

test/spec/PanelHeaderProvider.spec.js was changed to accommodate the new refactoring.