### PR TITLE
feat: add task listeners for Zeebe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: support Zeebe task listeners ([#1088](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1088))
 * `DEPS`: update to `zeebe-bpmn-moddle@1.7.0`
+* `DEPS`: update to `camunda-bpmn-js-behaviors@1.7.1`
 
 ## 5.26.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: support Zeebe task listeners ([#1088](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1088))
+* `DEPS`: update to `zeebe-bpmn-moddle@1.7.0`
 
 ## 5.26.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: support Zeebe task listeners ([#1088](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1088))
+
 ## 5.26.0
 
 * `FEAT`: make FEEL popup links configurable ([#1083](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1083))

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "sinon": "^17.0.1",
         "sinon-chai": "^3.7.0",
         "webpack": "^5.95.0",
-        "zeebe-bpmn-moddle": "^1.6.0"
+        "zeebe-bpmn-moddle": "^1.7.0"
       },
       "engines": {
         "node": "*"
@@ -10203,10 +10203,11 @@
       }
     },
     "node_modules/zeebe-bpmn-moddle": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.6.0.tgz",
-      "integrity": "sha512-vjPeJoLQs7UkC5m27K0CyZkQMEAI8GsISU6TcfD2n/SzqkhJ6tubvcIabLRAhreaiuHY26MjtSVXw1LRVgd7Iw==",
-      "dev": true
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.7.0.tgz",
+      "integrity": "sha512-eZ6OXSt0c4n9V/oN/46gTlwDIS3GhWQLt9jbM5uS/YryB4yN8wdrrKrtw+TpyNy0SSKWXNDHyC83nCA2blPO3Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.23.8",
@@ -17671,9 +17672,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.6.0.tgz",
-      "integrity": "sha512-vjPeJoLQs7UkC5m27K0CyZkQMEAI8GsISU6TcfD2n/SzqkhJ6tubvcIabLRAhreaiuHY26MjtSVXw1LRVgd7Iw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.7.0.tgz",
+      "integrity": "sha512-eZ6OXSt0c4n9V/oN/46gTlwDIS3GhWQLt9jbM5uS/YryB4yN8wdrrKrtw+TpyNy0SSKWXNDHyC83nCA2blPO3Q==",
       "dev": true
     },
     "zod": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "bpmn-js": "^17.11.1",
         "bpmn-js-create-append-anything": "^0.5.2",
         "bpmn-moddle": "^9.0.1",
-        "camunda-bpmn-js-behaviors": "^1.6.1",
+        "camunda-bpmn-js-behaviors": "^1.7.1",
         "camunda-bpmn-moddle": "^7.0.1",
         "chai": "^4.5.0",
         "cross-env": "^7.0.3",
@@ -2849,10 +2849,11 @@
       }
     },
     "node_modules/camunda-bpmn-js-behaviors": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.6.1.tgz",
-      "integrity": "sha512-nvfFmL2wrCi5IApt4NcYcpRHJx4nPS8AHSUq9ckyq9FiDeIwASafsvaEYY0r+FeobqUY1deYNYsKjhSYd4N0kQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.7.1.tgz",
+      "integrity": "sha512-hWgMbkwsuzDV274w/XZ6wF6vby9+RaJj7n175NTusfumZtQoMJMDm5/zw/gjeEkf+/3nkZ18TMid5FIe/H6Vhg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ids": "^1.0.0",
         "min-dash": "^4.0.0"
@@ -12251,9 +12252,9 @@
       "dev": true
     },
     "camunda-bpmn-js-behaviors": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.6.1.tgz",
-      "integrity": "sha512-nvfFmL2wrCi5IApt4NcYcpRHJx4nPS8AHSUq9ckyq9FiDeIwASafsvaEYY0r+FeobqUY1deYNYsKjhSYd4N0kQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.7.1.tgz",
+      "integrity": "sha512-hWgMbkwsuzDV274w/XZ6wF6vby9+RaJj7n175NTusfumZtQoMJMDm5/zw/gjeEkf+/3nkZ18TMid5FIe/H6Vhg==",
       "dev": true,
       "requires": {
         "ids": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "bpmn-js": "^17.11.1",
     "bpmn-js-create-append-anything": "^0.5.2",
     "bpmn-moddle": "^9.0.1",
-    "camunda-bpmn-js-behaviors": "^1.6.1",
+    "camunda-bpmn-js-behaviors": "^1.7.1",
     "camunda-bpmn-moddle": "^7.0.1",
     "chai": "^4.5.0",
     "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
     "webpack": "^5.95.0",
-    "zeebe-bpmn-moddle": "^1.6.0"
+    "zeebe-bpmn-moddle": "^1.7.0"
   },
   "peerDependencies": {
     "@bpmn-io/properties-panel": ">= 3.7",

--- a/src/provider/zeebe/ZeebePropertiesProvider.js
+++ b/src/provider/zeebe/ZeebePropertiesProvider.js
@@ -24,6 +24,7 @@ import {
   SignalProps,
   TargetProps,
   TaskDefinitionProps,
+  TaskListenersProps,
   TaskScheduleProps,
   TimerProps,
   UserTaskImplementationProps,
@@ -56,6 +57,7 @@ const ZEEBE_GROUPS = [
   OutputPropagationGroup,
   OutputGroup,
   HeaderGroup,
+  TaskListenersGroup,
   ExecutionListenersGroup,
   ExtensionPropertiesGroup
 ];
@@ -314,6 +316,22 @@ function ExecutionListenersGroup(element, injector) {
     id: 'Zeebe__ExecutionListeners',
     component: ListGroup,
     ...ExecutionListenersProps({ element, injector })
+  };
+
+  if (group.items) {
+    return group;
+  }
+
+  return null;
+}
+
+function TaskListenersGroup(element, injector) {
+  const translate = injector.get('translate');
+  const group = {
+    label: translate('Task listeners'),
+    id: 'Zeebe__TaskListeners',
+    component: ListGroup,
+    ...TaskListenersProps({ element, injector })
   };
 
   if (group.items) {

--- a/src/provider/zeebe/properties/TaskListener.js
+++ b/src/provider/zeebe/properties/TaskListener.js
@@ -1,60 +1,46 @@
 import { SelectEntry } from '@bpmn-io/properties-panel';
 
 import {
-  is,
-  isAny
-} from 'bpmn-js/lib/util/ModelUtil';
-
-import {
   useService
 } from '../../../hooks';
 
-import {
-  getErrorEventDefinition
-} from '../../../utils/EventDefinitionUtil';
-
 import { ListenerType, Retries } from './shared/Listener';
 
+export const EVENT_TYPE = [ 'complete', 'assignment' ];
 
 export const EVENT_TO_LABEL = {
-  'start': 'Start',
-  'end': 'End'
+  complete: 'Complete',
+  assignment: 'Assignment'
 };
 
-export function ExecutionListenerEntries(props) {
+export function TaskListenerEntries(props) {
 
   const {
-    element,
     idPrefix,
     listener
   } = props;
 
-  const eventTypes = getEventTypes(element);
-
-  const entries = eventTypes.length > 1 ? [
+  return [
     {
       id: idPrefix + '-eventType',
       component: EventType,
       idPrefix,
       listener,
-      eventTypes
+      eventTypes: EVENT_TYPE
+    },
+    {
+      id: idPrefix + '-listenerType',
+      component: ListenerType,
+      idPrefix,
+      listener
+    },
+    {
+      id: idPrefix + '-retries',
+      component: Retries,
+      idPrefix,
+      listener
     }
-  ] : [];
-
-  entries.push({
-    id: idPrefix + '-listenerType',
-    component: ListenerType,
-    idPrefix,
-    listener
-  },
-  {
-    id: idPrefix + '-retries',
-    component: Retries,
-    idPrefix,
-    listener
-  });
-
-  return entries;
+  ];
 }
 
 function EventType(props) {
@@ -95,18 +81,4 @@ function EventType(props) {
   });
 }
 
-export function getEventTypes(element) {
-  if (isAny(element, [ 'bpmn:BoundaryEvent', 'bpmn:StartEvent' ])) {
-    return [ 'end' ];
-  }
 
-  if (is(element, 'bpmn:EndEvent') && getErrorEventDefinition(element)) {
-    return [ 'start' ];
-  }
-
-  if (is(element, 'bpmn:Gateway')) {
-    return [ 'start' ];
-  }
-
-  return [ 'start', 'end' ];
-}

--- a/src/provider/zeebe/properties/TaskListenersProps.js
+++ b/src/provider/zeebe/properties/TaskListenersProps.js
@@ -1,0 +1,193 @@
+import {
+  getBusinessObject,
+  is,
+  isAny
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import { without } from 'min-dash';
+
+import { TaskListenerEntries, EVENT_TYPE, EVENT_TO_LABEL } from './TaskListener';
+
+import {
+  createElement
+} from '../../../utils/ElementUtil';
+
+import {
+  getExtensionElementsList
+} from '../../../utils/ExtensionElementsUtil';
+
+import { isZeebeUserTask } from '../utils/FormUtil';
+
+
+export function TaskListenersProps({ element, injector }) {
+  let businessObject = getRelevantBusinessObject(element);
+
+  // not allowed in empty pools
+  if (!businessObject) {
+    return;
+  }
+
+  if (!isZeebeUserTask(element)) {
+    return;
+  }
+
+  const moddle = injector.get('moddle');
+  if (!canHaveTaskListeners(businessObject, moddle)) {
+    return;
+  }
+
+  const listeners = getListenersList(businessObject) || [];
+
+  const bpmnFactory = injector.get('bpmnFactory'),
+        commandStack = injector.get('commandStack'),
+        modeling = injector.get('modeling'),
+        translate = injector.get('translate');
+
+  const items = listeners.map((listener, index) => {
+    const id = element.id + '-taskListener-' + index;
+    const type = listener.get('type') || '<no type>';
+
+    return {
+      id,
+      label: translate(`${EVENT_TO_LABEL[listener.get('eventType')]}: {type}`, { type }),
+      entries: TaskListenerEntries({
+        idPrefix: id,
+        listener
+      }),
+      autoFocusEntry: id + '-eventType',
+      remove: removeFactory({ modeling, element, listener })
+    };
+  });
+
+  return {
+    items,
+    add: addFactory({ bpmnFactory, commandStack, element })
+  };
+}
+
+function removeFactory({ modeling, element, listener }) {
+  return function(event) {
+    event.stopPropagation();
+
+    const businessObject = getRelevantBusinessObject(element);
+    const container = getTaskListenersContainer(businessObject);
+
+    if (!container) {
+      return;
+    }
+
+    const listeners = without(container.get('listeners'), listener);
+
+    modeling.updateModdleProperties(element, container, { listeners });
+  };
+}
+
+function addFactory({ bpmnFactory, commandStack, element }) {
+  return function(event) {
+    event.stopPropagation();
+
+    let commands = [];
+
+    const businessObject = getRelevantBusinessObject(element);
+
+    let extensionElements = businessObject.get('extensionElements');
+
+    // (1) ensure extension elements
+    if (!extensionElements) {
+      extensionElements = createElement(
+        'bpmn:ExtensionElements',
+        { values: [] },
+        businessObject,
+        bpmnFactory
+      );
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: businessObject,
+          properties: { extensionElements }
+        }
+      });
+    }
+
+    // (2) ensure zeebe:TaskListeners
+    let taskListeners = getTaskListenersContainer(businessObject);
+
+    if (!taskListeners) {
+      const parent = extensionElements;
+
+      taskListeners = createElement('zeebe:TaskListeners', {
+        listeners: []
+      }, parent, bpmnFactory);
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: extensionElements,
+          properties: {
+            values: [ ...extensionElements.get('values'), taskListeners ]
+          }
+        }
+      });
+    }
+
+    // (3) create zeebe:TaskListener
+    const TaskListener = createElement(
+      'zeebe:TaskListener', getDefaultListenerProps(), taskListeners, bpmnFactory
+    );
+
+    // (4) add TaskListener to list
+    commands.push({
+      cmd: 'element.updateModdleProperties',
+      context: {
+        element,
+        moddleElement: taskListeners,
+        properties: {
+          listeners: [ ...taskListeners.get('listeners'), TaskListener ]
+        }
+      }
+    });
+
+    // (5) commit all updates
+    commandStack.execute('properties-panel.multi-command-executor', commands);
+  };
+}
+
+
+// helper //////////////////
+
+function getRelevantBusinessObject(element) {
+  let businessObject = getBusinessObject(element);
+
+  if (is(element, 'bpmn:Participant')) {
+    return businessObject.get('processRef');
+  }
+
+  return businessObject;
+}
+
+function getTaskListenersContainer(element) {
+  const TaskListeners = getExtensionElementsList(element, 'zeebe:TaskListeners');
+
+  return TaskListeners && TaskListeners[0];
+}
+
+function getListenersList(element) {
+  const TaskListeners = getTaskListenersContainer(element);
+
+  return TaskListeners && TaskListeners.get('listeners');
+}
+
+function canHaveTaskListeners(bo, moddle) {
+  const TaskListenersDescriptor = moddle.getTypeDescriptor('zeebe:TaskListeners');
+
+  return isAny(bo, TaskListenersDescriptor.meta.allowedIn);
+}
+
+function getDefaultListenerProps() {
+  return {
+    eventType: EVENT_TYPE[0]
+  };
+}

--- a/src/provider/zeebe/properties/index.js
+++ b/src/provider/zeebe/properties/index.js
@@ -19,6 +19,7 @@ export { ScriptProps } from './ScriptProps';
 export { SignalProps } from './SignalProps';
 export { TargetProps } from './TargetProps';
 export { TaskDefinitionProps } from './TaskDefinitionProps';
+export { TaskListenersProps } from './TaskListenersProps';
 export { TaskScheduleProps } from './TaskScheduleProps';
 export { TimerProps } from './TimerProps';
 export { UserTaskImplementationProps } from './UserTaskImplementationProps';

--- a/src/provider/zeebe/properties/shared/Listener.js
+++ b/src/provider/zeebe/properties/shared/Listener.js
@@ -1,0 +1,67 @@
+import { FeelEntryWithVariableContext } from '../../../../entries/FeelEntryWithContext';
+
+import { useService } from '../../../../hooks';
+
+export function ListenerType(props) {
+  const {
+    idPrefix,
+    element,
+    listener
+  } = props;
+
+  const modeling = useService('modeling');
+  const translate = useService('translate');
+  const debounce = useService('debounceInput');
+
+  const setValue = (value) => {
+    modeling.updateModdleProperties(element, listener, {
+      type: value
+    });
+  };
+
+  const getValue = () => {
+    return listener.get('type');
+  };
+
+  return FeelEntryWithVariableContext({
+    element,
+    id: idPrefix + '-listenerType',
+    label: translate('Listener type'),
+    getValue,
+    setValue,
+    debounce,
+    feel: 'optional'
+  });
+}
+
+export function Retries(props) {
+  const {
+    idPrefix,
+    element,
+    listener
+  } = props;
+
+  const modeling = useService('modeling');
+  const translate = useService('translate');
+  const debounce = useService('debounceInput');
+
+  const setValue = (value) => {
+    modeling.updateModdleProperties(element, listener, {
+      retries: value
+    });
+  };
+
+  const getValue = () => {
+    return listener.get('retries');
+  };
+
+  return FeelEntryWithVariableContext({
+    element,
+    id: idPrefix + '-retries',
+    label: translate('Retries'),
+    getValue,
+    setValue,
+    debounce,
+    feel: 'optional'
+  });
+}

--- a/test/spec/provider/zeebe/TaskListenerProps.bpmn
+++ b/test/spec/provider/zeebe/TaskListenerProps.bpmn
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0qh9wc7" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:userTaskPlatform="Camunda Cloud" modeler:userTaskPlatformVersion="8.0.0">
+  <bpmn:process id="ZeebePropertiesTest" name="Zeebe Properties Test" isExecutable="true">
+    <bpmn:userTask id="UserTask">
+      <bpmn:extensionElements>
+        <zeebe:taskListeners>
+          <zeebe:taskListener eventType="assignment" retries="2" type="assign_listener" />
+        </zeebe:taskListeners>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+    <bpmn:userTask id="NonZeebeUserTask">
+      <bpmn:extensionElements>
+        <zeebe:taskListeners>
+          <zeebe:taskListener eventType="assignment" retries="2" type="assign_listener" />
+        </zeebe:taskListeners>
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+    <bpmn:subProcess id="SubProcess">
+      <bpmn:userTask id="UserTaskSubprocess">
+        <bpmn:extensionElements>
+          <zeebe:taskListeners>
+            <zeebe:taskListener eventType="assignment" retries="4" type="assign_listener" />
+            <zeebe:taskListener eventType="complete" retries="4" type="complete_listener" />
+          </zeebe:taskListeners>
+          <zeebe:userTask />
+        </bpmn:extensionElements>
+      </bpmn:userTask>
+      <bpmn:boundaryEvent id="CompensationBoundaryEvent" attachedToRef="SubProcess">
+        <bpmn:compensateEventDefinition id="Compensate" />
+        <bpmn:extensionElements>
+          <zeebe:taskListeners>
+            <zeebe:taskListener eventType="assignment" retries="4" type="assign_listener" />
+          </zeebe:taskListeners>
+        </bpmn:extensionElements>
+      </bpmn:boundaryEvent>
+      <bpmn:exclusiveGateway id="Gateway">
+        <bpmn:extensionElements>
+          <zeebe:taskListeners>
+            <zeebe:taskListener eventType="complete" retries="3" type="complete_listener" />
+          </zeebe:taskListeners>
+        </bpmn:extensionElements>
+      </bpmn:exclusiveGateway>
+      <bpmn:userTask id="Empty">
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+        </bpmn:extensionElements>
+      </bpmn:userTask>
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ZeebePropertiesTest">
+      <bpmndi:BPMNShape id="UserTask_di" bpmnElement="UserTask">
+        <dc:Bounds x="160" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_di" bpmnElement="SubProcess" isExpanded="true">
+        <dc:Bounds x="160" y="510" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTaskSubprocess_di" bpmnElement="UserTaskSubprocess">
+        <dc:Bounds x="200" y="592" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ComplexGateway_di" bpmnElement="ComplexGateway">
+        <dc:Bounds x="692" y="592" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CompensationBoundaryEvent_di" bpmnElement="CompensationBoundaryEvent">
+        <dc:Bounds x="432" y="692" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Empty_di" bpmnElement="Empty">
+        <dc:Bounds x="632" y="692" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/zeebe/TaskListenerProps.spec.js
+++ b/test/spec/provider/zeebe/TaskListenerProps.spec.js
@@ -1,0 +1,446 @@
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  act
+} from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  changeInput,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery,
+  queryAll as domQueryAll
+} from 'min-dom';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/render';
+
+import ZeebePropertiesProvider from 'src/provider/zeebe';
+import BehaviorsModule from 'camunda-bpmn-js-behaviors/lib/camunda-cloud';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe.json';
+
+import diagramXML from './TaskListenerProps.bpmn';
+import { getExtensionElementsList } from 'src/utils/ExtensionElementsUtil';
+
+
+describe('provider/zeebe - TaskListenerProps', function() {
+
+  const testModules = [
+    CoreModule, SelectionModule, ModelingModule,
+    BpmnPropertiesPanel,
+    ZeebePropertiesProvider,
+    BehaviorsModule
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    modules: testModules,
+    moddleExtensions,
+    debounceInput: false
+  }));
+
+
+  it('should display for zeebe UserTask', inject(async function(elementRegistry, selection) {
+
+    // given
+    const element = elementRegistry.get('UserTask');
+
+
+    await act(() => {
+      selection.select(element);
+    });
+
+    // when
+    const group = getTaskListenersGroup(container);
+    const listItems = getListenerListItems(group);
+
+    const listeners = getListeners(element);
+
+    // then
+    expect(group).to.exist;
+    expect(listItems).to.have.length(listeners.length);
+  }));
+
+
+  it('should NOT display for non-zeebe UserTask', inject(async function(elementRegistry, selection) {
+
+    // given
+    const element = elementRegistry.get('NonZeebeUserTask');
+
+
+    await act(() => {
+      selection.select(element);
+    });
+
+    // when
+    const group = getTaskListenersGroup(container);
+
+    // then
+    expect(group).not.to.exist;
+  }));
+
+
+  for (const elementType of [
+    'CompensationBoundaryEvent',
+    'Gateway'
+  ]) {
+
+    it(`should NOT display for ${elementType}`, inject(async function(elementRegistry, selection) {
+
+      // given
+      const compensationEvent = elementRegistry.get(elementType);
+
+      await act(() => {
+        selection.select(compensationEvent);
+      });
+
+      // when
+      const group = getTaskListenersGroup(container);
+
+      // then
+      expect(group).not.to.exist;
+    }));
+  }
+
+
+  it('should display proper label', inject(async function(elementRegistry, selection) {
+
+    // given
+    const element = elementRegistry.get('UserTask');
+
+    await act(() => {
+      selection.select(element);
+    });
+
+    // when
+    const group = getTaskListenersGroup(container);
+    const label = domQuery('.bio-properties-panel-collapsible-entry-header-title', group);
+
+    // then
+    expect(label).to.have.property('textContent', 'Assignment: assign_listener');
+  }));
+
+
+  it('should add new listener', inject(async function(elementRegistry, selection) {
+
+    // given
+    const element = elementRegistry.get('UserTaskSubprocess');
+
+    await act(() => {
+      selection.select(element);
+    });
+
+    // assume
+    expect(getListeners(element)).to.have.length(2);
+
+    const group = getTaskListenersGroup(container);
+    const addEntry = domQuery('.bio-properties-panel-add-entry', group);
+
+    // when
+    await act(() => {
+      addEntry.click();
+    });
+
+    // then
+    expect(getListeners(element)).to.have.length(3);
+  }));
+
+
+  it('should re-use existing extensionElements', inject(async function(elementRegistry, selection) {
+
+    // given
+    const empty = elementRegistry.get('Empty');
+
+    await act(() => {
+      selection.select(empty);
+    });
+
+    // assume
+    expect(getBusinessObject(empty).get('extensionElements')).to.exist;
+
+    const group = getTaskListenersGroup(container);
+    const addEntry = domQuery('.bio-properties-panel-add-entry', group);
+
+    // when
+    await act(() => {
+      addEntry.click();
+    });
+
+    // then
+    expect(getBusinessObject(empty).get('extensionElements')).to.exist;
+    expect(getListeners(empty)).to.have.length(1);
+  }));
+
+
+  it('should delete listener', inject(async function(elementRegistry, selection) {
+
+    // given
+    const element = elementRegistry.get('UserTask');
+
+    await act(() => {
+      selection.select(element);
+    });
+
+    const group = getTaskListenersGroup(container);
+    const listItems = getListenerListItems(group);
+    const removeEntry = domQuery('.bio-properties-panel-remove-entry', listItems[0]);
+
+    // when
+    await act(() => {
+      removeEntry.click();
+    });
+
+    // then
+    expect(getListeners(element)).to.have.length(0);
+  }));
+
+
+  it('should update on external change',
+    inject(async function(elementRegistry, selection, commandStack) {
+
+      // given
+      const element = elementRegistry.get('UserTask');
+      const originalListeners = getListeners(element);
+
+      await act(() => {
+        selection.select(element);
+      });
+
+      const group = getTaskListenersGroup(container);
+      const addEntry = domQuery('.bio-properties-panel-add-entry', group);
+      await act(() => {
+        addEntry.click();
+      });
+
+      // when
+      await act(() => {
+        commandStack.undo();
+      });
+
+      const listItems = getListenerListItems(group);
+
+      // then
+      expect(listItems).to.have.length(originalListeners.length);
+    })
+  );
+
+
+  describe('event type', function() {
+
+    it('should use a supported event type for a new listener', inject(
+      async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('Empty');
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        const group = getTaskListenersGroup(container);
+        const addEntry = domQuery('.bio-properties-panel-add-entry', group);
+
+        // when
+        await act(() => {
+          addEntry.click();
+        });
+
+
+        // then
+        const listeners = getListeners(element);
+        const newListener = listeners[listeners.length - 1];
+
+        expect(newListener).to.have.property('eventType', 'complete');
+      })
+    );
+
+
+    it('should update value', inject(async function(elementRegistry, selection) {
+
+      // given
+      const element = elementRegistry.get('UserTask');
+
+      await act(() => {
+        selection.select(element);
+      });
+
+      const group = getTaskListenersGroup(container);
+      const eventType = getEventType(group);
+      const input = domQuery('select', eventType);
+
+      // when
+      changeInput(input, 'complete');
+
+      // then
+      const listeners = getListeners(element);
+      const listener = listeners[0];
+
+      expect(listener).to.have.property('eventType', 'complete');
+    }));
+
+
+    it('should update on external change', inject(async function(elementRegistry, selection, commandStack) {
+
+      // given
+      const element = elementRegistry.get('UserTask');
+      await act(() => {
+        selection.select(element);
+      });
+      const group = getTaskListenersGroup(container);
+      const eventType = getEventType(group);
+      const input = domQuery('select', eventType);
+      changeInput(input, 'complete');
+
+      // when
+      await act(() => {
+        commandStack.undo();
+      });
+
+      // then
+      expect(input).to.have.property('value', 'assignment');
+    }));
+  });
+
+
+  describe('listener type', function() {
+
+    it('should update value', inject(async function(elementRegistry, selection) {
+
+      // given
+      const element = elementRegistry.get('UserTask');
+
+      await act(() => {
+        selection.select(element);
+      });
+
+      const group = getTaskListenersGroup(container);
+      const input = domQuery('[name*=listenerType]', group);
+
+      // when
+      changeInput(input, 'debug');
+
+      // then
+      const listeners = getListeners(element);
+      const listener = listeners[0];
+
+      expect(listener).to.have.property('type', 'debug');
+    }));
+
+
+    it('should update on external change', inject(async function(elementRegistry, selection, commandStack) {
+
+      // given
+      const element = elementRegistry.get('UserTask');
+      await act(() => {
+        selection.select(element);
+      });
+      const group = getTaskListenersGroup(container);
+      const input = domQuery('[name*=listenerType]', group);
+      changeInput(input, 'debug');
+
+      // when
+      await act(() => {
+        commandStack.undo();
+      });
+
+      // then
+      expect(input).to.have.property('value', 'assign_listener');
+    }));
+  });
+
+
+  describe('retries type', function() {
+
+    it('should update value', inject(async function(elementRegistry, selection) {
+
+      // given
+      const element = elementRegistry.get('UserTask');
+
+      await act(() => {
+        selection.select(element);
+      });
+
+      const group = getTaskListenersGroup(container);
+      const input = domQuery('[name*=retries]', group);
+
+      // when
+      changeInput(input, '22');
+
+      // then
+      const listeners = getListeners(element);
+      const listener = listeners[0];
+
+      expect(listener).to.have.property('retries', '22');
+    }));
+
+
+    it('should update on external change', inject(async function(elementRegistry, selection, commandStack) {
+
+      // given
+      const element = elementRegistry.get('UserTask');
+      await act(() => {
+        selection.select(element);
+      });
+      const group = getTaskListenersGroup(container);
+      const input = domQuery('[name*=retries]', group);
+      changeInput(input, '22');
+
+      // when
+      await act(() => {
+        commandStack.undo();
+      });
+
+      // then
+      expect(input).to.have.property('value', '2');
+    }));
+  });
+});
+
+
+// helper //////////////////
+function getTaskListenersGroup(container) {
+  return getGroup(container, 'Zeebe__TaskListeners');
+}
+
+function getGroup(container, id) {
+  return domQuery(`[data-group-id="group-${id}"`, container);
+}
+
+function getListItems(container, type) {
+  return domQueryAll(`div[data-entry-id*="-${type}-"].bio-properties-panel-collapsible-entry`, container);
+}
+
+function getListenerListItems(container) {
+  return getListItems(container, 'taskListener');
+}
+
+function getEventType(container) {
+  return domQuery('[data-entry-id*="eventType"]', container);
+}
+
+function getListeners(element) {
+  const bo = getBusinessObject(element);
+  const taskListeners = getExtensionElementsList(bo.get('processRef') || bo, 'zeebe:TaskListeners')[0];
+
+  return (taskListeners && taskListeners.get('listeners')) || [];
+}


### PR DESCRIPTION
related to https://github.com/camunda/camunda-modeler/issues/4590

### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

Add task listener to user task.
- [x] task listeners are allowed only for zeebe user tasks
- [x] event can be set to `complete` or `assignment`
- [x] listener type and number of retries can be set

[Screencast from 2024-11-07 13-56-29.webm](https://github.com/user-attachments/assets/58f725fd-d34d-4e1e-9e61-cb6805456368)

can be tested with `npm start` on the branch

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
