### PR TITLE
feat: change Header value input and Field Injection value input to text areas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@babel/plugin-transform-react-jsx": "^7.24.7",
         "@bpmn-io/element-template-chooser": "^1.0.0",
         "@bpmn-io/element-templates-icons-renderer": "^0.3.0",
-        "@bpmn-io/properties-panel": "^3.21.0",
+        "@bpmn-io/properties-panel": "^3.22.3",
         "@bpmn-io/variable-resolver": "^1.2.2",
         "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-babel": "^6.0.4",
@@ -638,13 +638,13 @@
       }
     },
     "node_modules/@bpmn-io/properties-panel": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.21.0.tgz",
-      "integrity": "sha512-r1Y8lEmZMCgetmB7w0GtJibv9ORbcsEGQL9Pn/W+67Tc9GaVoG1OCpVUubKw4RY3WU3q8OcXxNf8nccroYhI9g==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.22.3.tgz",
+      "integrity": "sha512-E+TvHURiYHQb2BuABLnHL8PrRUan2Y7xfSmhkpk/ZthYoDJqCQadHN5W7tWZF7E5Qq/gQrVtB7138Au4TnKEtg==",
       "dev": true,
       "dependencies": {
-        "@bpmn-io/feel-editor": "^1.5.0",
-        "@codemirror/view": "^6.14.0",
+        "@bpmn-io/feel-editor": "^1.6.0",
+        "@codemirror/view": "^6.28.1",
         "classnames": "^2.3.1",
         "feelers": "^1.4.0",
         "focus-trap": "^7.5.2",
@@ -10387,13 +10387,13 @@
       }
     },
     "@bpmn-io/properties-panel": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.21.0.tgz",
-      "integrity": "sha512-r1Y8lEmZMCgetmB7w0GtJibv9ORbcsEGQL9Pn/W+67Tc9GaVoG1OCpVUubKw4RY3WU3q8OcXxNf8nccroYhI9g==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.22.3.tgz",
+      "integrity": "sha512-E+TvHURiYHQb2BuABLnHL8PrRUan2Y7xfSmhkpk/ZthYoDJqCQadHN5W7tWZF7E5Qq/gQrVtB7138Au4TnKEtg==",
       "dev": true,
       "requires": {
-        "@bpmn-io/feel-editor": "^1.5.0",
-        "@codemirror/view": "^6.14.0",
+        "@bpmn-io/feel-editor": "^1.6.0",
+        "@codemirror/view": "^6.28.1",
         "classnames": "^2.3.1",
         "feelers": "^1.4.0",
         "focus-trap": "^7.5.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@babel/plugin-transform-react-jsx": "^7.24.7",
     "@bpmn-io/element-template-chooser": "^1.0.0",
     "@bpmn-io/element-templates-icons-renderer": "^0.3.0",
-    "@bpmn-io/properties-panel": "^3.21.0",
+    "@bpmn-io/properties-panel": "^3.22.3",
     "@bpmn-io/variable-resolver": "^1.2.2",
     "@rollup/plugin-alias": "^5.1.0",
     "@rollup/plugin-babel": "^6.0.4",

--- a/src/provider/camunda-platform/properties/FieldInjection.js
+++ b/src/provider/camunda-platform/properties/FieldInjection.js
@@ -1,4 +1,4 @@
-import { TextFieldEntry, SelectEntry } from '@bpmn-io/properties-panel';
+import { TextFieldEntry, SelectEntry, TextAreaEntry } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -156,13 +156,14 @@ function ValueProperty(props) {
     return field.string || field.stringValue || field.expression;
   };
 
-  return TextFieldEntry({
+  return TextAreaEntry({
     element: field,
     id: idPrefix + '-value',
     label: translate('Value'),
     getValue,
     setValue,
-    debounce
+    debounce,
+    autoResize: true
   });
 }
 

--- a/src/provider/zeebe/properties/Header.js
+++ b/src/provider/zeebe/properties/Header.js
@@ -1,4 +1,4 @@
-import { TextFieldEntry } from '@bpmn-io/properties-panel';
+import { TextFieldEntry, TextAreaEntry } from '@bpmn-io/properties-panel';
 
 import {
   useService
@@ -87,12 +87,13 @@ function ValueProperty(props) {
     return header.value;
   };
 
-  return TextFieldEntry({
+  return TextAreaEntry({
     element: header,
     id: idPrefix + '-value',
     label: translate('Value'),
     getValue,
     setValue,
-    debounce
+    debounce,
+    autoResize: true
   });
 }

--- a/test/spec/provider/camunda-platform/FieldInjectionProps.spec.js
+++ b/test/spec/provider/camunda-platform/FieldInjectionProps.spec.js
@@ -78,7 +78,7 @@ describe('provider/camunda-platform - FieldInjectionProps', function() {
 
       // when
       const executionListenerGroup = domQuery('[data-group-id="group-CamundaPlatform__ExecutionListener"]', container);
-      const valueInputField = domQuery('input[name*="value"]', executionListenerGroup);
+      const valueInputField = domQuery('textarea[name*="value"]', executionListenerGroup);
 
       changeInput(valueInputField, 'newValue');
 

--- a/test/spec/provider/zeebe/Header.spec.js
+++ b/test/spec/provider/zeebe/Header.spec.js
@@ -155,7 +155,7 @@ describe('provider/bpmn - Header', function() {
 
         // when
         const headerGroup = getGroup(container, 'headers');
-        const valueInput = domQuery('input[name=ServiceTask_empty-header-0-value]', headerGroup);
+        const valueInput = domQuery('textarea[name=ServiceTask_empty-header-0-value]', headerGroup);
 
         // then
         expect(valueInput).to.not.exist;
@@ -173,7 +173,7 @@ describe('provider/bpmn - Header', function() {
 
       // when
       const headerGroup = getGroup(container, 'headers');
-      const valueInput = domQuery('input[name=ServiceTask_1-header-0-value]', headerGroup);
+      const valueInput = domQuery('textarea[name=ServiceTask_1-header-0-value]', headerGroup);
 
       // then
       expect(valueInput.value).to.eql(getHeader(serviceTask, 0).get('value'));
@@ -191,7 +191,7 @@ describe('provider/bpmn - Header', function() {
 
       // when
       const headerGroup = getGroup(container, 'headers');
-      const valueInput = domQuery('input[name=ServiceTask_1-header-0-value]', headerGroup);
+      const valueInput = domQuery('textarea[name=ServiceTask_1-header-0-value]', headerGroup);
       changeInput(valueInput, 'newValue');
 
       // then
@@ -209,7 +209,7 @@ describe('provider/bpmn - Header', function() {
         await act(() => {
           selection.select(serviceTask);
         });
-        const valueInput = domQuery('input[name=ServiceTask_1-header-0-value]', container);
+        const valueInput = domQuery('textarea[name=ServiceTask_1-header-0-value]', container);
         changeInput(valueInput, 'newValue');
 
         // when


### PR DESCRIPTION
### Proposed Changes

As a user I want to be able to conveniently put multiple lines of text into Header value input and Field Injection value input.

Updated dependency to `@bpmn-io/properties-panel` as the new version has a fix for UX of text area. Don't want to introduce new text areas that I know would be bugged.

Related to https://github.com/camunda/camunda-modeler/issues/2982

![image](https://github.com/user-attachments/assets/f5907d0d-ef74-459d-adb0-8034d8df1420)

![image](https://github.com/user-attachments/assets/179bc39c-1822-4318-b8db-33e35bbf321e)

### Checklist

To ensure you provided everything we need to look at your PR:

* [X] **Brief textual description** of the changes present
* [X] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [X] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
