### PR TITLE
chore: remove legacy check

### DIFF
--- a/src/render/BpmnPropertiesPanel.js
+++ b/src/render/BpmnPropertiesPanel.js
@@ -250,9 +250,7 @@ export default function BpmnPropertiesPanel(props) {
 // helpers //////////////////////////
 
 function isImplicitRoot(element) {
-
-  // Backwards compatibility for diagram-js<7.4.0, see https://github.com/bpmn-io/bpmn-properties-panel/pull/102
-  return element && (element.isImplicit || element.id === '__implicitroot');
+  return element && element.isImplicit;
 }
 
 function findElement(elements, element) {

--- a/src/render/BpmnPropertiesPanelRenderer.js
+++ b/src/render/BpmnPropertiesPanelRenderer.js
@@ -201,9 +201,7 @@ BpmnPropertiesPanelRenderer.$inject = [ 'config.propertiesPanel', 'injector', 'e
 // helpers ///////////////////////
 
 function isImplicitRoot(element) {
-
-  // Backwards compatibility for diagram-js<7.4.0, see https://github.com/bpmn-io/bpmn-properties-panel/pull/102
-  return element && (element.isImplicit || element.id === '__implicitroot');
+  return element && element.isImplicit;
 }
 
 /**

--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -401,32 +401,6 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
   });
 
 
-  it('should ignore implicit root - legacy', async function() {
-
-    // given
-    const diagramXml = require('test/fixtures/simple.bpmn').default;
-
-    // when
-    const { modeler } = await createModeler(diagramXml, {
-      shouldImport: false,
-      propertiesPanel: {}
-    });
-
-    const implicitRootElement = {
-      id: '__implicitroot',
-      children: []
-    };
-
-    // when
-    const propertiesPanel = modeler.get('propertiesPanel');
-    propertiesPanel.attachTo(propertiesContainer);
-    propertiesPanel._render(implicitRootElement);
-
-    // then
-    expect(domQuery('.bio-properties-panel', propertiesContainer)).to.not.exist;
-  });
-
-
   describe('providers', function() {
 
     const diagramXML = require('test/fixtures/simple.bpmn').default;


### PR DESCRIPTION
We don't need it since we require more
recent diagram-js version.

### Proposed Changes

This removes the ID check for implicit root which was required prior to diagram-js@7.4.0

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
