### PR TITLE
test: remove deprecated `keyboard.bindTo`

### DIFF
--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -246,52 +246,6 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
 
   describe('keyboard bindings (undo/redo)', function() {
 
-    it('should bind', async function() {
-      const diagramXml = require('test/fixtures/simple.bpmn').default;
-
-      const keyboardTarget = document.createElement('div');
-
-      const { modeler } = await createModeler(diagramXml, {
-        keyboard: {
-          bindTo: keyboardTarget
-        }
-      });
-
-      modeler.invoke(function(eventBus, elementRegistry, modeling) {
-
-        // given
-        modeling.updateLabel(elementRegistry.get('Task_1'), 'FOOBAR');
-
-        const executeSpy = sinon.spy();
-        const undoSpy = sinon.spy();
-
-        eventBus.on('commandStack.execute', executeSpy);
-        eventBus.on('commandStack.reverted', undoSpy);
-
-        const panelParent = domQuery('.bio-properties-panel-container', propertiesContainer);
-
-        // when
-        panelParent.dispatchEvent(createKeyEvent('z', {
-          ctrlKey: true
-        }));
-
-        // then
-        // undo got executed
-        expect(undoSpy).to.have.been.called;
-
-        // but when
-        panelParent.dispatchEvent(createKeyEvent('y', {
-          ctrlKey: true
-        }));
-
-        // then
-        // redo got executed
-        expect(executeSpy).to.have.been.called;
-      });
-
-    });
-
-
     it('should NOT bind with keyboard binding deactivated', async function() {
       const diagramXml = require('test/fixtures/simple.bpmn').default;
 


### PR DESCRIPTION
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

The `keyboard.bindTo` was deprecated and shouldn't be used anymore so this PR removes the leftover from one of the tests still using it

This issue was pointed in the [comment](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1087#issuecomment-2462681373)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
