### PR TITLE
Add _Binding_ entry to busines rule task, call activity and user task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "bpmn-js": "^17.9.1",
         "bpmn-js-create-append-anything": "^0.5.2",
         "bpmn-moddle": "^9.0.1",
-        "camunda-bpmn-js-behaviors": "^1.4.0",
+        "camunda-bpmn-js-behaviors": "^1.5.0",
         "camunda-bpmn-moddle": "^7.0.1",
         "chai": "^4.4.1",
         "cross-env": "^7.0.3",
@@ -2926,11 +2926,10 @@
       }
     },
     "node_modules/camunda-bpmn-js-behaviors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.4.0.tgz",
-      "integrity": "sha512-z7TN1I5zCj5p521xobxqe3p+/7EsmUV3ao8ZsDdk5lr1y3b/FeykvzsxH/d+8werZNwm1SXGCZbzGb7rEtnpsg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.5.0.tgz",
+      "integrity": "sha512-LHExkeC+ZallNMirN9pcm3y43ifUS5465mFIRsTUlitU1apgGS/L52NS0tsPXXQvCgNdEMk2bjs/kwiHhBLdSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ids": "^1.0.0",
         "min-dash": "^4.0.0"
@@ -12353,9 +12352,9 @@
       "dev": true
     },
     "camunda-bpmn-js-behaviors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.4.0.tgz",
-      "integrity": "sha512-z7TN1I5zCj5p521xobxqe3p+/7EsmUV3ao8ZsDdk5lr1y3b/FeykvzsxH/d+8werZNwm1SXGCZbzGb7rEtnpsg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.5.0.tgz",
+      "integrity": "sha512-LHExkeC+ZallNMirN9pcm3y43ifUS5465mFIRsTUlitU1apgGS/L52NS0tsPXXQvCgNdEMk2bjs/kwiHhBLdSw==",
       "dev": true,
       "requires": {
         "ids": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "sinon": "^17.0.1",
         "sinon-chai": "^3.7.0",
         "webpack": "^5.93.0",
-        "zeebe-bpmn-moddle": "^1.2.0"
+        "zeebe-bpmn-moddle": "^1.4.0"
       },
       "engines": {
         "node": "*"
@@ -10213,11 +10213,10 @@
       }
     },
     "node_modules/zeebe-bpmn-moddle": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.2.0.tgz",
-      "integrity": "sha512-KtY9CYs2qYKQMV7xdLY7Oj7Mgb0fA13DD8T0bYwv3JOkdqfW4IIqm+aMD+vvZ4j+2iaCGaqEA6XKHS5sZKG3Fg==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.4.0.tgz",
+      "integrity": "sha512-XSm0fMHPjQ5cmEGxga02du9arxb5NKH5ve7VQ0LFSes4wGcrZ/oJjaR3NlBqH6xTTD3g+Mcbh45+yesydPUQPg==",
+      "dev": true
     },
     "node_modules/zod": {
       "version": "3.23.8",
@@ -17793,9 +17792,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.2.0.tgz",
-      "integrity": "sha512-KtY9CYs2qYKQMV7xdLY7Oj7Mgb0fA13DD8T0bYwv3JOkdqfW4IIqm+aMD+vvZ4j+2iaCGaqEA6XKHS5sZKG3Fg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.4.0.tgz",
+      "integrity": "sha512-XSm0fMHPjQ5cmEGxga02du9arxb5NKH5ve7VQ0LFSes4wGcrZ/oJjaR3NlBqH6xTTD3g+Mcbh45+yesydPUQPg==",
       "dev": true
     },
     "zod": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@babel/plugin-transform-react-jsx": "^7.24.7",
         "@bpmn-io/element-template-chooser": "^1.0.0",
         "@bpmn-io/element-templates-icons-renderer": "^0.3.0",
-        "@bpmn-io/properties-panel": "^3.22.3",
+        "@bpmn-io/properties-panel": "^3.22.4",
         "@bpmn-io/variable-resolver": "^1.2.2",
         "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-babel": "^6.0.4",
@@ -627,9 +627,9 @@
       }
     },
     "node_modules/@bpmn-io/properties-panel": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.22.3.tgz",
-      "integrity": "sha512-E+TvHURiYHQb2BuABLnHL8PrRUan2Y7xfSmhkpk/ZthYoDJqCQadHN5W7tWZF7E5Qq/gQrVtB7138Au4TnKEtg==",
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.22.4.tgz",
+      "integrity": "sha512-Wgx/HWUAuQ7IoOPQEy3zCoh42w03ZuC3A4OYQ+XS4mwTXlsCdcPQS53c+r3c6PZRAJ3MlNlo+IAdp48aqwzs1A==",
       "dev": true,
       "dependencies": {
         "@bpmn-io/feel-editor": "^1.6.0",
@@ -10640,9 +10640,9 @@
       }
     },
     "@bpmn-io/properties-panel": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.22.3.tgz",
-      "integrity": "sha512-E+TvHURiYHQb2BuABLnHL8PrRUan2Y7xfSmhkpk/ZthYoDJqCQadHN5W7tWZF7E5Qq/gQrVtB7138Au4TnKEtg==",
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.22.4.tgz",
+      "integrity": "sha512-Wgx/HWUAuQ7IoOPQEy3zCoh42w03ZuC3A4OYQ+XS4mwTXlsCdcPQS53c+r3c6PZRAJ3MlNlo+IAdp48aqwzs1A==",
       "dev": true,
       "requires": {
         "@bpmn-io/feel-editor": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@babel/plugin-transform-react-jsx": "^7.24.7",
     "@bpmn-io/element-template-chooser": "^1.0.0",
     "@bpmn-io/element-templates-icons-renderer": "^0.3.0",
-    "@bpmn-io/properties-panel": "^3.22.3",
+    "@bpmn-io/properties-panel": "^3.22.4",
     "@bpmn-io/variable-resolver": "^1.2.2",
     "@rollup/plugin-alias": "^5.1.0",
     "@rollup/plugin-babel": "^6.0.4",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "bpmn-js": "^17.9.1",
     "bpmn-js-create-append-anything": "^0.5.2",
     "bpmn-moddle": "^9.0.1",
-    "camunda-bpmn-js-behaviors": "^1.4.0",
+    "camunda-bpmn-js-behaviors": "^1.5.0",
     "camunda-bpmn-moddle": "^7.0.1",
     "chai": "^4.4.1",
     "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
     "webpack": "^5.93.0",
-    "zeebe-bpmn-moddle": "^1.2.0"
+    "zeebe-bpmn-moddle": "^1.4.0"
   },
   "peerDependencies": {
     "@bpmn-io/properties-panel": ">= 3.7",

--- a/src/contextProvider/zeebe/TooltipProvider.js
+++ b/src/contextProvider/zeebe/TooltipProvider.js
@@ -278,6 +278,23 @@ const TooltipProvider = {
         </p>
       </div>
     );
+  },
+  'bindingType': (element) => {
+
+    const translate = useService('translate');
+
+    return (
+      <div>
+        <p>
+          <h1>{ translate('Latest binding') }</h1>
+          { translate('Uses the most recent deployed resource.') }
+        </p>
+        <p>
+          <h1>{ translate('Deployment binding') }</h1>
+          { translate('Uses the resource found in the same deployment.') }
+        </p>
+      </div>
+    );
   }
 };
 

--- a/src/provider/HOCs/index.js
+++ b/src/provider/HOCs/index.js
@@ -1,2 +1,3 @@
+export { withProps } from './withProps';
 export { withVariableContext } from './withVariableContext';
 export { withTooltipContainer } from './withTooltipContainer';

--- a/src/provider/HOCs/withProps.js
+++ b/src/provider/HOCs/withProps.js
@@ -1,0 +1,5 @@
+export function withProps(Component, otherProps) {
+  return props => {
+    return <Component { ...props } { ...otherProps } />;
+  };
+}

--- a/src/provider/zeebe/properties/CalledDecisionProps.js
+++ b/src/provider/zeebe/properties/CalledDecisionProps.js
@@ -4,9 +4,13 @@ import {
 } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
-  TextFieldEntry, isTextFieldEntryEdited,
-  isFeelEntryEdited
+  isFeelEntryEdited,
+  isSelectEntryEdited,
+  isTextFieldEntryEdited,
+  TextFieldEntry
 } from '@bpmn-io/properties-panel';
+
+import Binding from './shared/Binding';
 
 import {
   getExtensionElementsList
@@ -20,6 +24,7 @@ import { useService } from '../../../hooks';
 
 import { FeelEntryWithVariableContext } from '../../../entries/FeelEntryWithContext';
 
+import { withProps } from '../../HOCs/withProps.js';
 
 
 export function CalledDecisionProps(props) {
@@ -36,6 +41,11 @@ export function CalledDecisionProps(props) {
       id: 'decisionId',
       component: DecisionID,
       isEdited: isFeelEntryEdited
+    },
+    {
+      id: 'bindingType',
+      component: withProps(Binding, { type: 'zeebe:CalledDecision' }),
+      isEdited: isSelectEntryEdited
     },
     {
       id: 'resultVariable',

--- a/src/provider/zeebe/properties/FormProps.js
+++ b/src/provider/zeebe/properties/FormProps.js
@@ -13,9 +13,12 @@ import {
   TextFieldEntry,
   TextAreaEntry,
   isFeelEntryEdited,
+  isSelectEntryEdited,
   isTextFieldEntryEdited,
   isTextAreaEntryEdited
 } from '@bpmn-io/properties-panel';
+
+import Binding from './shared/Binding';
 
 import { FeelEntryWithVariableContext } from '../../../entries/FeelEntryWithContext';
 
@@ -33,6 +36,8 @@ import {
   isZeebeUserTask,
   userTaskFormIdToFormKey
 } from '../utils/FormUtil';
+
+import { withProps } from '../../HOCs';
 
 const NONE_VALUE = 'none';
 
@@ -75,6 +80,14 @@ export function FormProps(props) {
       id: 'externalReference',
       component: ExternalReference,
       isEdited: isFeelEntryEdited
+    });
+  }
+
+  if (formType === FORM_TYPES.CAMUNDA_FORM_LINKED) {
+    entries.push({
+      id: 'bindingType',
+      component: withProps(Binding, { type: 'zeebe:FormDefinition' }),
+      isEdited: isSelectEntryEdited
     });
   }
 

--- a/src/provider/zeebe/properties/TargetProps.js
+++ b/src/provider/zeebe/properties/TargetProps.js
@@ -4,8 +4,11 @@ import {
 } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
-  isFeelEntryEdited
+  isFeelEntryEdited,
+  isSelectEntryEdited
 } from '@bpmn-io/properties-panel';
+
+import Binding from './shared/Binding';
 
 import {
   createElement
@@ -19,6 +22,8 @@ import {
 import { useService } from '../../../hooks';
 
 import { FeelEntryWithVariableContext } from '../../../entries/FeelEntryWithContext';
+
+import { withProps } from '../../HOCs/withProps.js';
 
 
 export function TargetProps(props) {
@@ -35,6 +40,11 @@ export function TargetProps(props) {
       id: 'targetProcessId',
       component: TargetProcessId,
       isEdited: isFeelEntryEdited
+    },
+    {
+      id: 'bindingType',
+      component: withProps(Binding, { type: 'zeebe:CalledElement' }),
+      isEdited: isSelectEntryEdited
     }
   ];
 }

--- a/src/provider/zeebe/properties/shared/Binding.js
+++ b/src/provider/zeebe/properties/shared/Binding.js
@@ -1,0 +1,112 @@
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import { SelectEntry } from '@bpmn-io/properties-panel';
+
+import { createElement } from '../../../../utils/ElementUtil';
+
+import { useService } from '../../../../hooks';
+
+import { getExtensionElementsList } from '../../../../utils/ExtensionElementsUtil';
+
+export default function Binding(props) {
+  const {
+    element,
+    type
+  } = props;
+
+  const bpmnFactory = useService('bpmnFactory'),
+        commandStack = useService('commandStack'),
+        translate = useService('translate');
+
+  const getValue = () => {
+    const businessObject = getBusinessObject(element);
+
+    const extensionElement = getExtensionElementsList(businessObject, type)[ 0 ];
+
+    if (!extensionElement) {
+      return 'latest';
+    }
+
+    return extensionElement.get('bindingType');
+  };
+
+  const setValue = value => {
+    const commands = [];
+
+    const businessObject = getBusinessObject(element);
+
+    // (1) ensure extension elements
+    let extensionElements = businessObject.get('extensionElements');
+
+    if (!extensionElements) {
+      extensionElements = createElement(
+        'bpmn:ExtensionElements',
+        { values: [] },
+        businessObject,
+        bpmnFactory
+      );
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: businessObject,
+          properties: { extensionElements }
+        }
+      });
+    }
+
+    // (2) ensure extension element
+    let extensionElement = getExtensionElementsList(businessObject, type)[ 0 ];
+
+    if (!extensionElement) {
+      extensionElement = createElement(
+        type,
+        {},
+        extensionElements,
+        bpmnFactory
+      );
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: extensionElements,
+          properties: {
+            values: [ ...extensionElements.get('values'), extensionElement ]
+          }
+        }
+      });
+
+    }
+
+    // (3) Update bindingType attribute
+    commands.push({
+      cmd: 'element.updateModdleProperties',
+      context: {
+        element,
+        moddleElement: extensionElement,
+        properties: {
+          bindingType: value
+        }
+      }
+    });
+
+    // (4) Execute the commands
+    commandStack.execute('properties-panel.multi-command-executor', commands);
+  };
+
+  const getOptions = () => ([
+    { value: 'latest', label: translate('latest') },
+    { value: 'deployment', label: translate('deployment') }
+  ]);
+
+  return <SelectEntry
+    element={ element }
+    id="bindingType"
+    label={ translate('Binding') }
+    getValue={ getValue }
+    setValue={ setValue }
+    getOptions={ getOptions }
+  />;
+}

--- a/src/provider/zeebe/utils/CalledElementUtil.js
+++ b/src/provider/zeebe/utils/CalledElementUtil.js
@@ -25,6 +25,12 @@ export function getProcessId(element) {
   return calledElement ? calledElement.get('processId') : '';
 }
 
+export function getBindingType(element) {
+  const calledElement = getCalledElement(element);
+
+  return calledElement ? calledElement.get('bindingType') : '';
+}
+
 export function getCalledElement(element) {
   const calledElements = getCalledElements(element);
   return calledElements[0];

--- a/test/spec/provider/zeebe/CalledDecisionProps.spec.js
+++ b/test/spec/provider/zeebe/CalledDecisionProps.spec.js
@@ -153,6 +153,98 @@ describe('provider/zeebe - CalledDecisionProps', function() {
     });
 
 
+    describe('#calledDecision.bindingType', function() {
+
+      it('should display', inject(async function(elementRegistry, selection) {
+
+        // given
+        const businessRuleTask = elementRegistry.get('BusinessRuleTask_1');
+
+        // assume
+        const bindingType = getBindingType(businessRuleTask);
+
+        expect(bindingType).to.equal('latest');
+
+        // when
+        await act(() => {
+          selection.select(businessRuleTask);
+        });
+
+        const bindingTypeSelect = domQuery('select[name=bindingType]', container);
+
+        // then
+        expect(bindingTypeSelect).to.exist;
+
+        expect(bindingTypeSelect.value).to.equal('latest');
+      }));
+
+
+      it('should not display', inject(async function(elementRegistry, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        // when
+        await act(() => {
+          selection.select(task);
+        });
+
+        const bindingTypeSelect = domQuery('select[name=bindingType]', container);
+
+        // then
+        expect(bindingTypeSelect).not.to.exist;
+      }));
+
+
+      it('should update', inject(async function(elementRegistry, selection) {
+
+        // given
+        const businessRuleTask = elementRegistry.get('BusinessRuleTask_1');
+
+        await act(() => {
+          selection.select(businessRuleTask);
+        });
+
+        const bindingTypeSelect = domQuery('select[name=bindingType]', container);
+
+        // when
+        changeInput(bindingTypeSelect, 'deployment');
+
+        // then
+        const bindingType = getBindingType(businessRuleTask);
+
+        expect(bindingType).to.equal('deployment');
+      }));
+
+
+      it('should update on external change',
+        inject(async function(elementRegistry, selection, commandStack) {
+
+          // given
+          const businessRuleTask = elementRegistry.get('BusinessRuleTask_1'),
+                originalValue = getBindingType(businessRuleTask);
+
+          await act(() => {
+            selection.select(businessRuleTask);
+          });
+
+          const bindingTypeSelect = domQuery('select[name=bindingType]', container);
+
+          changeInput(bindingTypeSelect, 'deployment');
+
+          // when
+          await act(() => {
+            commandStack.undo();
+          });
+
+          // then
+          expect(getBindingType(businessRuleTask)).to.eql(originalValue);
+        })
+      );
+
+    });
+
+
     describe('#calledDecision.resultVariable', function() {
 
       it('should display', inject(async function(elementRegistry, selection) {
@@ -253,6 +345,12 @@ export function getDecisionId(element) {
   const calledDecision = getCalledDecision(element);
 
   return calledDecision ? calledDecision.get('decisionId') : '';
+}
+
+export function getBindingType(element) {
+  const calledDecision = getCalledDecision(element);
+
+  return calledDecision ? calledDecision.get('bindingType') : '';
 }
 
 export function getResultVariable(element) {

--- a/test/spec/provider/zeebe/Forms.spec.js
+++ b/test/spec/provider/zeebe/Forms.spec.js
@@ -476,6 +476,70 @@ describe('provider/zeebe - Forms', function() {
       expectFormId(userTask, initialFormId);
     }));
 
+
+    describe('binding type', function() {
+
+      it('should display', inject(async function(elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const bindingTypeSelect = getBindingTypeSelect(container);
+
+        // then
+        expect(bindingTypeSelect).to.exist;
+      }));
+
+
+      it('should update', inject(async function(elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const bindingTypeSelect = getBindingTypeSelect(container);
+
+        // when
+        changeInput(bindingTypeSelect, 'deployment');
+
+        // then
+        expectBindingType(userTask, 'deployment');
+      }));
+
+
+      it('should update on external change', inject(async function(commandStack, elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const bindingTypeSelect = getBindingTypeSelect(container);
+        const initialBindingType = bindingTypeSelect.value;
+
+        changeInput(bindingTypeSelect, 'deployment');
+        expectBindingType(userTask, 'deployment');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        expectBindingType(userTask, initialBindingType);
+      }));
+
+    });
+
   });
 
 
@@ -675,6 +739,7 @@ describe('provider/zeebe - Forms', function() {
       expectExternalReference(userTask, initialFormKey);
     }));
   });
+
 });
 
 
@@ -700,11 +765,22 @@ function getFormTypeSelect(container) {
   return domQuery('select[name=formType]', container);
 }
 
+function getBindingTypeSelect(container) {
+  return domQuery('select[name=bindingType]', container);
+}
+
 function expectFormId(element, expected) {
   const formDefinition = getFormDefinition(element);
 
   expect(formDefinition).to.exist;
   expect(formDefinition.get('formId')).to.eql(expected);
+}
+
+function expectBindingType(element, expected) {
+  const formDefinition = getFormDefinition(element);
+
+  expect(formDefinition).to.exist;
+  expect(formDefinition.get('bindingType')).to.eql(expected);
 }
 
 function expectFormKey(element, expected) {

--- a/test/spec/provider/zeebe/TargetProps.spec.js
+++ b/test/spec/provider/zeebe/TargetProps.spec.js
@@ -23,6 +23,7 @@ import {
 } from 'src/utils/ExtensionElementsUtil.js';
 
 import {
+  getBindingType,
   getCalledElement,
   getProcessId
 } from 'src/provider/zeebe/utils/CalledElementUtil.js';
@@ -219,6 +220,97 @@ describe('provider/zeebe - TargetProps', function() {
 
         // then
         expect(targetProcessIdInput.value).to.eql(originalValue);
+      })
+    );
+
+  });
+
+
+  describe('bpmn:CallActivity#calledElement.bindingType', function() {
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_1');
+
+      // assume
+      const bindingType = getBindingType(callActivity);
+
+      expect(bindingType).to.equal('latest');
+
+      // when
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      const bindingTypeSelect = domQuery('select[name=bindingType]', container);
+
+      // then
+      expect(bindingTypeSelect).to.exist;
+
+      expect(bindingTypeSelect.value).to.equal('latest');
+    }));
+
+
+    it('should not display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      await act(() => {
+        selection.select(task);
+      });
+
+      const bindingTypeSelect = domQuery('select[name=bindingType]', container);
+
+      // then
+      expect(bindingTypeSelect).not.to.exist;
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_1');
+
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      const bindingTypeSelect = domQuery('select[name=bindingType]', container);
+
+      // when
+      changeInput(bindingTypeSelect, 'deployment');
+
+      // then
+      const bindingType = getBindingType(callActivity);
+
+      expect(bindingType).to.equal('deployment');
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const callActivity = elementRegistry.get('CallActivity_1'),
+              originalValue = getBindingType(callActivity);
+
+        await act(() => {
+          selection.select(callActivity);
+        });
+
+        const bindingTypeSelect = domQuery('select[name=bindingType]', container);
+        changeInput(bindingTypeSelect, 'deployment');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(getBindingType(callActivity)).to.eql(originalValue);
       })
     );
 


### PR DESCRIPTION
### Proposed Changes

* adds a _Binding_ entry to business rule tasks implemented as DMN, call activities and user tasks with linked form 

Check out the branch and run `npm start` to test.

#### Business rule tasks

![image](https://github.com/user-attachments/assets/47716e1e-a095-4c53-beb9-8f1aab3ea658)

#### Call activities

![image](https://github.com/user-attachments/assets/e65dd157-77d8-4c8f-8933-a77c6b5a0de9)

#### User tasks

![image](https://github.com/user-attachments/assets/f5886f1f-0136-455c-9171-5b502be41390)

Depends on https://github.com/camunda/camunda-bpmn-js-behaviors/pull/78
Depends on https://github.com/bpmn-io/properties-panel/pull/376

### Tooltip

![image](https://github.com/user-attachments/assets/d167e162-fa7b-42f4-9575-b9c9d0710b7d)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
---

Related to https://github.com/camunda/camunda-modeler/issues/4385