### PR TITLE
Add `Version tag` field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "sinon": "^17.0.1",
         "sinon-chai": "^3.7.0",
         "webpack": "^5.93.0",
-        "zeebe-bpmn-moddle": "^1.5.1"
+        "zeebe-bpmn-moddle": "^1.6.0"
       },
       "engines": {
         "node": "*"
@@ -10213,9 +10213,9 @@
       }
     },
     "node_modules/zeebe-bpmn-moddle": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.5.1.tgz",
-      "integrity": "sha512-20dqDop32YdjqyVLZB3Vhh8oq+VKVcmOPNGRUkW6m1kJOtkR/abZSPdqiMtjY310tkagMS56ocZB2yW8itMOHQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.6.0.tgz",
+      "integrity": "sha512-vjPeJoLQs7UkC5m27K0CyZkQMEAI8GsISU6TcfD2n/SzqkhJ6tubvcIabLRAhreaiuHY26MjtSVXw1LRVgd7Iw==",
       "dev": true
     },
     "node_modules/zod": {
@@ -17793,9 +17793,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.5.1.tgz",
-      "integrity": "sha512-20dqDop32YdjqyVLZB3Vhh8oq+VKVcmOPNGRUkW6m1kJOtkR/abZSPdqiMtjY310tkagMS56ocZB2yW8itMOHQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.6.0.tgz",
+      "integrity": "sha512-vjPeJoLQs7UkC5m27K0CyZkQMEAI8GsISU6TcfD2n/SzqkhJ6tubvcIabLRAhreaiuHY26MjtSVXw1LRVgd7Iw==",
       "dev": true
     },
     "zod": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "bpmn-js": "^17.9.1",
         "bpmn-js-create-append-anything": "^0.5.2",
         "bpmn-moddle": "^9.0.1",
-        "camunda-bpmn-js-behaviors": "^1.5.0",
+        "camunda-bpmn-js-behaviors": "^1.6.0",
         "camunda-bpmn-moddle": "^7.0.1",
         "chai": "^4.4.1",
         "cross-env": "^7.0.3",
@@ -2926,9 +2926,9 @@
       }
     },
     "node_modules/camunda-bpmn-js-behaviors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.5.0.tgz",
-      "integrity": "sha512-LHExkeC+ZallNMirN9pcm3y43ifUS5465mFIRsTUlitU1apgGS/L52NS0tsPXXQvCgNdEMk2bjs/kwiHhBLdSw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.6.0.tgz",
+      "integrity": "sha512-iz3+SW5yXMuR2znQiDaSsmPmMs36zzRbA5SNKxeAGBSwfoNze0DwUnbewU8K+mb+j9G4XVZzy2w8qJtSO/I2jg==",
       "dev": true,
       "dependencies": {
         "ids": "^1.0.0",
@@ -12353,9 +12353,9 @@
       "dev": true
     },
     "camunda-bpmn-js-behaviors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.5.0.tgz",
-      "integrity": "sha512-LHExkeC+ZallNMirN9pcm3y43ifUS5465mFIRsTUlitU1apgGS/L52NS0tsPXXQvCgNdEMk2bjs/kwiHhBLdSw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.6.0.tgz",
+      "integrity": "sha512-iz3+SW5yXMuR2znQiDaSsmPmMs36zzRbA5SNKxeAGBSwfoNze0DwUnbewU8K+mb+j9G4XVZzy2w8qJtSO/I2jg==",
       "dev": true,
       "requires": {
         "ids": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "bpmn-js": "^17.9.1",
     "bpmn-js-create-append-anything": "^0.5.2",
     "bpmn-moddle": "^9.0.1",
-    "camunda-bpmn-js-behaviors": "^1.5.0",
+    "camunda-bpmn-js-behaviors": "^1.6.0",
     "camunda-bpmn-moddle": "^7.0.1",
     "chai": "^4.4.1",
     "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
     "webpack": "^5.93.0",
-    "zeebe-bpmn-moddle": "^1.5.1"
+    "zeebe-bpmn-moddle": "^1.6.0"
   },
   "peerDependencies": {
     "@bpmn-io/properties-panel": ">= 3.7",

--- a/src/contextProvider/zeebe/TooltipProvider.js
+++ b/src/contextProvider/zeebe/TooltipProvider.js
@@ -296,6 +296,18 @@ const TooltipProvider = {
       </div>
     );
   },
+  'versionTag': (element) => {
+
+    const translate = useService('translate');
+
+    return (
+      <div>
+        <p>
+          { translate('Specifying a version tag will allow you to reference this process in another process.') }
+        </p>
+      </div>
+    );
+  },
   'priorityDefinitionPriority': (element) => {
 
     const translate = useService('translate');

--- a/src/contextProvider/zeebe/TooltipProvider.js
+++ b/src/contextProvider/zeebe/TooltipProvider.js
@@ -297,16 +297,41 @@ const TooltipProvider = {
     );
   },
   'versionTag': (element) => {
-
     const translate = useService('translate');
 
-    return (
-      <div>
-        <p>
-          { translate('Specifying a version tag will allow you to reference this process in another process.') }
-        </p>
-      </div>
-    );
+    if (is(element, 'bpmn:Process')) {
+      return (
+        <div>
+          <p>
+            { translate('Version tag by which this process can be referenced.') }
+          </p>
+        </div>
+      );
+    } else if (is(element, 'bpmn:CallActivity')) {
+      return (
+        <div>
+          <p>
+            { translate('Version tag by which the called process will be referenced.') }
+          </p>
+        </div>
+      );
+    } else if (is(element, 'bpmn:BusinessRuleTask')) {
+      return (
+        <div>
+          <p>
+            { translate('Version tag by which the called decision will be referenced.') }
+          </p>
+        </div>
+      );
+    } else if (is(element, 'bpmn:UserTask')) {
+      return (
+        <div>
+          <p>
+            { translate('Version tag by which the linked form will be referenced.') }
+          </p>
+        </div>
+      );
+    }
   },
   'priorityDefinitionPriority': (element) => {
 

--- a/src/contextProvider/zeebe/TooltipProvider.js
+++ b/src/contextProvider/zeebe/TooltipProvider.js
@@ -1,6 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import {
-  is
+  is,
+  isAny
 } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
@@ -293,13 +294,17 @@ const TooltipProvider = {
           <h1>{ translate('Deployment binding') }</h1>
           { translate('Uses the resource found in the same deployment.') }
         </p>
+        <p>
+          <h1>{ translate('Version tag binding') }</h1>
+          { translate('Uses the most recent deployed resource with the given version tag.') }
+        </p>
       </div>
     );
   },
   'versionTag': (element) => {
     const translate = useService('translate');
 
-    if (is(element, 'bpmn:Process')) {
+    if (isAny(element, [ 'bpmn:Process', 'bpmn:Participant' ])) {
       return (
         <div>
           <p>

--- a/src/provider/zeebe/ZeebePropertiesProvider.js
+++ b/src/provider/zeebe/ZeebePropertiesProvider.js
@@ -1,5 +1,7 @@
 import { Group, ListGroup } from '@bpmn-io/properties-panel';
 
+import { findIndex } from 'min-dash';
+
 import {
   AssignmentDefinitionProps,
   BusinessRuleImplementationProps,
@@ -24,7 +26,8 @@ import {
   TaskDefinitionProps,
   TaskScheduleProps,
   TimerProps,
-  UserTaskImplementationProps
+  UserTaskImplementationProps,
+  VersionTagProps
 } from './properties';
 
 import { ExtensionPropertiesProps } from '../shared/ExtensionPropertiesProps';
@@ -72,6 +75,7 @@ export default class ZeebePropertiesProvider {
       groups = groups.concat(this._getGroups(element));
 
       // (2) update existing groups with zeebe specific properties
+      updateGeneralGroup(groups, element);
       updateErrorGroup(groups, element);
       updateEscalationGroup(groups, element);
       updateMessageGroup(groups, element);
@@ -333,6 +337,22 @@ function ExtensionPropertiesGroup(element, injector) {
   }
 
   return null;
+}
+
+function updateGeneralGroup(groups, element) {
+
+  const generalGroup = findGroup(groups, 'general');
+
+  if (!generalGroup) {
+    return;
+  }
+
+  const { entries } = generalGroup;
+
+  const executableEntry = findIndex(entries, (entry) => entry.id === 'isExecutable');
+  const insertIndex = executableEntry >= 0 ? executableEntry : entries.length;
+
+  entries.splice(insertIndex, 0, ...VersionTagProps({ element }));
 }
 
 function updateErrorGroup(groups, element) {

--- a/src/provider/zeebe/properties/CalledDecisionProps.js
+++ b/src/provider/zeebe/properties/CalledDecisionProps.js
@@ -10,7 +10,8 @@ import {
   TextFieldEntry
 } from '@bpmn-io/properties-panel';
 
-import Binding from './shared/Binding';
+import Binding, { getBindingType } from './shared/Binding';
+import VersionTag from './shared/VersionTag.js';
 
 import {
   getExtensionElementsList
@@ -36,7 +37,7 @@ export function CalledDecisionProps(props) {
     return [];
   }
 
-  return [
+  const entries = [
     {
       id: 'decisionId',
       component: DecisionID,
@@ -46,13 +47,24 @@ export function CalledDecisionProps(props) {
       id: 'bindingType',
       component: withProps(Binding, { type: 'zeebe:CalledDecision' }),
       isEdited: isSelectEntryEdited
-    },
-    {
-      id: 'resultVariable',
-      component: ResultVariable,
-      isEdited: isTextFieldEntryEdited
     }
   ];
+
+  if (getBindingType(element, 'zeebe:CalledDecision') === 'versionTag') {
+    entries.push({
+      id: 'versionTag',
+      component: withProps(VersionTag, { type: 'zeebe:CalledDecision' }),
+      isEdited: isTextFieldEntryEdited
+    });
+  }
+
+  entries.push({
+    id: 'resultVariable',
+    component: ResultVariable,
+    isEdited: isTextFieldEntryEdited
+  });
+
+  return entries;
 }
 
 function DecisionID(props) {

--- a/src/provider/zeebe/properties/FormProps.js
+++ b/src/provider/zeebe/properties/FormProps.js
@@ -18,7 +18,8 @@ import {
   isTextAreaEntryEdited
 } from '@bpmn-io/properties-panel';
 
-import Binding from './shared/Binding';
+import Binding, { getBindingType } from './shared/Binding';
+import VersionTag from './shared/VersionTag';
 
 import { FeelEntryWithVariableContext } from '../../../entries/FeelEntryWithContext';
 
@@ -89,6 +90,14 @@ export function FormProps(props) {
       component: withProps(Binding, { type: 'zeebe:FormDefinition' }),
       isEdited: isSelectEntryEdited
     });
+
+    if (getBindingType(element, 'zeebe:FormDefinition') === 'versionTag') {
+      entries.push({
+        id: 'versionTag',
+        component: withProps(VersionTag, { type: 'zeebe:FormDefinition' }),
+        isEdited: isTextFieldEntryEdited
+      });
+    }
   }
 
   return entries;

--- a/src/provider/zeebe/properties/TargetProps.js
+++ b/src/provider/zeebe/properties/TargetProps.js
@@ -5,10 +5,12 @@ import {
 
 import {
   isFeelEntryEdited,
-  isSelectEntryEdited
+  isSelectEntryEdited,
+  isTextFieldEntryEdited
 } from '@bpmn-io/properties-panel';
 
-import Binding from './shared/Binding';
+import Binding, { getBindingType } from './shared/Binding';
+import VersionTag from './shared/VersionTag.js';
 
 import {
   createElement
@@ -35,7 +37,7 @@ export function TargetProps(props) {
     return [];
   }
 
-  return [
+  const entries = [
     {
       id: 'targetProcessId',
       component: TargetProcessId,
@@ -47,6 +49,16 @@ export function TargetProps(props) {
       isEdited: isSelectEntryEdited
     }
   ];
+
+  if (getBindingType(element, 'zeebe:CalledElement') === 'versionTag') {
+    entries.push({
+      id: 'versionTag',
+      component: withProps(VersionTag, { type: 'zeebe:CalledElement' }),
+      isEdited: isTextFieldEntryEdited
+    });
+  }
+
+  return entries;
 }
 
 function TargetProcessId(props) {

--- a/src/provider/zeebe/properties/VersionTagProps.js
+++ b/src/provider/zeebe/properties/VersionTagProps.js
@@ -1,0 +1,139 @@
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
+
+import {
+  useService
+} from '../../../hooks';
+
+import { createElement } from '../../../utils/ElementUtil';
+
+import { getExtensionElementsList } from '../../../utils/ExtensionElementsUtil';
+
+
+export function VersionTagProps(props) {
+  const {
+    element
+  } = props;
+
+  const businessObject = getBusinessObject(element);
+
+  if (!is(element, 'bpmn:Process') &&
+      !(is(element, 'bpmn:Participant') && businessObject.get('processRef'))) {
+    return [];
+  }
+
+  return [
+    {
+      id: 'versionTag',
+      component: VersionTag,
+      isEdited: isTextFieldEntryEdited
+    },
+  ];
+}
+
+function VersionTag(props) {
+  const { element } = props;
+
+  const bpmnFactory = useService('bpmnFactory');
+  const commandStack = useService('commandStack');
+  const debounce = useService('debounceInput');
+  const translate = useService('translate');
+
+  const getValue = () => {
+    const versionTag = getVersionTag(element);
+
+    if (versionTag) {
+      return versionTag.get('value');
+    }
+  };
+
+  const setValue = (value) => {
+    let commands = [];
+
+    const businessObject = getProcess(element);
+
+    let extensionElements = businessObject.get('extensionElements');
+
+    // (1) ensure extension elements
+    if (!extensionElements) {
+      extensionElements = createElement(
+        'bpmn:ExtensionElements',
+        { values: [] },
+        businessObject,
+        bpmnFactory
+      );
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: businessObject,
+          properties: { extensionElements }
+        }
+      });
+    }
+
+    // (2) ensure version tag
+    let versionTag = getVersionTag(element);
+
+    if (!versionTag) {
+      versionTag = createElement(
+        'zeebe:VersionTag',
+        {},
+        extensionElements,
+        bpmnFactory
+      );
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: extensionElements,
+          properties: {
+            values: [ ...extensionElements.get('values'), versionTag ]
+          }
+        }
+      });
+    }
+
+    // (3) update version tag value
+    commands.push({
+      cmd: 'element.updateModdleProperties',
+      context: {
+        element,
+        moddleElement: versionTag,
+        properties: { value }
+      }
+    });
+
+    commandStack.execute('properties-panel.multi-command-executor', commands);
+  };
+
+  return TextFieldEntry({
+    element,
+    id: 'versionTag',
+    label: translate('Version tag'),
+    getValue,
+    setValue,
+    debounce
+  });
+}
+
+
+// helper //////////////////
+
+function getProcess(element) {
+  return is(element, 'bpmn:Process') ?
+    getBusinessObject(element) :
+    getBusinessObject(element).get('processRef');
+}
+
+function getVersionTag(element) {
+  const businessObject = getProcess(element);
+
+  return getExtensionElementsList(businessObject, 'zeebe:VersionTag')[ 0 ];
+}

--- a/src/provider/zeebe/properties/index.js
+++ b/src/provider/zeebe/properties/index.js
@@ -22,3 +22,4 @@ export { TaskDefinitionProps } from './TaskDefinitionProps';
 export { TaskScheduleProps } from './TaskScheduleProps';
 export { TimerProps } from './TimerProps';
 export { UserTaskImplementationProps } from './UserTaskImplementationProps';
+export { VersionTagProps } from './VersionTagProps';

--- a/src/provider/zeebe/properties/shared/VersionTag.js
+++ b/src/provider/zeebe/properties/shared/VersionTag.js
@@ -1,6 +1,6 @@
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
-import { SelectEntry } from '@bpmn-io/properties-panel';
+import { TextFieldEntry } from '@bpmn-io/properties-panel';
 
 import { createElement } from '../../../../utils/ElementUtil';
 
@@ -8,7 +8,7 @@ import { useService } from '../../../../hooks';
 
 import { getExtensionElementsList } from '../../../../utils/ExtensionElementsUtil';
 
-export default function Binding(props) {
+export default function VersionTag(props) {
   const {
     element,
     type
@@ -16,9 +16,10 @@ export default function Binding(props) {
 
   const bpmnFactory = useService('bpmnFactory'),
         commandStack = useService('commandStack'),
+        debounce = useService('debounceInput'),
         translate = useService('translate');
 
-  const getValue = () => getBindingType(element, type);
+  const getValue = () => getVersionTag(element, type);
 
   const setValue = value => {
     const commands = [];
@@ -70,14 +71,14 @@ export default function Binding(props) {
 
     }
 
-    // (3) Update bindingType attribute
+    // (3) Update versionTag attribute
     commands.push({
       cmd: 'element.updateModdleProperties',
       context: {
         element,
         moddleElement: extensionElement,
         properties: {
-          bindingType: value
+          versionTag: value
         }
       }
     });
@@ -86,30 +87,24 @@ export default function Binding(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  const getOptions = () => ([
-    { value: 'latest', label: translate('latest') },
-    { value: 'deployment', label: translate('deployment') },
-    { value: 'versionTag', label: translate('version tag') }
-  ]);
-
-  return <SelectEntry
-    element={ element }
-    id="bindingType"
-    label={ translate('Binding') }
-    getValue={ getValue }
-    setValue={ setValue }
-    getOptions={ getOptions }
-  />;
+  return TextFieldEntry({
+    element,
+    id: 'versionTag',
+    label: translate('Version tag'),
+    getValue,
+    setValue,
+    debounce
+  });
 }
 
-export function getBindingType(element, type) {
+export function getVersionTag(element, type) {
   const businessObject = getBusinessObject(element);
 
   const extensionElement = getExtensionElementsList(businessObject, type)[ 0 ];
 
   if (!extensionElement) {
-    return 'latest';
+    return '';
   }
 
-  return extensionElement.get('bindingType');
+  return extensionElement.get('versionTag') || '';
 }

--- a/test/spec/provider/zeebe/CalledDecisionProps.bpmn
+++ b/test/spec/provider/zeebe/CalledDecisionProps.bpmn
@@ -7,7 +7,11 @@
         <zeebe:calledDecision decisionId="myDecisionId" resultVariable="myResultVariable" />
       </bpmn:extensionElements>
     </bpmn:businessRuleTask>
-    <bpmn:businessRuleTask id="BusinessRuleTask_2" name="BusinessRuleTask_2" />
+    <bpmn:businessRuleTask id="BusinessRuleTask_2" name="BusinessRuleTask_2">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision decisionId="myDecisionId" resultVariable="myResultVariable" bindingType="versionTag" versionTag="v1.0.0" />
+      </bpmn:extensionElements>
+    </bpmn:businessRuleTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0mgn9vm">

--- a/test/spec/provider/zeebe/CalledDecisionProps.spec.js
+++ b/test/spec/provider/zeebe/CalledDecisionProps.spec.js
@@ -245,6 +245,98 @@ describe('provider/zeebe - CalledDecisionProps', function() {
     });
 
 
+    describe('#calledDecision.versionTag', function() {
+
+      it('should display', inject(async function(elementRegistry, selection) {
+
+        // given
+        const businessRuleTask = elementRegistry.get('BusinessRuleTask_2');
+
+        // assume
+        const versionTag = getVersionTag(businessRuleTask);
+
+        expect(versionTag).to.equal('v1.0.0');
+
+        // when
+        await act(() => {
+          selection.select(businessRuleTask);
+        });
+
+        const versionTagInput = domQuery('input[name=versionTag]', container);
+
+        // then
+        expect(versionTagInput).to.exist;
+
+        expect(versionTagInput.value).to.equal('v1.0.0');
+      }));
+
+
+      it('should not display', inject(async function(elementRegistry, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        // when
+        await act(() => {
+          selection.select(task);
+        });
+
+        const versionTagInput = domQuery('input[name=versionTag]', container);
+
+        // then
+        expect(versionTagInput).not.to.exist;
+      }));
+
+
+      it('should update', inject(async function(elementRegistry, selection) {
+
+        // given
+        const businessRuleTask = elementRegistry.get('BusinessRuleTask_2');
+
+        await act(() => {
+          selection.select(businessRuleTask);
+        });
+
+        const versionTagInput = domQuery('input[name=versionTag]', container);
+
+        // when
+        changeInput(versionTagInput, 'v2.0.0');
+
+        // then
+        const versionTag = getVersionTag(businessRuleTask);
+
+        expect(versionTag).to.equal('v2.0.0');
+      }));
+
+
+      it('should update on external change',
+        inject(async function(elementRegistry, selection, commandStack) {
+
+          // given
+          const businessRuleTask = elementRegistry.get('BusinessRuleTask_2'),
+                originalValue = getVersionTag(businessRuleTask);
+
+          await act(() => {
+            selection.select(businessRuleTask);
+          });
+
+          const versionTagInput = domQuery('input[name=versionTag]', container);
+
+          changeInput(versionTagInput, 'v2.0.0');
+
+          // when
+          await act(() => {
+            commandStack.undo();
+          });
+
+          // then
+          expect(getVersionTag(businessRuleTask)).to.eql(originalValue);
+        })
+      );
+
+    });
+
+
     describe('#calledDecision.resultVariable', function() {
 
       it('should display', inject(async function(elementRegistry, selection) {
@@ -351,6 +443,12 @@ export function getBindingType(element) {
   const calledDecision = getCalledDecision(element);
 
   return calledDecision ? calledDecision.get('bindingType') : '';
+}
+
+export function getVersionTag(element) {
+  const calledDecision = getCalledDecision(element);
+
+  return calledDecision ? calledDecision.get('versionTag') : '';
 }
 
 export function getResultVariable(element) {

--- a/test/spec/provider/zeebe/Forms.bpmn
+++ b/test/spec/provider/zeebe/Forms.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.16.0-dev" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:extensionElements>
       <zeebe:userTaskForm id="UserTaskForm_1">{}</zeebe:userTaskForm>
@@ -37,36 +37,44 @@
         <zeebe:userTask />
       </bpmn:extensionElements>
     </bpmn:userTask>
+    <bpmn:userTask id="CAMUNDA_FORM_LINKED_VERSION_TAG" name="CAMUNDA_FORM_LINKED_VERSION_TAG">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="foo" bindingType="versionTag" versionTag="v1.0.0" />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
-      <bpmndi:BPMNShape id="Activity_0fgvv7q_di" bpmnElement="CAMUNDA_FORM_EMBEDDED">
-        <dc:Bounds x="270" y="77" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0w86vs0_di" bpmnElement="NO_FORM">
-        <dc:Bounds x="160" y="77" width="100" height="80" />
+        <dc:Bounds x="160" y="80" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="NO_FORM_ZEEBE_USER_TASK_DI" bpmnElement="NO_FORM_ZEEBE_USER_TASK">
-        <dc:Bounds x="160" y="177" width="100" height="80" />
+        <dc:Bounds x="270" y="80" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1kgbvcd_di" bpmnElement="CUSTOM_FORM">
-        <dc:Bounds x="490" y="77" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="CUSTOM_FORM_ZEEBE_USER_TASK_di" bpmnElement="CUSTOM_FORM_ZEEBE_USER_TASK">
-        <dc:Bounds x="490" y="177" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_0fgvv7q_di" bpmnElement="CAMUNDA_FORM_EMBEDDED">
+        <dc:Bounds x="160" y="190" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1u420cc_di" bpmnElement="CAMUNDA_FORM_LINKED">
-        <dc:Bounds x="380" y="77" width="100" height="80" />
+        <dc:Bounds x="270" y="190" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="CAMUNDA_FORM_LINKED_ZEEBE_USER_TASK_DI" bpmnElement="CAMUNDA_FORM_LINKED_ZEEBE_USER_TASK">
-        <dc:Bounds x="380" y="177" width="100" height="80" />
+        <dc:Bounds x="380" y="190" width="100" height="80" />
         <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kgbvcd_di" bpmnElement="CUSTOM_FORM">
+        <dc:Bounds x="160" y="300" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CUSTOM_FORM_ZEEBE_USER_TASK_di" bpmnElement="CUSTOM_FORM_ZEEBE_USER_TASK">
+        <dc:Bounds x="270" y="300" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0q4ulf7_di" bpmnElement="CAMUNDA_FORM_LINKED_VERSION_TAG">
+        <dc:Bounds x="490" y="190" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/zeebe/Forms.spec.js
+++ b/test/spec/provider/zeebe/Forms.spec.js
@@ -540,6 +540,70 @@ describe('provider/zeebe - Forms', function() {
 
     });
 
+
+    describe('version tag', function() {
+
+      it('should display', inject(async function(elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED_VERSION_TAG');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const versionTagInput = getVersionTagInput(container);
+
+        // then
+        expect(versionTagInput).to.exist;
+      }));
+
+
+      it('should update', inject(async function(elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED_VERSION_TAG');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const versionTagInput = getVersionTagInput(container);
+
+        // when
+        changeInput(versionTagInput, 'v2.0.0');
+
+        // then
+        expectVersionTag(userTask, 'v2.0.0');
+      }));
+
+
+      it('should update on external change', inject(async function(commandStack, elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED_VERSION_TAG');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const versionTagInput = getVersionTagInput(container);
+        const initialVersionTag = versionTagInput.value;
+
+        changeInput(versionTagInput, 'v2.0.0');
+        expectVersionTag(userTask, 'v2.0.0');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        expectVersionTag(userTask, initialVersionTag);
+      }));
+
+    });
+
   });
 
 
@@ -769,6 +833,10 @@ function getBindingTypeSelect(container) {
   return domQuery('select[name=bindingType]', container);
 }
 
+function getVersionTagInput(container) {
+  return domQuery('input[name=versionTag]', container);
+}
+
 function expectFormId(element, expected) {
   const formDefinition = getFormDefinition(element);
 
@@ -781,6 +849,13 @@ function expectBindingType(element, expected) {
 
   expect(formDefinition).to.exist;
   expect(formDefinition.get('bindingType')).to.eql(expected);
+}
+
+function expectVersionTag(element, expected) {
+  const formDefinition = getFormDefinition(element);
+
+  expect(formDefinition).to.exist;
+  expect(formDefinition.get('versionTag')).to.eql(expected);
 }
 
 function expectFormKey(element, expected) {

--- a/test/spec/provider/zeebe/TargetProps.bpmn
+++ b/test/spec/provider/zeebe/TargetProps.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0oevfuo" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0-alpha.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0oevfuo" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
   <bpmn:process id="Process_04htq1t" isExecutable="true">
     <bpmn:callActivity id="CallActivity_1" name="CallActivity_1">
       <bpmn:extensionElements>
@@ -20,7 +20,7 @@
     </bpmn:callActivity>
     <bpmn:callActivity id="CallActivity_4" name="CallActivity_4">
       <bpmn:extensionElements>
-        <zeebe:calledElement propagateAllChildVariables="false" />
+        <zeebe:calledElement propagateAllChildVariables="false" bindingType="versionTag" versionTag="v1.0.0" />
       </bpmn:extensionElements>
     </bpmn:callActivity>
   </bpmn:process>

--- a/test/spec/provider/zeebe/TargetProps.spec.js
+++ b/test/spec/provider/zeebe/TargetProps.spec.js
@@ -28,6 +28,8 @@ import {
   getProcessId
 } from 'src/provider/zeebe/utils/CalledElementUtil.js';
 
+import { getVersionTag } from 'src/provider/zeebe/properties/shared/VersionTag';
+
 import BpmnPropertiesPanel from 'src/render';
 import CoreModule from 'bpmn-js/lib/core';
 import ModelingModule from 'bpmn-js/lib/features/modeling';
@@ -311,6 +313,97 @@ describe('provider/zeebe - TargetProps', function() {
 
         // then
         expect(getBindingType(callActivity)).to.eql(originalValue);
+      })
+    );
+
+  });
+
+
+  describe('bpmn:CallActivity#calledElement.versionTag', function() {
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_4');
+
+      // assume
+      const versionTag = getVersionTag(callActivity);
+
+      expect(versionTag).to.equal('v1.0.0');
+
+      // when
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      const versionTagInput = domQuery('input[name=versionTag]', container);
+
+      // then
+      expect(versionTagInput).to.exist;
+
+      expect(versionTagInput.value).to.equal('v1.0.0');
+    }));
+
+
+    it('should not display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      await act(() => {
+        selection.select(task);
+      });
+
+      const versionTagInput = domQuery('input[name=versionTag]', container);
+
+      // then
+      expect(versionTagInput).not.to.exist;
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_4');
+
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      const versionTagInput = domQuery('input[name=versionTag]', container);
+
+      // when
+      changeInput(versionTagInput, 'v2.0.0');
+
+      // then
+      const versionTag = getVersionTag(callActivity);
+
+      expect(versionTag).to.equal('v2.0.0');
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const callActivity = elementRegistry.get('CallActivity_4'),
+              originalValue = getVersionTag(callActivity);
+
+        await act(() => {
+          selection.select(callActivity);
+        });
+
+        const versionTagInput = domQuery('input[name=versionTag]', container);
+        changeInput(versionTagInput, 'v2.0.0');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(getVersionTag(callActivity)).to.eql(originalValue);
       })
     );
 

--- a/test/spec/provider/zeebe/VersionTagProps-collaboration.bpmn
+++ b/test/spec/provider/zeebe/VersionTagProps-collaboration.bpmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:collaboration id="Collaboration_1pt34ye">
+    <bpmn:participant id="Participant_1" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:versionTag value="v1.0.0" />
+      <zeebe:properties>
+        <zeebe:property name="foo" value="bar" />
+      </zeebe:properties>
+    </bpmn:extensionElements>
+    <bpmn:task id="Task_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1pt34ye">
+      <bpmndi:BPMNShape id="Participant_02oh0k3_di" bpmnElement="Participant_1" isHorizontal="true">
+        <dc:Bounds x="160" y="85" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0kx78hk_di" bpmnElement="Task_1">
+        <dc:Bounds x="410" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/zeebe/VersionTagProps-process.bpmn
+++ b/test/spec/provider/zeebe/VersionTagProps-process.bpmn
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:versionTag value="v1.0.0" />
+      <zeebe:properties>
+        <zeebe:property name="foo" value="bar" />
+      </zeebe:properties>
+    </bpmn:extensionElements>
+    <bpmn:task id="Task_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_0kx78hk_di" bpmnElement="Task_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/zeebe/VersionTagProps.spec.js
+++ b/test/spec/provider/zeebe/VersionTagProps.spec.js
@@ -1,0 +1,272 @@
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  act
+} from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  changeInput,
+  inject,
+  mouseEnter
+} from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+import BpmnPropertiesPanel from 'src/render';
+
+import BpmnPropertiesProvider from 'src/provider/bpmn';
+import ZeebePropertiesProvider from 'src/provider/zeebe';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import TooltipProvider from 'src/contextProvider/zeebe/TooltipProvider';
+
+import {
+  getExtensionElementsList
+} from 'src/utils/ExtensionElementsUtil';
+
+import processDiagramXML from './VersionTagProps-process.bpmn';
+import collaborationDiagramXML from './VersionTagProps-collaboration.bpmn';
+
+
+describe('provider/zeebe - VersionTagProps', function() {
+
+  const testModules = [
+    CoreModule, SelectionModule, ModelingModule,
+    BpmnPropertiesPanel,
+    BpmnPropertiesProvider,
+    ZeebePropertiesProvider
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container, clock;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(function() {
+    clock.restore();
+  });
+
+  function openTooltip() {
+    return act(() => {
+      const wrapper = domQuery('.bio-properties-panel-tooltip-wrapper', container);
+      mouseEnter(wrapper);
+      clock.tick(200);
+    });
+  }
+
+  [
+    [ 'process', 'Process_1', processDiagramXML ],
+    [ 'collaboration', 'Participant_1', collaborationDiagramXML ]
+  ].forEach(([ title, elementId, diagramXML ]) => {
+
+    describe(title, function() {
+
+      beforeEach(bootstrapPropertiesPanel(diagramXML, {
+        modules: testModules,
+        moddleExtensions,
+        propertiesPanel: {
+          tooltip: TooltipProvider
+        },
+        debounceInput: false
+      }));
+
+
+      it('should NOT display for task', inject(async function(elementRegistry, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        await act(() => {
+          selection.select(task);
+        });
+
+        // when
+        const versionTagInput = domQuery('input[name=versionTag]', container);
+
+        // then
+        expect(versionTagInput).to.not.exist;
+      }));
+
+
+      it('should display for process', inject(async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get(elementId);
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        // when
+        const versionTagInput = domQuery('input[name=versionTag]', container);
+
+        // then
+        expect(versionTagInput).to.exist;
+        expect(versionTagInput.value).to.eql(getVersionTag(element).get('value'));
+      }));
+
+
+      it('should update', inject(async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get(elementId);
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        // when
+        const versionTagInput = domQuery('input[name=versionTag]', container);
+
+        changeInput(versionTagInput, 'v2.0.0');
+
+        // then
+        expect(getVersionTag(element).get('value')).to.eql('v2.0.0');
+      }));
+
+
+      it('should update on external change',
+        inject(async function(elementRegistry, selection, commandStack) {
+
+          // given
+          const element = elementRegistry.get(elementId);
+
+          const originalValue = getVersionTag(element).get('value');
+
+          await act(() => {
+            selection.select(element);
+          });
+
+          const versionTagInput = domQuery('input[name=versionTag]', container);
+
+          changeInput(versionTagInput, 'v2.0.0');
+
+          // when
+          await act(() => {
+            commandStack.undo();
+          });
+
+          // then
+          expect(versionTagInput.value).to.eql(originalValue);
+        })
+      );
+
+
+      it('should create non existing extension elements',
+        inject(async function(elementRegistry, modeling, selection) {
+
+          // given
+          const element = elementRegistry.get(elementId);
+
+          modeling.updateModdleProperties(element, getProcess(element), { extensionElements: undefined });
+
+          // assume
+          expect(getProcess(element).get('extensionElements')).to.not.exist;
+
+          await act(() => {
+            selection.select(element);
+          });
+
+          // when
+          const versionTagInput = domQuery('input[name=versionTag]', container);
+
+          changeInput(versionTagInput, 'v1.0.0');
+
+          // then
+          expect(getProcess(element).get('extensionElements')).to.exist;
+          expect(getVersionTag(element).get('value')).to.eql('v1.0.0');
+        })
+      );
+
+
+      it('should create non existing version tag',
+        inject(async function(elementRegistry, modeling, selection) {
+
+          // given
+          const element = elementRegistry.get(elementId);
+
+          modeling.updateModdleProperties(
+            element,
+            getProcess(element).get('extensionElements'),
+            { values: [] }
+          );
+
+          // assume
+          expect(getProcess(element).get('extensionElements')).to.exist;
+          expect(getVersionTag(element)).not.to.exist;
+
+          await act(() => {
+            selection.select(element);
+          });
+
+          // when
+          const versionTagInput = domQuery('input[name=versionTag]', container);
+
+          changeInput(versionTagInput, 'v1.0.0');
+
+          // then
+          expect(getVersionTag(element)).to.exist;
+          expect(getVersionTag(element).get('value')).to.eql('v1.0.0');
+        })
+      );
+
+
+      it('should display correct documentation', inject(async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get(elementId);
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        // when
+        await openTooltip();
+
+        const documentationLinkGroup = domQuery('.bio-properties-panel-tooltip-content p', container);
+
+        // then
+        expect(documentationLinkGroup).to.exist;
+        expect(documentationLinkGroup.textContent).to.equal('Version tag by which this process can be referenced.');
+      }));
+
+    });
+
+  });
+
+});
+
+
+// helper //////////////////
+
+function getProcess(element) {
+  return is(element, 'bpmn:Process') ?
+    getBusinessObject(element) :
+    getBusinessObject(element).get('processRef');
+}
+
+function getVersionTag(element) {
+  const businessObject = getProcess(element);
+
+  return getExtensionElementsList(businessObject, 'zeebe:VersionTag')[ 0 ];
+}


### PR DESCRIPTION
### Proposed Changes

* adds _Version tag_ field to processes

![image](https://github.com/user-attachments/assets/fa6c4339-98a4-4018-9965-94e206ba5220)

* adds _Version tag_ field to resources linked through _version tag_ option

![image](https://github.com/user-attachments/assets/e8a4564d-f458-47ea-851e-7bb459e59de5)

* adjusts the _Binding type_ tooltip

![image](https://github.com/user-attachments/assets/be99bf37-5b19-4384-a648-c2e30755da4a)

Requires https://github.com/camunda/zeebe-bpmn-moddle/pull/65
Requires https://github.com/camunda/camunda-bpmn-js-behaviors/pull/80

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
