### PR TITLE
feat: restore focus on the canvas when properties panel loses focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: restore focus on the canvas when properties panel loses focus
+
 ## 5.27.0
 
 * `FEAT`: support Zeebe task listeners ([#1088](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1088))

--- a/src/render/BpmnPropertiesPanelRenderer.js
+++ b/src/render/BpmnPropertiesPanelRenderer.js
@@ -51,13 +51,18 @@ export default class BpmnPropertiesPanelRenderer {
 
     commandStack && setupKeyboard(this._container, eventBus, commandStack);
 
+    const handleFocusOut = () => this._restoreCanvasFocus();
+
     eventBus.on('diagram.init', () => {
       if (parent) {
         this.attachTo(parent);
       }
+
+      domEvent.bind(this._container, 'focusout', handleFocusOut);
     });
 
     eventBus.on('diagram.destroy', () => {
+      domEvent.unbind(this._container, 'focusout', handleFocusOut);
       this.detach();
     });
 
@@ -156,6 +161,11 @@ export default class BpmnPropertiesPanelRenderer {
     this._eventBus.fire(event);
 
     return event.providers;
+  }
+
+  _restoreCanvasFocus() {
+    const canvas = this._injector.get('canvas');
+    canvas && canvas.restoreFocus && canvas.restoreFocus();
   }
 
   _render(element) {

--- a/src/render/BpmnPropertiesPanelRenderer.js
+++ b/src/render/BpmnPropertiesPanelRenderer.js
@@ -165,7 +165,11 @@ export default class BpmnPropertiesPanelRenderer {
 
   _restoreCanvasFocus() {
     const canvas = this._injector.get('canvas');
-    canvas && canvas.restoreFocus && canvas.restoreFocus();
+
+    // Only available with diagram-js >= 15.0.0
+    if (canvas.restoreFocus) {
+      canvas.restoreFocus();
+    }
   }
 
   _render(element) {

--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -536,6 +536,34 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
       expect(error.textContent).to.equal('foo');
     });
 
+
+    it('should try to restore focus on the canvas on focusout', async function() {
+
+      // given
+      const diagramXml = require('test/fixtures/simple.bpmn').default;
+
+      let modeler;
+      await act(async () => {
+        const result = await createModeler(diagramXml);
+        modeler = result.modeler;
+      });
+
+      const propertiesPanel = modeler.get('propertiesPanel');
+      const spy = sinon.spy(propertiesPanel, '_restoreCanvasFocus');
+      const group = domQuery('.bio-properties-panel-group-header', propertiesContainer);
+      const input = domQuery('#bio-properties-panel-name', propertiesContainer);
+
+      // when
+      act(() => group.click());
+      act(() => input.focus());
+
+      // and then
+      input.blur();
+
+      // then
+      expect(spy).to.have.been.called;
+    });
+
   });
 
 


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/bpmn-io/internal-docs/issues/1081
Related to https://github.com/camunda/camunda-modeler/pull/4620

Make use of the new `diagram-js@15` `Canvas#restoreFocus` API to focus back on the canvas when properties panel loses focus.

In addresses a case explain in this [comment](https://github.com/camunda/camunda-modeler/pull/4620#pullrequestreview-2444450740), when user briefly interacts with properties panel without focusing any input. In that case, we want the focus to stay on the modeling canvas.

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [X] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [X] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
