### PR TITLE
Remove unsupported flag "shouldSort"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: drop alphabetic sorting of list entries  ([#1047](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1047))
+
+
 ## 5.16.0
 
 * `FEAT`: add hint for the process ID field in the Camunda 7 ([#1038](https://github.com/bpmn-io/bpmn-js-properties-panel/issues/1038))

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@babel/plugin-transform-react-jsx": "^7.23.4",
         "@bpmn-io/element-template-chooser": "^1.0.0",
         "@bpmn-io/element-templates-icons-renderer": "^0.3.0",
-        "@bpmn-io/properties-panel": "^3.18.2",
+        "@bpmn-io/properties-panel": "^3.19.0",
         "@bpmn-io/variable-resolver": "^1.2.2",
         "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-babel": "^6.0.4",
@@ -622,9 +622,9 @@
       }
     },
     "node_modules/@bpmn-io/properties-panel": {
-      "version": "3.18.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.18.2.tgz",
-      "integrity": "sha512-IQ6NUZ4McSmr6KLyptnhnKxBind5Oz+FSZ5u8MJX/s/10RRj+RIVYCBS2UnfCKHZCE9YMWTdCHdA7XQ4lIjuzw==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.19.0.tgz",
+      "integrity": "sha512-ZVr8LC8ZiMYRkh9Vf4EnuQ7hJIzjBLpLUoex+q5/tGj1I2B/iFAgDUaqnD/yOyBzkRDi1K9IedsUA01XaqG13w==",
       "dev": true,
       "dependencies": {
         "@bpmn-io/feel-editor": "^1.3.0",
@@ -10269,9 +10269,9 @@
       }
     },
     "@bpmn-io/properties-panel": {
-      "version": "3.18.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.18.2.tgz",
-      "integrity": "sha512-IQ6NUZ4McSmr6KLyptnhnKxBind5Oz+FSZ5u8MJX/s/10RRj+RIVYCBS2UnfCKHZCE9YMWTdCHdA7XQ4lIjuzw==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.19.0.tgz",
+      "integrity": "sha512-ZVr8LC8ZiMYRkh9Vf4EnuQ7hJIzjBLpLUoex+q5/tGj1I2B/iFAgDUaqnD/yOyBzkRDi1K9IedsUA01XaqG13w==",
       "dev": true,
       "requires": {
         "@bpmn-io/feel-editor": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@babel/plugin-transform-react-jsx": "^7.23.4",
     "@bpmn-io/element-template-chooser": "^1.0.0",
     "@bpmn-io/element-templates-icons-renderer": "^0.3.0",
-    "@bpmn-io/properties-panel": "^3.18.2",
+    "@bpmn-io/properties-panel": "^3.19.0",
     "@bpmn-io/variable-resolver": "^1.2.2",
     "@rollup/plugin-alias": "^5.1.0",
     "@rollup/plugin-babel": "^6.0.4",

--- a/src/provider/camunda-platform/properties/ErrorsProps.js
+++ b/src/provider/camunda-platform/properties/ErrorsProps.js
@@ -48,8 +48,7 @@ export function ErrorsProps({ element, injector }) {
 
   return {
     items,
-    add: addFactory({ bpmnFactory, commandStack, element }),
-    shouldSort: false
+    add: addFactory({ bpmnFactory, commandStack, element })
   };
 }
 

--- a/src/provider/camunda-platform/properties/FormDataProps.js
+++ b/src/provider/camunda-platform/properties/FormDataProps.js
@@ -45,8 +45,7 @@ export function FormDataProps({ element, injector }) {
 
   return {
     items,
-    add: addFactory({ bpmnFactory, commandStack, element }),
-    shouldSort: false
+    add: addFactory({ bpmnFactory, commandStack, element })
   };
 }
 

--- a/src/provider/camunda-platform/properties/FormField.js
+++ b/src/provider/camunda-platform/properties/FormField.js
@@ -590,7 +590,7 @@ function PropertiesList(props) {
 
   return <ListEntry
     element={ element }
-    autoFocusEntry={ true }
+    autoFocusEntry={ `[data-entry-id="${id}-property-${propertyEntries.length - 1}"] input` }
     id={ id }
     label={ translate('Properties') }
     items={ propertyEntries }

--- a/src/provider/camunda-platform/properties/FormField.js
+++ b/src/provider/camunda-platform/properties/FormField.js
@@ -592,21 +592,10 @@ function PropertiesList(props) {
     element={ element }
     autoFocusEntry={ true }
     id={ id }
-    compareFn={ createAlphanumericCompare('id') }
     label={ translate('Properties') }
     items={ propertyEntries }
     component={ Property }
     onAdd={ addProperty }
     onRemove={ removeProperty }
   />;
-}
-
-// helper //////////////////
-
-function createAlphanumericCompare(field) {
-  return function(entry, anotherEntry) {
-    const [ key = '', anotherKey = '' ] = [ entry[field], anotherEntry[field] ];
-
-    return key === anotherKey ? 0 : key > anotherKey ? 1 : -1;
-  };
 }

--- a/src/provider/camunda-platform/properties/InputProps.js
+++ b/src/provider/camunda-platform/properties/InputProps.js
@@ -53,7 +53,6 @@ export function InputProps(props) {
   return {
     items,
     add,
-    shouldSort: false
   };
 }
 

--- a/src/provider/camunda-platform/properties/ListProps.js
+++ b/src/provider/camunda-platform/properties/ListProps.js
@@ -70,16 +70,9 @@ export function ListProps(props) {
     });
   }
 
-  function compareFn(item, anotherItem) {
-    const [ value = '', anotherValue = '' ] = [ item.value, anotherItem.value ];
-
-    return value === anotherValue ? 0 : value > anotherValue ? 1 : -1;
-  }
-
   return ListEntry({
     element,
     autoFocusEntry: true,
-    compareFn,
     id: idPrefix + '-list',
     items,
     label: translate('List values'),

--- a/src/provider/camunda-platform/properties/ListenerProps.js
+++ b/src/provider/camunda-platform/properties/ListenerProps.js
@@ -473,7 +473,7 @@ function Fields(props) {
     onAdd={ addField }
     onRemove={ removeField }
     compareFn={ compareName }
-    autoFocusEntry
+    autoFocusEntry={ `[data-entry-id="${id}-field-${fields.length - 1}"] input` }
   />;
 }
 

--- a/src/provider/camunda-platform/properties/ListenerProps.js
+++ b/src/provider/camunda-platform/properties/ListenerProps.js
@@ -131,6 +131,7 @@ export function ExecutionListenerProps({ element, injector }) {
           element,
           listener
         }),
+        autoFocusEntry: id + '-javaClass',
         remove: removeListenerFactory({ element, listener, commandStack })
       };
     }),

--- a/src/provider/camunda-platform/properties/ListenerProps.js
+++ b/src/provider/camunda-platform/properties/ListenerProps.js
@@ -472,7 +472,6 @@ function Fields(props) {
     component={ Field }
     onAdd={ addField }
     onRemove={ removeField }
-    compareFn={ compareName }
     autoFocusEntry={ `[data-entry-id="${id}-field-${fields.length - 1}"] input` }
   />;
 }
@@ -557,12 +556,6 @@ function getDefaultEventTypeProperties(type, bpmnFactory) {
 
 function getPrefixedId(prefix, id) {
   return `${prefix}-${id}`;
-}
-
-function compareName(field, anotherField) {
-  const [ name = '', anotherName = '' ] = [ field.name, anotherField.name ];
-
-  return name === anotherName ? 0 : name > anotherName ? 1 : -1;
 }
 
 function getListenersContainer(element) {

--- a/src/provider/camunda-platform/properties/ListenerProps.js
+++ b/src/provider/camunda-platform/properties/ListenerProps.js
@@ -190,7 +190,7 @@ export function TaskListenerProps({ element, injector }) {
           element,
           listener
         }),
-
+        autoFocusEntry: id + '-listenerId',
         remove: removeListenerFactory({ element, listener, commandStack })
       };
     }),

--- a/src/provider/camunda-platform/properties/MapProps.js
+++ b/src/provider/camunda-platform/properties/MapProps.js
@@ -78,16 +78,9 @@ export function MapProps(props) {
     });
   }
 
-  function compareFn(entry, anotherEntry) {
-    const [ key = '', anotherKey = '' ] = [ entry.key, anotherEntry.key ];
-
-    return key === anotherKey ? 0 : key > anotherKey ? 1 : -1;
-  }
-
   return ListEntry({
     element,
     autoFocusEntry: true,
-    compareFn,
     id: idPrefix + '-map',
     items: entries,
     label: translate('Map entries'),

--- a/src/provider/camunda-platform/properties/MapProps.js
+++ b/src/provider/camunda-platform/properties/MapProps.js
@@ -53,6 +53,7 @@ export function MapProps(props) {
   const commandStack = useService('commandStack');
   const translate = useService('translate');
 
+  const id = idPrefix + '-map';
   const map = parameter.get('definition');
   const entries = map.get('entries');
 
@@ -80,7 +81,7 @@ export function MapProps(props) {
 
   return ListEntry({
     element,
-    autoFocusEntry: true,
+    autoFocusEntry: `[data-entry-id="${id}-mapEntry-${entries.length - 1}"] input`,
     id: idPrefix + '-map',
     items: entries,
     label: translate('Map entries'),

--- a/src/provider/camunda-platform/properties/OutputProps.js
+++ b/src/provider/camunda-platform/properties/OutputProps.js
@@ -40,7 +40,6 @@ export function OutputProps({ element, injector }) {
   return {
     items,
     add: addFactory({ bpmnFactory, commandStack, element }),
-    shouldSort: false
   };
 }
 

--- a/src/provider/camunda-platform/properties/ProcessVariablesProps.js
+++ b/src/provider/camunda-platform/properties/ProcessVariablesProps.js
@@ -88,7 +88,7 @@ function ProcessVariablesEntry(props) {
     };
   });
 
-  return <ListGroup { ...props } items={ items } shouldSort={ false } />;
+  return <ListGroup { ...props } items={ items } />;
 }
 
 export function ProcessVariablesProps(props) {
@@ -103,7 +103,6 @@ export function ProcessVariablesProps(props) {
 
   return {
     component: ProcessVariablesEntry,
-    shouldSort: false
   };
 }
 

--- a/src/provider/shared/ExtensionPropertiesProps.js
+++ b/src/provider/shared/ExtensionPropertiesProps.js
@@ -48,7 +48,6 @@ export function ExtensionPropertiesProps({ element, injector, namespace = 'camun
   return {
     items,
     add: addFactory({ bpmnFactory, commandStack, element, namespace }),
-    shouldSort: false
   };
 }
 

--- a/src/provider/zeebe/properties/BusinessRuleImplementationProps.js
+++ b/src/provider/zeebe/properties/BusinessRuleImplementationProps.js
@@ -136,7 +136,7 @@ function getCalledDecision(element) {
 }
 
 function isBusinessRuleImplementationEdited(element) {
-  return getTaskDefinition(element);
+  return getTaskDefinition(element) || getCalledDecision(element);
 }
 
 function resetElement(element, commandStack) {

--- a/src/provider/zeebe/properties/HeaderProps.js
+++ b/src/provider/zeebe/properties/HeaderProps.js
@@ -47,7 +47,6 @@ export function HeaderProps({ element, injector }) {
   return {
     items,
     add: addFactory({ bpmnFactory, commandStack, element }),
-    shouldSort: false
   };
 }
 

--- a/src/provider/zeebe/properties/InputProps.js
+++ b/src/provider/zeebe/properties/InputProps.js
@@ -49,7 +49,6 @@ export function InputProps({ element, injector }) {
   return {
     items,
     add: addFactory({ element, bpmnFactory, commandStack }),
-    shouldSort: false
   };
 }
 

--- a/src/provider/zeebe/properties/OutputProps.js
+++ b/src/provider/zeebe/properties/OutputProps.js
@@ -49,7 +49,6 @@ export function OutputProps({ element, injector }) {
   return {
     items,
     add: addFactory({ element, bpmnFactory, commandStack }),
-    shouldSort: false
   };
 }
 

--- a/test/spec/provider/camunda-platform/FormField.spec.js
+++ b/test/spec/provider/camunda-platform/FormField.spec.js
@@ -866,7 +866,7 @@ describe('provider/camunda-platform - FormField', function() {
         // then
         const properties = getFormFieldProperties(task, 0);
         const propertyEntries = domQueryAll('div[data-entry-id=UserTask_1-formField-0-formFieldProperties] li', container);
-        const label = domQuery('.bio-properties-panel-collapsible-entry-header-title', propertyEntries[1]);
+        const label = domQuery('.bio-properties-panel-collapsible-entry-header-title', propertyEntries[0]);
 
         expect(properties.get('values')[0].id).to.equal(label.innerHTML);
       }));
@@ -883,7 +883,7 @@ describe('provider/camunda-platform - FormField', function() {
 
         // then
         const propertyEntries = domQueryAll('div[data-entry-id=UserTask_1-formField-0-formFieldProperties] li', container);
-        const label = domQuery('.bio-properties-panel-collapsible-entry-header-title', propertyEntries[0]);
+        const label = domQuery('.bio-properties-panel-collapsible-entry-header-title', propertyEntries[1]);
 
         expect(label.innerHTML).to.equal('&lt;empty&gt;');
       }));
@@ -911,9 +911,9 @@ describe('provider/camunda-platform - FormField', function() {
           container)).map(e => e.innerHTML);
 
         expect(propertiesEntries).to.eql([
+          'Property3',
           'Property1',
-          'Property2',
-          'Property3' ]);
+          'Property2' ]);
       }));
 
     });

--- a/test/spec/provider/camunda-platform/FormFieldProperty.spec.js
+++ b/test/spec/provider/camunda-platform/FormFieldProperty.spec.js
@@ -72,7 +72,7 @@ describe('provider/camunda-platform - FormFieldProperty', function() {
         selection.select(task);
       });
 
-      const idInput = domQuery('#bio-properties-panel-UserTask_1-formField-0-formFieldProperties-property-1-id', container);
+      const idInput = domQuery('#bio-properties-panel-UserTask_1-formField-0-formFieldProperties-property-0-id', container);
       const properties = getFormFieldProperties(task, 0);
 
       // then
@@ -90,7 +90,7 @@ describe('provider/camunda-platform - FormFieldProperty', function() {
         selection.select(task);
       });
 
-      const idInput = domQuery('#bio-properties-panel-UserTask_1-formField-0-formFieldProperties-property-1-id', container);
+      const idInput = domQuery('#bio-properties-panel-UserTask_1-formField-0-formFieldProperties-property-0-id', container);
       const properties = getFormFieldProperties(task, 0);
 
       // when
@@ -113,7 +113,7 @@ describe('provider/camunda-platform - FormFieldProperty', function() {
           selection.select(task);
         });
 
-        const idInput = domQuery('#bio-properties-panel-UserTask_1-formField-0-formFieldProperties-property-1-id', container);
+        const idInput = domQuery('#bio-properties-panel-UserTask_1-formField-0-formFieldProperties-property-0-id', container);
 
         changeInput(idInput, 'newVal');
 
@@ -140,7 +140,7 @@ describe('provider/camunda-platform - FormFieldProperty', function() {
         selection.select(task);
       });
 
-      const valueInput = domQuery('#bio-properties-panel-UserTask_1-formField-0-formFieldProperties-property-1-value', container);
+      const valueInput = domQuery('#bio-properties-panel-UserTask_1-formField-0-formFieldProperties-property-0-value', container);
       const properties = getFormFieldProperties(task, 0);
 
       // then
@@ -158,7 +158,7 @@ describe('provider/camunda-platform - FormFieldProperty', function() {
         selection.select(task);
       });
 
-      const valueInput = domQuery('#bio-properties-panel-UserTask_1-formField-0-formFieldProperties-property-1-value', container);
+      const valueInput = domQuery('#bio-properties-panel-UserTask_1-formField-0-formFieldProperties-property-0-value', container);
       const properties = getFormFieldProperties(task, 0);
 
       // when
@@ -181,7 +181,7 @@ describe('provider/camunda-platform - FormFieldProperty', function() {
           selection.select(task);
         });
 
-        const valueInput = domQuery('#bio-properties-panel-UserTask_1-formField-0-formFieldProperties-property-1-value', container);
+        const valueInput = domQuery('#bio-properties-panel-UserTask_1-formField-0-formFieldProperties-property-0-value', container);
 
         changeInput(valueInput, 'newVal');
 

--- a/test/spec/provider/zeebe/BusinessRuleImplementationProps.spec.js
+++ b/test/spec/provider/zeebe/BusinessRuleImplementationProps.spec.js
@@ -34,8 +34,11 @@ import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
 
 import diagramXML from './BusinessRuleImplementationProps.bpmn';
 
+const GROUP_SELECTOR = '[data-group-id="group-businessRuleImplementation"]';
+const IMPLEMENTATION_SELECTOR = 'select[name=businessRuleImplementation]';
 
-describe('provider/zeebe - TargetProps', function() {
+
+describe('provider/zeebe - BusinessRuleImplementationProps', function() {
 
   const testModules = [
     BpmnPropertiesPanel,
@@ -110,6 +113,9 @@ describe('provider/zeebe - TargetProps', function() {
       // then
       const implementation = getImplementationSelect(container);
       expect(implementation.value).to.equal('');
+
+      // and also
+      return expectEdited(container, false);
     }));
 
 
@@ -126,6 +132,9 @@ describe('provider/zeebe - TargetProps', function() {
       // then
       const implementation = getImplementationSelect(container);
       expect(implementation.value).to.equal('dmn');
+
+      // and also
+      return expectEdited(container, true);
     }));
 
 
@@ -142,6 +151,9 @@ describe('provider/zeebe - TargetProps', function() {
       // then
       const implementation = getImplementationSelect(container);
       expect(implementation.value).to.equal('jobWorker');
+
+      // and also
+      return expectEdited(container, true);
     }));
 
 
@@ -334,7 +346,7 @@ describe('provider/zeebe - TargetProps', function() {
 // helper /////////////////
 
 function getImplementationSelect(container) {
-  return domQuery('select[name=businessRuleImplementation]', container);
+  return domQuery(IMPLEMENTATION_SELECTOR, container);
 }
 
 function getTaskDefinition(element) {
@@ -353,4 +365,21 @@ function getTaskHeaders(element) {
   const businessObject = getBusinessObject(element);
 
   return getExtensionElementsList(businessObject, 'zeebe:TaskHeaders')[ 0 ];
+}
+
+async function expectEdited(container, exists) {
+
+  await wait(50);
+
+  const indicator = domQuery(`${GROUP_SELECTOR} .bio-properties-panel-dot`, container);
+
+  if (exists) {
+    expect(indicator).to.exist;
+  } else {
+    expect(indicator).not.to.exist;
+  }
+}
+
+function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/test/spec/provider/zeebe/ScriptImplementationProps.spec.js
+++ b/test/spec/provider/zeebe/ScriptImplementationProps.spec.js
@@ -324,20 +324,6 @@ describe('provider/zeebe - ScriptImplementationProps', function() {
 
 // helper /////////////////
 
-async function expectEdited(container, exists) {
-  await new Promise(resolve => {
-    setTimeout(resolve, 0);
-  });
-
-  const indicator = domQuery(`${GROUP_SELECTOR} .bio-properties-panel-dot`, container);
-
-  if (exists) {
-    expect(indicator).to.exist;
-  } else {
-    expect(indicator).not.to.exist;
-  }
-}
-
 function getImplementationSelect(container) {
   return domQuery(IMPLEMENTATION_SELECTOR, container);
 }
@@ -358,4 +344,21 @@ function getTaskHeaders(element) {
   const businessObject = getBusinessObject(element);
 
   return getExtensionElementsList(businessObject, 'zeebe:TaskHeaders')[ 0 ];
+}
+
+async function expectEdited(container, exists) {
+
+  await wait(50);
+
+  const indicator = domQuery(`${GROUP_SELECTOR} .bio-properties-panel-dot`, container);
+
+  if (exists) {
+    expect(indicator).to.exist;
+  } else {
+    expect(indicator).not.to.exist;
+  }
+}
+
+function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/test/spec/provider/zeebe/UserTaskImplementationProps.spec.js
+++ b/test/spec/provider/zeebe/UserTaskImplementationProps.spec.js
@@ -34,6 +34,9 @@ import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
 
 import diagramXML from './UserTaskImplementationProps.bpmn';
 
+const GROUP_SELECTOR = '[data-group-id="group-userTaskImplementation"]';
+const IMPLEMENTATION_SELECTOR = 'select[name=userTaskImplementation]';
+
 
 describe('provider/zeebe - UserTaskImplementationProps', function() {
 
@@ -110,6 +113,9 @@ describe('provider/zeebe - UserTaskImplementationProps', function() {
       // then
       const implementation = getImplementationSelect(container);
       expect(implementation.value).to.equal('zeebeUserTask');
+
+      // and also
+      return expectEdited(container, true);
     }));
 
 
@@ -126,6 +132,9 @@ describe('provider/zeebe - UserTaskImplementationProps', function() {
       // then
       const implementation = getImplementationSelect(container);
       expect(implementation.value).to.equal('jobWorker');
+
+      // and also
+      return expectEdited(container, false);
     }));
 
 
@@ -223,11 +232,29 @@ describe('provider/zeebe - UserTaskImplementationProps', function() {
 // helper /////////////////
 
 function getImplementationSelect(container) {
-  return domQuery('select[name=userTaskImplementation]', container);
+  return domQuery(IMPLEMENTATION_SELECTOR, container);
 }
 
 function getZeebeUserTask(element) {
   const businessObject = getBusinessObject(element);
 
   return getExtensionElementsList(businessObject, 'zeebe:UserTask')[0];
+}
+
+
+async function expectEdited(container, exists) {
+
+  await wait(50);
+
+  const indicator = domQuery(`${GROUP_SELECTOR} .bio-properties-panel-dot`, container);
+
+  if (exists) {
+    expect(indicator).to.exist;
+  } else {
+    expect(indicator).not.to.exist;
+  }
+}
+
+function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
This pull request aims to fix [#311 in properties-panel](https://github.com/bpmn-io/properties-panel/issues/311) together [#353 in properties-panel](https://github.com/bpmn-io/properties-panel/pull/353). Currently, it is being developed.

- [x] Remove "shouldSort" property where ever the flag was set to `false` explicitly
- [x] Implement sorting where necessary
       => Potentially every component which did not explicitly set `shouldSort` to `false`, but we should use  this opportunity to evaluate where it actually should be sorted.
- [x] Write a note in CHANGELOG.md

Regarding the `shouldSort` flag, I saw the following throughout this project.

**Camunda 7 - Camunda Platform**
Usages without the `shouldSort` flags, thus using the previous default of sorting:
- FieldInjectionGroup
- InMappingGroup
- OutMappingGroup
- ExecutionListenerGroup
- TaskListenerGroup
- ConnectorInputGroup
- ConnectorOutputGroup
- ExtensionPropertiesGroup

Usages with the `shouldSort` flag set to `false`, thus already disabling sorting:
- ErrorsGroup
- FormDataGroup
- InputGroup
- OutputGroup
- ProcessVariablesGroup
- ExtensionPropertiesGroup

**Camunda 8 - Zeebee**
Usages with the `shouldSort` flag set to `false`, thus already disabling sorting:
- ExtensionPropertiesGroup
- HeaderGroup
- InputGroup
- OutputGroup

----

Related to https://github.com/bpmn-io/properties-panel/issues/311