### PR TITLE
Rename type configure field to Job Type in Service Task: Task Definition

### DIFF
--- a/src/provider/zeebe/properties/TaskDefinitionProps.js
+++ b/src/provider/zeebe/properties/TaskDefinitionProps.js
@@ -125,7 +125,7 @@ function TaskDefinitionType(props) {
   return FeelEntryWithVariableContext({
     element,
     id,
-    label: translate('Type'),
+    label: translate('Job Type'),
     feel: 'optional',
     getValue,
     setValue,


### PR DESCRIPTION
### Related Issue
https://github.com/camunda/camunda-modeler/issues/3534

### Description

Renamed Type to Job Type in Service Task 