### PR TITLE
feat: make properties panel container focusable

### DIFF
--- a/src/render/BpmnPropertiesPanelRenderer.js
+++ b/src/render/BpmnPropertiesPanelRenderer.js
@@ -44,7 +44,7 @@ export default class BpmnPropertiesPanelRenderer {
     this._getFeelPopupLinks = getFeelPopupLinks;
 
     this._container = domify(
-      '<div style="height: 100%" class="bio-properties-panel-container"></div>'
+      '<div style="height: 100%" tabindex="-1" class="bio-properties-panel-container"></div>'
     );
 
     var commandStack = injector.get('commandStack', false);


### PR DESCRIPTION
Related to https://github.com/bpmn-io/internal-docs/issues/1081

### Proposed Changes

By making properties panel container focusable, user can click somewhere in the container (not only on buttons and inputs) to continue using keyboard shortcuts in the context of the panel.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
