### PR TITLE
Don't create new `Binding` and `Version tag` components on every render

### DIFF
--- a/src/provider/zeebe/properties/CalledDecisionProps.js
+++ b/src/provider/zeebe/properties/CalledDecisionProps.js
@@ -27,6 +27,9 @@ import { FeelEntryWithVariableContext } from '../../../entries/FeelEntryWithCont
 
 import { withProps } from '../../HOCs/withProps.js';
 
+const CalledDecisionBinding = withProps(Binding, { type: 'zeebe:CalledDecision' }),
+      CalledDecisionVersionTag = withProps(VersionTag, { type: 'zeebe:CalledDecision' });
+
 
 export function CalledDecisionProps(props) {
   const {
@@ -45,7 +48,7 @@ export function CalledDecisionProps(props) {
     },
     {
       id: 'bindingType',
-      component: withProps(Binding, { type: 'zeebe:CalledDecision' }),
+      component: CalledDecisionBinding,
       isEdited: isSelectEntryEdited
     }
   ];
@@ -53,7 +56,7 @@ export function CalledDecisionProps(props) {
   if (getBindingType(element, 'zeebe:CalledDecision') === 'versionTag') {
     entries.push({
       id: 'versionTag',
-      component: withProps(VersionTag, { type: 'zeebe:CalledDecision' }),
+      component: CalledDecisionVersionTag,
       isEdited: isTextFieldEntryEdited
     });
   }

--- a/src/provider/zeebe/properties/FormProps.js
+++ b/src/provider/zeebe/properties/FormProps.js
@@ -40,6 +40,9 @@ import {
 
 import { withProps } from '../../HOCs';
 
+const FormDefinitionBinding = withProps(Binding, { type: 'zeebe:FormDefinition' }),
+      FormDefinitionVersionTag = withProps(VersionTag, { type: 'zeebe:FormDefinition' });
+
 const NONE_VALUE = 'none';
 
 
@@ -87,14 +90,14 @@ export function FormProps(props) {
   if (formType === FORM_TYPES.CAMUNDA_FORM_LINKED) {
     entries.push({
       id: 'bindingType',
-      component: withProps(Binding, { type: 'zeebe:FormDefinition' }),
+      component: FormDefinitionBinding,
       isEdited: isSelectEntryEdited
     });
 
     if (getBindingType(element, 'zeebe:FormDefinition') === 'versionTag') {
       entries.push({
         id: 'versionTag',
-        component: withProps(VersionTag, { type: 'zeebe:FormDefinition' }),
+        component: FormDefinitionVersionTag,
         isEdited: isTextFieldEntryEdited
       });
     }

--- a/src/provider/zeebe/properties/TargetProps.js
+++ b/src/provider/zeebe/properties/TargetProps.js
@@ -27,6 +27,9 @@ import { FeelEntryWithVariableContext } from '../../../entries/FeelEntryWithCont
 
 import { withProps } from '../../HOCs/withProps.js';
 
+const CalledElementBinding = withProps(Binding, { type: 'zeebe:CalledElement' }),
+      CalledElementVersionTag = withProps(VersionTag, { type: 'zeebe:CalledElement' });
+
 
 export function TargetProps(props) {
   const {
@@ -45,7 +48,7 @@ export function TargetProps(props) {
     },
     {
       id: 'bindingType',
-      component: withProps(Binding, { type: 'zeebe:CalledElement' }),
+      component: CalledElementBinding,
       isEdited: isSelectEntryEdited
     }
   ];
@@ -53,7 +56,7 @@ export function TargetProps(props) {
   if (getBindingType(element, 'zeebe:CalledElement') === 'versionTag') {
     entries.push({
       id: 'versionTag',
-      component: withProps(VersionTag, { type: 'zeebe:CalledElement' }),
+      component: CalledElementVersionTag,
       isEdited: isTextFieldEntryEdited
     });
   }


### PR DESCRIPTION
### Proposed Changes

Creates the component only once so that React doesn't replace it in the DOM on every render assuming it's a different component.

![brave_7UumTgsygU](https://github.com/user-attachments/assets/0bfbae02-b384-4d4d-b541-2de2afc3d562)

---

Related to https://github.com/camunda/camunda-modeler/issues/4513