### PR TITLE
feat: support editing `zeebe:priorityDefinition`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "sinon": "^17.0.1",
         "sinon-chai": "^3.7.0",
         "webpack": "^5.93.0",
-        "zeebe-bpmn-moddle": "^1.4.0"
+        "zeebe-bpmn-moddle": "^1.5.1"
       },
       "engines": {
         "node": "*"
@@ -10213,9 +10213,9 @@
       }
     },
     "node_modules/zeebe-bpmn-moddle": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.4.0.tgz",
-      "integrity": "sha512-XSm0fMHPjQ5cmEGxga02du9arxb5NKH5ve7VQ0LFSes4wGcrZ/oJjaR3NlBqH6xTTD3g+Mcbh45+yesydPUQPg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.5.1.tgz",
+      "integrity": "sha512-20dqDop32YdjqyVLZB3Vhh8oq+VKVcmOPNGRUkW6m1kJOtkR/abZSPdqiMtjY310tkagMS56ocZB2yW8itMOHQ==",
       "dev": true
     },
     "node_modules/zod": {
@@ -17793,9 +17793,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.4.0.tgz",
-      "integrity": "sha512-XSm0fMHPjQ5cmEGxga02du9arxb5NKH5ve7VQ0LFSes4wGcrZ/oJjaR3NlBqH6xTTD3g+Mcbh45+yesydPUQPg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.5.1.tgz",
+      "integrity": "sha512-20dqDop32YdjqyVLZB3Vhh8oq+VKVcmOPNGRUkW6m1kJOtkR/abZSPdqiMtjY310tkagMS56ocZB2yW8itMOHQ==",
       "dev": true
     },
     "zod": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
     "webpack": "^5.93.0",
-    "zeebe-bpmn-moddle": "^1.4.0"
+    "zeebe-bpmn-moddle": "^1.5.1"
   },
   "peerDependencies": {
     "@bpmn-io/properties-panel": ">= 3.7",

--- a/src/contextProvider/zeebe/TooltipProvider.js
+++ b/src/contextProvider/zeebe/TooltipProvider.js
@@ -295,6 +295,17 @@ const TooltipProvider = {
         </p>
       </div>
     );
+  },
+  'priorityDefinitionPriority': (element) => {
+
+    const translate = useService('translate');
+
+    return (
+      <div>
+        <p>{ translate('An integer value that can range from 0 to 100, where a higher value indicates a higher priority.') }</p>
+        <p>{ translate('If unset, the default value is 50.') }</p>
+      </div>
+    );
   }
 };
 

--- a/src/provider/zeebe/ZeebePropertiesProvider.js
+++ b/src/provider/zeebe/ZeebePropertiesProvider.js
@@ -16,6 +16,7 @@ import {
   MultiInstanceProps,
   OutputPropagationProps,
   OutputProps,
+  PriorityDefinitionProps,
   ScriptImplementationProps,
   ScriptProps,
   SignalProps,
@@ -293,7 +294,8 @@ function AssignmentDefinitionGroup(element, injector) {
     label: translate('Assignment'),
     entries: [
       ...AssignmentDefinitionProps({ element }),
-      ...TaskScheduleProps({ element })
+      ...TaskScheduleProps({ element }),
+      ...PriorityDefinitionProps({ element })
     ],
     component: Group
   };

--- a/src/provider/zeebe/properties/PriorityDefinitionProps.js
+++ b/src/provider/zeebe/properties/PriorityDefinitionProps.js
@@ -1,0 +1,155 @@
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import { isFeelEntryEdited } from '@bpmn-io/properties-panel';
+
+import {
+  getExtensionElementsList
+} from '../../../utils/ExtensionElementsUtil';
+
+import {
+  createElement
+} from '../../../utils/ElementUtil';
+
+import {
+  useService
+} from '../../../hooks';
+
+import { FeelEntryWithVariableContext } from '../../../entries/FeelEntryWithContext';
+
+
+export function PriorityDefinitionProps(props) {
+  const {
+    element
+  } = props;
+
+  if (!is(element, 'bpmn:UserTask')) {
+    return [];
+  }
+
+  return [
+    {
+      id: 'priorityDefinitionPriority',
+      component: Priority,
+      isEdited: isFeelEntryEdited
+    }
+  ];
+}
+
+function Priority(props) {
+  const {
+    element
+  } = props;
+
+  const commandStack = useService('commandStack');
+  const bpmnFactory = useService('bpmnFactory');
+  const translate = useService('translate');
+  const debounce = useService('debounceInput');
+
+  const getValue = () => {
+    return (getPriorityDefinition(element) || {}).priority;
+  };
+
+  const setValue = (value) => {
+    const commands = [];
+
+    const businessObject = getBusinessObject(element);
+
+    let extensionElements = businessObject.get('extensionElements');
+
+    // (1) ensure extension elements
+    if (!extensionElements) {
+      extensionElements = createElement(
+        'bpmn:ExtensionElements',
+        { values: [] },
+        businessObject,
+        bpmnFactory
+      );
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: businessObject,
+          properties: { extensionElements }
+        }
+      });
+    }
+
+    // (2) ensure PriorityDefinition
+    let priorityDefinition = getPriorityDefinition(element);
+    const isNullValue = value === null || value === '' || value === undefined;
+
+    if (priorityDefinition && isNullValue) {
+
+      // (3a) remove priority definition if it exists and priority is set to null
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: extensionElements,
+          properties: {
+            values: extensionElements.get('values').filter(v => v !== priorityDefinition)
+          }
+        }
+      });
+
+    } else if (priorityDefinition && !isNullValue) {
+
+      // (3b) update priority definition if it already exists
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: priorityDefinition,
+          properties: { priority: value }
+        }
+      });
+
+    } else if (!priorityDefinition && !isNullValue) {
+
+      // (3c) create priority definition if it does not exist
+      priorityDefinition = createElement(
+        'zeebe:PriorityDefinition',
+        { priority: value },
+        extensionElements,
+        bpmnFactory
+      );
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: extensionElements,
+          properties: {
+            values: [ ...extensionElements.get('values'), priorityDefinition ]
+          }
+        }
+      });
+    }
+
+    // (4) commit all updates
+    commandStack.execute('properties-panel.multi-command-executor', commands);
+  };
+
+  return FeelEntryWithVariableContext({
+    element,
+    id: 'priorityDefinitionPriority',
+    label: translate('Priority'),
+    feel: 'optional',
+    getValue,
+    setValue,
+    debounce
+  });
+}
+
+
+// helper ///////////////////////
+
+export function getPriorityDefinition(element) {
+  const businessObject = getBusinessObject(element);
+
+  return getExtensionElementsList(businessObject, 'zeebe:PriorityDefinition')[0];
+}

--- a/src/provider/zeebe/properties/index.js
+++ b/src/provider/zeebe/properties/index.js
@@ -13,6 +13,7 @@ export { MessageProps } from './MessageProps';
 export { MultiInstanceProps } from './MultiInstanceProps';
 export { OutputPropagationProps } from './OutputPropagationProps';
 export { OutputProps } from './OutputProps';
+export { PriorityDefinitionProps } from './PriorityDefinitionProps';
 export { ScriptImplementationProps } from './ScriptImplementationProps';
 export { ScriptProps } from './ScriptProps';
 export { SignalProps } from './SignalProps';

--- a/test/spec/provider/zeebe/PriorityDefinitionProps.bpmn
+++ b/test/spec/provider/zeebe/PriorityDefinitionProps.bpmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0sp2msp" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.8.0-rc.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <bpmn:process id="Process_08jq0zy" isExecutable="true">
+    <bpmn:serviceTask id="ServiceTask_1" name="ServiceTask_1" />
+    <bpmn:userTask id="UserTask_1" name="UserTask_1">
+      <bpmn:extensionElements>
+        <zeebe:PriorityDefinition priority="=myPriorityValue" />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+    <bpmn:userTask id="UserTask_2" name="UserTask_2" />
+    <bpmn:userTask id="UserTask_3" name="UserTask_3">
+      <bpmn:extensionElements>
+        <zeebe:assignmentDefinition assignee="foo" />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+    <bpmn:userTask id="UserTask_4" name="UserTask_4">
+      <bpmn:extensionElements>
+        <zeebe:PriorityDefinition priority="=myPriorityValue" />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_08jq0zy">
+      <bpmndi:BPMNShape id="Activity_1c08csw_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0618037_di" bpmnElement="UserTask_1">
+        <dc:Bounds x="280" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_13kad5p_di" bpmnElement="UserTask_2">
+        <dc:Bounds x="400" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1puoc3v_di" bpmnElement="UserTask_3">
+        <dc:Bounds x="520" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0zxgguv_di" bpmnElement="UserTask_4">
+        <dc:Bounds x="280" y="180" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/zeebe/PriorityDefinitionProps.spec.js
+++ b/test/spec/provider/zeebe/PriorityDefinitionProps.spec.js
@@ -1,0 +1,232 @@
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  act
+} from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  changeInput,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import { getPriorityDefinition } from 'src/provider/zeebe/properties/PriorityDefinitionProps';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/render';
+
+import ZeebePropertiesProvider from 'src/provider/zeebe';
+
+import BehaviorsModule from 'camunda-bpmn-js-behaviors/lib/camunda-cloud';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import diagramXML from './PriorityDefinitionProps.bpmn';
+import { setEditorValue } from '../../../TestHelper';
+
+
+describe('provider/zeebe - PriorityDefinitionProps', function() {
+
+  const testModules = [
+    CoreModule,
+    SelectionModule,
+    ModelingModule,
+    BpmnPropertiesPanel,
+    ZeebePropertiesProvider,
+    BehaviorsModule
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    modules: testModules,
+    moddleExtensions,
+    debounceInput: false
+  }));
+
+
+  describe('zeebe:priorityDefinition', function() {
+
+    it('should NOT display for service task', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const priorityInput = domQuery('input[name=priorityDefinitionPriority]', container);
+
+      // then
+      expect(priorityInput).to.not.exist;
+    }));
+
+
+    it('should display for user task', inject(async function(elementRegistry, selection) {
+
+      // given
+      const userTask = elementRegistry.get('UserTask_1');
+
+      await act(() => {
+        selection.select(userTask);
+      });
+
+      // when
+      const entry = domQuery('[data-entry-id="priorityDefinitionPriority"]', container);
+
+      // then
+      expect(entry).to.exist;
+
+      // is FEEL input
+      const input = domQuery('[role="textbox"]', entry);
+      expect(input).to.exist;
+
+      const priorityDefinition = getPriorityDefinition(userTask);
+      const feelExpression = priorityDefinition.get('priority').substring(1);
+
+      expect(input.textContent).to.equal(feelExpression);
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const userTask = elementRegistry.get('UserTask_1');
+
+      await act(() => {
+        selection.select(userTask);
+      });
+
+      // when
+      const priorityInput = domQuery('[data-entry-id="priorityDefinitionPriority"] [role="textbox"]', container);
+
+      await setEditorValue(priorityInput, 'newValue');
+
+      // then
+      // keep FEEL configuration
+      expect(getPriorityDefinition(userTask).get('priority')).to.eql('=newValue');
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const userTask = elementRegistry.get('UserTask_1');
+        const originalValue = getPriorityDefinition(userTask).get('priority');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+        const priorityInput = domQuery('[data-entry-id="priorityDefinitionPriority"] [role="textbox"]', container);
+        await setEditorValue(priorityInput, 'newValue');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect('=' + priorityInput.textContent).to.eql(originalValue);
+      })
+    );
+
+
+    it('should create non-existing extension elements and priority definition',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('UserTask_2');
+
+        // assume
+        expect(getBusinessObject(userTask).get('extensionElements')).to.not.exist;
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        // when
+        const priorityInput = domQuery('input[name=priorityDefinitionPriority]', container);
+        changeInput(priorityInput, 'newValue');
+
+        // then
+        expect(getBusinessObject(userTask).get('extensionElements')).to.exist;
+      })
+    );
+
+
+    it('should re-use existing extension elements, creating new priority definition',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('UserTask_3');
+
+        // assume
+        expect(getBusinessObject(userTask).get('extensionElements')).to.exist;
+        expect(getPriorityDefinition(userTask)).not.to.exist;
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        // when
+        const priorityInput = domQuery('input[name=priorityDefinitionPriority]', container);
+        changeInput(priorityInput, 'newValue');
+
+        // then
+        const extensionElements = getBusinessObject(userTask).get('extensionElements');
+        expect(getPriorityDefinition(userTask).get('priority')).to.eql('newValue');
+        expect(extensionElements.values).to.have.length(2);
+      })
+    );
+
+  });
+
+  describe('integration', function() {
+
+    describe('removing priority definition when empty', function() {
+
+      it('removing zeebe:priority', inject(async function(elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('UserTask_4');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        // when
+        const priorityInput = domQuery('[data-entry-id="priorityDefinitionPriority"] [role="textbox"]', container);
+
+        await setEditorValue(priorityInput, '');
+
+        // then
+        expect(getPriorityDefinition(userTask)).not.to.exist;
+      }));
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
### Proposed Changes

Adds an entry in the properties panel to edit the `zeebe:priorityDefinition::priority` of a user task. Should have a tooltip with some info and a (currently empty) link to docs. 

Closes #1069

![image](https://github.com/user-attachments/assets/35ee522c-dd02-4850-9415-586bd52eb3bc)

`npx @bpmn-io/sr bpmn-io/bpmn-js#main -l bpmn-io/bpmn-js-properties-panel#1069-support-priority-editing`
