### PR TITLE
feat: add execution listeners for Zeebe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "bpmn-js": "^17.3.0",
         "bpmn-js-create-append-anything": "^0.5.1",
         "bpmn-moddle": "^9.0.1",
-        "camunda-bpmn-js-behaviors": "^1.3.0",
+        "camunda-bpmn-js-behaviors": "^1.4.0",
         "camunda-bpmn-moddle": "^7.0.1",
         "chai": "^4.4.1",
         "cross-env": "^7.0.3",
@@ -65,7 +65,7 @@
         "sinon": "^17.0.1",
         "sinon-chai": "^3.7.0",
         "webpack": "^5.92.1",
-        "zeebe-bpmn-moddle": "^1.1.0"
+        "zeebe-bpmn-moddle": "^1.2.0"
       },
       "engines": {
         "node": "*"
@@ -2909,10 +2909,11 @@
       }
     },
     "node_modules/camunda-bpmn-js-behaviors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.3.0.tgz",
-      "integrity": "sha512-Nz+Fa5B6SVUq6d+Mb0UOP0GZI6a+NrMwUXKeyA5LSXjVEKxwso500PGwbzW7HGgFfqT40Fv8i/ukvI0adTBPyA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.4.0.tgz",
+      "integrity": "sha512-z7TN1I5zCj5p521xobxqe3p+/7EsmUV3ao8ZsDdk5lr1y3b/FeykvzsxH/d+8werZNwm1SXGCZbzGb7rEtnpsg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ids": "^1.0.0",
         "min-dash": "^4.0.0"
@@ -9946,10 +9947,11 @@
       }
     },
     "node_modules/zeebe-bpmn-moddle": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.1.0.tgz",
-      "integrity": "sha512-ES/UZFO0VmKvAzL4+cD3VcQpKvlmgLtnFKTyiv0DdDcxNrdQg1rI0OmUdrKMiybAbtAgPDkVXZCusE3kkXwEyQ==",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.2.0.tgz",
+      "integrity": "sha512-KtY9CYs2qYKQMV7xdLY7Oj7Mgb0fA13DD8T0bYwv3JOkdqfW4IIqm+aMD+vvZ4j+2iaCGaqEA6XKHS5sZKG3Fg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.23.8",
@@ -12083,9 +12085,9 @@
       "dev": true
     },
     "camunda-bpmn-js-behaviors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.3.0.tgz",
-      "integrity": "sha512-Nz+Fa5B6SVUq6d+Mb0UOP0GZI6a+NrMwUXKeyA5LSXjVEKxwso500PGwbzW7HGgFfqT40Fv8i/ukvI0adTBPyA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.4.0.tgz",
+      "integrity": "sha512-z7TN1I5zCj5p521xobxqe3p+/7EsmUV3ao8ZsDdk5lr1y3b/FeykvzsxH/d+8werZNwm1SXGCZbzGb7rEtnpsg==",
       "dev": true,
       "requires": {
         "ids": "^1.0.0",
@@ -17347,9 +17349,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.1.0.tgz",
-      "integrity": "sha512-ES/UZFO0VmKvAzL4+cD3VcQpKvlmgLtnFKTyiv0DdDcxNrdQg1rI0OmUdrKMiybAbtAgPDkVXZCusE3kkXwEyQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.2.0.tgz",
+      "integrity": "sha512-KtY9CYs2qYKQMV7xdLY7Oj7Mgb0fA13DD8T0bYwv3JOkdqfW4IIqm+aMD+vvZ4j+2iaCGaqEA6XKHS5sZKG3Fg==",
       "dev": true
     },
     "zod": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "bpmn-js": "^17.3.0",
     "bpmn-js-create-append-anything": "^0.5.1",
     "bpmn-moddle": "^9.0.1",
-    "camunda-bpmn-js-behaviors": "^1.3.0",
+    "camunda-bpmn-js-behaviors": "^1.4.0",
     "camunda-bpmn-moddle": "^7.0.1",
     "chai": "^4.4.1",
     "cross-env": "^7.0.3",
@@ -106,7 +106,7 @@
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
     "webpack": "^5.92.1",
-    "zeebe-bpmn-moddle": "^1.1.0"
+    "zeebe-bpmn-moddle": "^1.2.0"
   },
   "peerDependencies": {
     "@bpmn-io/properties-panel": ">= 3.7",

--- a/src/provider/zeebe/ZeebePropertiesProvider.js
+++ b/src/provider/zeebe/ZeebePropertiesProvider.js
@@ -7,6 +7,7 @@ import {
   ConditionProps,
   ErrorProps,
   EscalationProps,
+  ExecutionListenersProps,
   FormProps,
   HeaderProps,
   InputPropagationProps,
@@ -51,6 +52,7 @@ const ZEEBE_GROUPS = [
   OutputPropagationGroup,
   OutputGroup,
   HeaderGroup,
+  ExecutionListenersGroup,
   ExtensionPropertiesGroup
 ];
 
@@ -297,6 +299,22 @@ function AssignmentDefinitionGroup(element, injector) {
   };
 
   return group.entries.length ? group : null;
+}
+
+function ExecutionListenersGroup(element, injector) {
+  const translate = injector.get('translate');
+  const group = {
+    label: translate('Execution listeners'),
+    id: 'Zeebe__ExecutionListeners',
+    component: ListGroup,
+    ...ExecutionListenersProps({ element, injector })
+  };
+
+  if (group.items) {
+    return group;
+  }
+
+  return null;
 }
 
 function ExtensionPropertiesGroup(element, injector) {

--- a/src/provider/zeebe/properties/ExecutionListener.js
+++ b/src/provider/zeebe/properties/ExecutionListener.js
@@ -1,0 +1,176 @@
+import { SelectEntry } from '@bpmn-io/properties-panel';
+
+import {
+  is,
+  isAny
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  useService
+} from '../../../hooks';
+
+import {
+  getErrorEventDefinition
+} from '../../../utils/EventDefinitionUtil';
+
+import { FeelEntryWithVariableContext } from '../../../entries/FeelEntryWithContext';
+
+
+export const EVENT_TO_LABEL = {
+  'start': 'Start',
+  'end': 'End'
+};
+
+export function ExecutionListenerEntries(props) {
+
+  const {
+    element,
+    idPrefix,
+    listener
+  } = props;
+
+  const eventTypes = getEventTypes(element);
+
+  const entries = eventTypes.length > 1 ? [
+    {
+      id: idPrefix + '-eventType',
+      component: EventType,
+      idPrefix,
+      listener,
+      eventTypes
+    }
+  ] : [];
+
+  entries.push({
+    id: idPrefix + '-listenerType',
+    component: ListenerType,
+    idPrefix,
+    listener
+  },
+  {
+    id: idPrefix + '-retries',
+    component: Retries,
+    idPrefix,
+    listener
+  });
+
+  return entries;
+}
+
+function EventType(props) {
+  const {
+    idPrefix,
+    element,
+    listener,
+    eventTypes
+  } = props;
+
+  const modeling = useService('modeling');
+  const translate = useService('translate');
+
+  const getOptions = () => {
+    return eventTypes.map(eventType => ({
+      value: eventType,
+      label: translate(EVENT_TO_LABEL[eventType])
+    }));
+  };
+
+  const setValue = (value) => {
+    modeling.updateModdleProperties(element, listener, {
+      eventType: value
+    });
+  };
+
+  const getValue = () => {
+    return listener.get('eventType');
+  };
+
+  return SelectEntry({
+    element,
+    id: idPrefix + '-eventType',
+    label: translate('Event type'),
+    getValue,
+    setValue,
+    getOptions
+  });
+}
+
+function ListenerType(props) {
+  const {
+    idPrefix,
+    element,
+    listener
+  } = props;
+
+  const modeling = useService('modeling');
+  const translate = useService('translate');
+  const debounce = useService('debounceInput');
+
+  const setValue = (value) => {
+    modeling.updateModdleProperties(element, listener, {
+      type: value
+    });
+  };
+
+  const getValue = () => {
+    return listener.get('type');
+  };
+
+  return FeelEntryWithVariableContext({
+    element,
+    id: idPrefix + '-listenerType',
+    label: translate('Listener type'),
+    getValue,
+    setValue,
+    debounce,
+    feel: 'optional'
+  });
+}
+
+function Retries(props) {
+  const {
+    idPrefix,
+    element,
+    listener
+  } = props;
+
+  const modeling = useService('modeling');
+  const translate = useService('translate');
+  const debounce = useService('debounceInput');
+
+  const setValue = (value) => {
+    modeling.updateModdleProperties(element, listener, {
+      retries: value
+    });
+  };
+
+  const getValue = () => {
+    return listener.get('retries');
+  };
+
+  return FeelEntryWithVariableContext({
+    element,
+    id: idPrefix + '-retries',
+    label: translate('Retries'),
+    getValue,
+    setValue,
+    debounce,
+    feel: 'optional'
+  });
+}
+
+export function getEventTypes(element) {
+  if (isAny(element, [ 'bpmn:BoundaryEvent', 'bpmn:StartEvent' ])) {
+    return [ 'end' ];
+  }
+
+  if (is(element, 'bpmn:EndEvent') && getErrorEventDefinition(element)) {
+    return [ 'start' ];
+  }
+
+  if (is(element, 'bpmn:Gateway')) {
+    return [ 'start' ];
+  }
+
+  return [ 'start', 'end' ];
+}

--- a/src/provider/zeebe/properties/ExecutionListenersProps.js
+++ b/src/provider/zeebe/properties/ExecutionListenersProps.js
@@ -1,0 +1,206 @@
+import {
+  getBusinessObject,
+  is,
+  isAny
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import { without } from 'min-dash';
+
+import { ExecutionListenerEntries, getEventTypes, EVENT_TO_LABEL } from './ExecutionListener';
+
+import {
+  createElement
+} from '../../../utils/ElementUtil';
+
+import {
+  getExtensionElementsList
+} from '../../../utils/ExtensionElementsUtil';
+
+import {
+  getCompensateEventDefinition
+} from '../../../utils/EventDefinitionUtil';
+
+
+export function ExecutionListenersProps({ element, injector }) {
+  let businessObject = getRelevantBusinessObject(element);
+
+  // not allowed in empty pools
+  if (!businessObject) {
+    return;
+  }
+
+  const moddle = injector.get('moddle');
+  if (!canHaveExecutionListeners(businessObject, moddle)) {
+    return;
+  }
+
+  const listeners = getListenersList(businessObject) || [];
+
+  const bpmnFactory = injector.get('bpmnFactory'),
+        commandStack = injector.get('commandStack'),
+        modeling = injector.get('modeling'),
+        translate = injector.get('translate');
+
+  const items = listeners.map((listener, index) => {
+    const id = element.id + '-executionListener-' + index;
+    const type = listener.get('type') || '<no type>';
+
+    return {
+      id,
+      label: translate(`${EVENT_TO_LABEL[listener.get('eventType')]}: {type}`, { type }),
+      entries: ExecutionListenerEntries({
+        idPrefix: id,
+        element,
+        listener
+      }),
+      autoFocusEntry: id + '-eventType',
+      remove: removeFactory({ modeling, element, listener })
+    };
+  });
+
+  return {
+    items,
+    add: addFactory({ bpmnFactory, commandStack, element })
+  };
+}
+
+function removeFactory({ modeling, element, listener }) {
+  return function(event) {
+    event.stopPropagation();
+
+    const businessObject = getRelevantBusinessObject(element);
+    const container = getExecutionListenersContainer(businessObject);
+
+    if (!container) {
+      return;
+    }
+
+    const listeners = without(container.get('listeners'), listener);
+
+    modeling.updateModdleProperties(element, container, { listeners });
+  };
+}
+
+function addFactory({ bpmnFactory, commandStack, element }) {
+  return function(event) {
+    event.stopPropagation();
+
+    let commands = [];
+
+    const businessObject = getRelevantBusinessObject(element);
+
+    let extensionElements = businessObject.get('extensionElements');
+
+    // (1) ensure extension elements
+    if (!extensionElements) {
+      extensionElements = createElement(
+        'bpmn:ExtensionElements',
+        { values: [] },
+        businessObject,
+        bpmnFactory
+      );
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: businessObject,
+          properties: { extensionElements }
+        }
+      });
+    }
+
+    // (2) ensure zeebe:ExecutionListeners
+    let executionListeners = getExecutionListenersContainer(businessObject);
+
+    if (!executionListeners) {
+      const parent = extensionElements;
+
+      executionListeners = createElement('zeebe:ExecutionListeners', {
+        listeners: []
+      }, parent, bpmnFactory);
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: extensionElements,
+          properties: {
+            values: [ ...extensionElements.get('values'), executionListeners ]
+          }
+        }
+      });
+    }
+
+    // (3) create zeebe:ExecutionListener
+    const executionListener = createElement(
+      'zeebe:ExecutionListener', getDefaultListenerProps(element), executionListeners, bpmnFactory
+    );
+
+    // (4) add executionListener to list
+    commands.push({
+      cmd: 'element.updateModdleProperties',
+      context: {
+        element,
+        moddleElement: executionListeners,
+        properties: {
+          listeners: [ ...executionListeners.get('listeners'), executionListener ]
+        }
+      }
+    });
+
+    // (5) commit all updates
+    commandStack.execute('properties-panel.multi-command-executor', commands);
+  };
+}
+
+
+// helper //////////////////
+
+function getRelevantBusinessObject(element) {
+  let businessObject = getBusinessObject(element);
+
+  if (is(element, 'bpmn:Participant')) {
+    return businessObject.get('processRef');
+  }
+
+  return businessObject;
+}
+
+function getExecutionListenersContainer(element) {
+  const executionListeners = getExtensionElementsList(element, 'zeebe:ExecutionListeners');
+
+  return executionListeners && executionListeners[0];
+}
+
+function getListenersList(element) {
+  const executionListeners = getExecutionListenersContainer(element);
+
+  return executionListeners && executionListeners.get('listeners');
+}
+
+function canHaveExecutionListeners(bo, moddle) {
+  const executionListenersDescriptor = moddle.getTypeDescriptor('zeebe:ExecutionListeners');
+
+  if (!isAny(bo, executionListenersDescriptor.meta.allowedIn)) {
+    return false;
+  }
+
+  if (isCompensationBoundaryEvent(bo)) {
+    return false;
+  }
+
+  return true;
+}
+
+function isCompensationBoundaryEvent(bo) {
+  return is(bo, 'bpmn:BoundaryEvent') && getCompensateEventDefinition(bo);
+}
+
+function getDefaultListenerProps(element) {
+  const eventTypes = getEventTypes(element);
+
+  return {
+    eventType: eventTypes[0]
+  };
+}

--- a/src/provider/zeebe/properties/index.js
+++ b/src/provider/zeebe/properties/index.js
@@ -4,6 +4,7 @@ export { CalledDecisionProps } from './CalledDecisionProps';
 export { ConditionProps } from './ConditionProps';
 export { ErrorProps } from './ErrorProps';
 export { EscalationProps } from './EscalationProps';
+export { ExecutionListenersProps } from './ExecutionListenersProps';
 export { FormProps } from './FormProps';
 export { HeaderProps } from './HeaderProps';
 export { InputPropagationProps } from './InputPropagationProps';

--- a/test/spec/provider/zeebe/ExecutionListenerProps.bpmn
+++ b/test/spec/provider/zeebe/ExecutionListenerProps.bpmn
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0qh9wc7" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process" name="Execution Listeners Test" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:executionListeners>
+        <zeebe:executionListener eventType="start" retries="3" type="sysout" />
+        <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+      </zeebe:executionListeners>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+          <zeebe:executionListener eventType="end" retries="3" type="another" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+    </bpmn:startEvent>
+    <bpmn:intermediateThrowEvent id="IntermediateThrowEvent">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="3" type="sysout" />
+          <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="EndEvent">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="3" type="sysout" />
+          <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="TimerEndEvent">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+          <zeebe:executionListener eventType="end" retries="3" type="another" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_2" />
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="3" type="sysout" />
+          <zeebe:executionListener eventType="start" retries="3" type="another" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+    </bpmn:exclusiveGateway>
+    <bpmn:task id="Task">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="3" type="sysout" />
+          <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+    </bpmn:task>
+    <bpmn:subProcess id="SubProcess">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="3" type="sysout" />
+          <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:startEvent id="SingleListener">
+        <bpmn:extensionElements>
+          <zeebe:executionListeners>
+            <zeebe:executionListener eventType="end" retries="3" type="another" />
+          </zeebe:executionListeners>
+          <zeebe:properties>
+            <zeebe:property name="key" value="value" />
+          </zeebe:properties>
+        </bpmn:extensionElements>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent" attachedToRef="SubProcess">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="end" retries="3" type="another" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0jqwplw" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="CompensationBoundaryEvent" attachedToRef="SubProcess">
+      <bpmn:compensateEventDefinition id="Compensate" />
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="Empty" />
+    <bpmn:endEvent id="OtherExtensions">
+      <bpmn:extensionElements />
+    </bpmn:endEvent>
+    <bpmn:complexGateway id="ComplexGateway" />
+    <bpmn:endEvent id="ErrorEndEvent">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="3" type="sysout" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:errorEventDefinition />
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
+      <bpmndi:BPMNShape id="StartEvent_di" bpmnElement="StartEvent">
+        <dc:Bounds x="192" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateThrowEvent_di" bpmnElement="IntermediateThrowEvent">
+        <dc:Bounds x="192" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_di" bpmnElement="EndEvent">
+        <dc:Bounds x="192" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TimerEndEvent_di" bpmnElement="TimerEndEvent">
+        <dc:Bounds x="292" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_di" bpmnElement="Gateway" isMarkerVisible="true">
+        <dc:Bounds x="185" y="315" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_di" bpmnElement="Task">
+        <dc:Bounds x="160" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_di" bpmnElement="SubProcess" isExpanded="true">
+        <dc:Bounds x="160" y="510" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SingleListener_di" bpmnElement="SingleListener">
+        <dc:Bounds x="200" y="592" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_di" bpmnElement="BoundaryEvent">
+        <dc:Bounds x="492" y="692" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CompensationBoundaryEvent_di" bpmnElement="CompensationBoundaryEvent">
+        <dc:Bounds x="432" y="692" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Empty_di" bpmnElement="Empty">
+        <dc:Bounds x="632" y="692" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="OtherExtensions_di" bpmnElement="OtherExtensions">
+        <dc:Bounds x="632" y="592" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ComplexGateway_di" bpmnElement="ComplexGateway">
+        <dc:Bounds x="692" y="592" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ErrorEndEvent_di" bpmnElement="ErrorEndEvent">
+        <dc:Bounds x="792" y="592" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/zeebe/ExecutionListenerProps.spec.js
+++ b/test/spec/provider/zeebe/ExecutionListenerProps.spec.js
@@ -1,0 +1,519 @@
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  act
+} from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  changeInput,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery,
+  queryAll as domQueryAll
+} from 'min-dom';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/render';
+
+import ZeebePropertiesProvider from 'src/provider/zeebe';
+import BehaviorsModule from 'camunda-bpmn-js-behaviors/lib/camunda-cloud';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe.json';
+
+import diagramXML from './ExecutionListenerProps.bpmn';
+import { getExtensionElementsList } from 'src/utils/ExtensionElementsUtil';
+
+
+describe('provider/zeebe - ExecutionListenerProps', function() {
+
+  const testModules = [
+    CoreModule, SelectionModule, ModelingModule,
+    BpmnPropertiesPanel,
+    ZeebePropertiesProvider,
+    BehaviorsModule
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    modules: testModules,
+    moddleExtensions,
+    debounceInput: false
+  }));
+
+
+  for (const elementType of [
+    'Process',
+    'StartEvent',
+    'IntermediateThrowEvent',
+    'EndEvent',
+    'TimerEndEvent',
+    'Gateway',
+    'Task',
+    'SubProcess',
+    'BoundaryEvent'
+  ]) {
+
+    it(`should display for ${elementType}`, inject(async function(elementRegistry, selection) {
+
+      // given
+      const element = elementRegistry.get(elementType);
+
+      await act(() => {
+        selection.select(element);
+      });
+
+      // when
+      const group = getExecutionListenersGroup(container);
+      const listItems = getListenerListItems(group);
+
+      const listeners = getListeners(element);
+
+      // then
+      expect(group).to.exist;
+      expect(listItems).to.have.length(listeners.length);
+    }));
+  }
+
+
+  for (const elementType of [
+    'CompensationBoundaryEvent',
+    'ComplexGateway'
+  ]) {
+
+    it(`should NOT display for ${elementType}`, inject(async function(elementRegistry, selection) {
+
+      // given
+      const compensationEvent = elementRegistry.get(elementType);
+
+      await act(() => {
+        selection.select(compensationEvent);
+      });
+
+      // when
+      const group = getExecutionListenersGroup(container);
+
+      // then
+      expect(group).not.to.exist;
+    }));
+  }
+
+
+  it('should display proper label', inject(async function(elementRegistry, selection) {
+
+    // given
+    const element = elementRegistry.get('StartEvent');
+
+    await act(() => {
+      selection.select(element);
+    });
+
+    // when
+    const group = getExecutionListenersGroup(container);
+    const label = domQuery('.bio-properties-panel-collapsible-entry-header-title', group);
+
+    // then
+    expect(label).to.have.property('textContent', 'End: sysout');
+  }));
+
+
+  it('should add new listener', inject(async function(elementRegistry, selection) {
+
+    // given
+    const element = elementRegistry.get('StartEvent');
+
+    await act(() => {
+      selection.select(element);
+    });
+
+    const group = getExecutionListenersGroup(container);
+    const addEntry = domQuery('.bio-properties-panel-add-entry', group);
+
+    // when
+    await act(() => {
+      addEntry.click();
+    });
+
+    // then
+    expect(getListeners(element)).to.have.length(3);
+  }));
+
+
+  it('should create non existing extension elements',
+    inject(async function(elementRegistry, selection) {
+
+      // given
+      const empty = elementRegistry.get('Empty');
+
+      await act(() => {
+        selection.select(empty);
+      });
+
+      // assume
+      expect(getBusinessObject(empty).get('extensionElements')).not.to.exist;
+
+      const group = getExecutionListenersGroup(container);
+      const addEntry = domQuery('.bio-properties-panel-add-entry', group);
+
+      // when
+      await act(() => {
+        addEntry.click();
+      });
+
+      // then
+      expect(getBusinessObject(empty).get('extensionElements')).to.exist;
+      expect(getListeners(empty)).to.have.length(1);
+    })
+  );
+
+
+  it('should re-use existing extensionElements', inject(async function(elementRegistry, selection) {
+
+    // given
+    const otherExtensions = elementRegistry.get('OtherExtensions');
+
+    await act(() => {
+      selection.select(otherExtensions);
+    });
+
+    // assume
+    expect(getBusinessObject(otherExtensions).get('extensionElements')).to.exist;
+
+    const group = getExecutionListenersGroup(container);
+    const addEntry = domQuery('.bio-properties-panel-add-entry', group);
+
+    // when
+    await act(() => {
+      addEntry.click();
+    });
+
+    // then
+    expect(getBusinessObject(otherExtensions).get('extensionElements')).to.exist;
+    expect(getListeners(otherExtensions)).to.have.length(1);
+  }));
+
+
+  it('should delete listener', inject(async function(elementRegistry, selection) {
+
+    // given
+    const element = elementRegistry.get('SingleListener');
+
+    await act(() => {
+      selection.select(element);
+    });
+
+    const group = getExecutionListenersGroup(container);
+    const listItems = getListenerListItems(group);
+    const removeEntry = domQuery('.bio-properties-panel-remove-entry', listItems[0]);
+
+    // when
+    await act(() => {
+      removeEntry.click();
+    });
+
+    // then
+    expect(getListeners(element)).to.have.length(0);
+  }));
+
+
+  it('should update on external change',
+    inject(async function(elementRegistry, selection, commandStack) {
+
+      // given
+      const element = elementRegistry.get('SingleListener');
+      const originalListeners = getListeners(element);
+
+      await act(() => {
+        selection.select(element);
+      });
+
+      const group = getExecutionListenersGroup(container);
+      const addEntry = domQuery('.bio-properties-panel-add-entry', group);
+      await act(() => {
+        addEntry.click();
+      });
+
+      // when
+      await act(() => {
+        commandStack.undo();
+      });
+
+      const listItems = getListenerListItems(group);
+
+      // then
+      expect(listItems).to.have.length(originalListeners.length);
+    })
+  );
+
+
+  describe('event type', function() {
+
+    for (const elementType of [
+      'Process',
+      'IntermediateThrowEvent',
+      'EndEvent',
+      'TimerEndEvent',
+      'Task',
+      'SubProcess'
+    ]) {
+
+      it(`should display for ${elementType}`, inject(async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get(elementType);
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        // when
+        const group = getExecutionListenersGroup(container);
+        const eventType = getEventType(group);
+
+        // then
+        expect(eventType).to.exist;
+      }));
+    }
+
+
+    for (const elementType of [
+      'StartEvent',
+      'ErrorEndEvent',
+      'Gateway',
+      'BoundaryEvent'
+    ]) {
+
+      it(`should NOT display for ${elementType}`, inject(async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get(elementType);
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        // when
+        const group = getExecutionListenersGroup(container);
+        const eventType = getEventType(group);
+
+        // then
+        expect(eventType).not.to.exist;
+      }));
+    }
+
+
+    it('should use a supported event type for a new listener', inject(
+      async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('StartEvent');
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        const group = getExecutionListenersGroup(container);
+        const addEntry = domQuery('.bio-properties-panel-add-entry', group);
+
+        // when
+        await act(() => {
+          addEntry.click();
+        });
+
+
+        // then
+        const listeners = getListeners(element);
+        const newListener = listeners[listeners.length - 1];
+
+        expect(newListener).to.have.property('eventType', 'end');
+      })
+    );
+
+
+    it('should update value', inject(async function(elementRegistry, selection) {
+
+      // given
+      const element = elementRegistry.get('TimerEndEvent');
+
+      await act(() => {
+        selection.select(element);
+      });
+
+      const group = getExecutionListenersGroup(container);
+      const eventType = getEventType(group);
+      const input = domQuery('select', eventType);
+
+      // when
+      changeInput(input, 'start');
+
+      // then
+      const listeners = getListeners(element);
+      const listener = listeners[0];
+
+      expect(listener).to.have.property('eventType', 'start');
+    }));
+
+
+    it('should update on external change', inject(async function(elementRegistry, selection, commandStack) {
+
+      // given
+      const element = elementRegistry.get('TimerEndEvent');
+      await act(() => {
+        selection.select(element);
+      });
+      const group = getExecutionListenersGroup(container);
+      const eventType = getEventType(group);
+      const input = domQuery('select', eventType);
+      changeInput(input, 'start');
+
+      // when
+      await act(() => {
+        commandStack.undo();
+      });
+
+      // then
+      expect(input).to.have.property('value', 'end');
+    }));
+  });
+
+
+  describe('listener type', function() {
+
+    it('should update value', inject(async function(elementRegistry, selection) {
+
+      // given
+      const element = elementRegistry.get('TimerEndEvent');
+
+      await act(() => {
+        selection.select(element);
+      });
+
+      const group = getExecutionListenersGroup(container);
+      const input = domQuery('[name*=listenerType]', group);
+
+      // when
+      changeInput(input, 'debug');
+
+      // then
+      const listeners = getListeners(element);
+      const listener = listeners[0];
+
+      expect(listener).to.have.property('type', 'debug');
+    }));
+
+
+    it('should update on external change', inject(async function(elementRegistry, selection, commandStack) {
+
+      // given
+      const element = elementRegistry.get('TimerEndEvent');
+      await act(() => {
+        selection.select(element);
+      });
+      const group = getExecutionListenersGroup(container);
+      const input = domQuery('[name*=listenerType]', group);
+      changeInput(input, 'debug');
+
+      // when
+      await act(() => {
+        commandStack.undo();
+      });
+
+      // then
+      expect(input).to.have.property('value', 'sysout');
+    }));
+  });
+
+
+  describe('retries type', function() {
+
+    it('should update value', inject(async function(elementRegistry, selection) {
+
+      // given
+      const element = elementRegistry.get('TimerEndEvent');
+
+      await act(() => {
+        selection.select(element);
+      });
+
+      const group = getExecutionListenersGroup(container);
+      const input = domQuery('[name*=retries]', group);
+
+      // when
+      changeInput(input, '22');
+
+      // then
+      const listeners = getListeners(element);
+      const listener = listeners[0];
+
+      expect(listener).to.have.property('retries', '22');
+    }));
+
+
+    it('should update on external change', inject(async function(elementRegistry, selection, commandStack) {
+
+      // given
+      const element = elementRegistry.get('TimerEndEvent');
+      await act(() => {
+        selection.select(element);
+      });
+      const group = getExecutionListenersGroup(container);
+      const input = domQuery('[name*=retries]', group);
+      changeInput(input, '22');
+
+      // when
+      await act(() => {
+        commandStack.undo();
+      });
+
+      // then
+      expect(input).to.have.property('value', '3');
+    }));
+  });
+});
+
+
+// helper //////////////////
+function getExecutionListenersGroup(container) {
+  return getGroup(container, 'Zeebe__ExecutionListeners');
+}
+
+function getGroup(container, id) {
+  return domQuery(`[data-group-id="group-${id}"`, container);
+}
+
+function getListItems(container, type) {
+  return domQueryAll(`div[data-entry-id*="-${type}-"].bio-properties-panel-collapsible-entry`, container);
+}
+
+function getListenerListItems(container) {
+  return getListItems(container, 'executionListener');
+}
+
+function getEventType(container) {
+  return domQuery('[data-entry-id*="eventType"]', container);
+}
+
+function getListeners(element) {
+  const bo = getBusinessObject(element);
+  const executionListeners = getExtensionElementsList(bo.get('processRef') || bo, 'zeebe:ExecutionListeners')[0];
+
+  return (executionListeners && executionListeners.get('listeners')) || [];
+}


### PR DESCRIPTION

https://github.com/user-attachments/assets/7f18da21-bb77-4418-bec1-14b3bbf47892

* [x] I can add execution listeners according to the support table https://github.com/camunda/camunda-docs/blob/11199d68e93a81f8d84ffbc1a6f2054d4751c194/docs/components/concepts/execution-listeners.md
* [x] If only a single type is supported, no event type dropdown is placed to avoid useless entries.

Related to https://github.com/camunda/camunda-modeler/issues/3951

Try out via `npm start` on the branch.