### PR TITLE
feat: rename task listener event types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "bpmn-js": "^18.0.0",
         "bpmn-js-create-append-anything": "^0.5.2",
         "bpmn-moddle": "^9.0.1",
-        "camunda-bpmn-js-behaviors": "^1.7.1",
+        "camunda-bpmn-js-behaviors": "^1.9.0",
         "camunda-bpmn-moddle": "^7.0.1",
         "chai": "^4.5.0",
         "cross-env": "^7.0.3",
@@ -2838,9 +2838,9 @@
       }
     },
     "node_modules/camunda-bpmn-js-behaviors": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.7.1.tgz",
-      "integrity": "sha512-hWgMbkwsuzDV274w/XZ6wF6vby9+RaJj7n175NTusfumZtQoMJMDm5/zw/gjeEkf+/3nkZ18TMid5FIe/H6Vhg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.9.0.tgz",
+      "integrity": "sha512-s80UtNaEemOjmVjpgFaX81PK/+As4qPNdpJenyDXCalIDDdFNoKgqH/HjKlfhKq/PjUxgqY9p7FwbxKXe18Lmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12203,9 +12203,9 @@
       "dev": true
     },
     "camunda-bpmn-js-behaviors": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.7.1.tgz",
-      "integrity": "sha512-hWgMbkwsuzDV274w/XZ6wF6vby9+RaJj7n175NTusfumZtQoMJMDm5/zw/gjeEkf+/3nkZ18TMid5FIe/H6Vhg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.9.0.tgz",
+      "integrity": "sha512-s80UtNaEemOjmVjpgFaX81PK/+As4qPNdpJenyDXCalIDDdFNoKgqH/HjKlfhKq/PjUxgqY9p7FwbxKXe18Lmw==",
       "dev": true,
       "requires": {
         "ids": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "bpmn-js": "^18.0.0",
     "bpmn-js-create-append-anything": "^0.5.2",
     "bpmn-moddle": "^9.0.1",
-    "camunda-bpmn-js-behaviors": "^1.7.1",
+    "camunda-bpmn-js-behaviors": "^1.9.0",
     "camunda-bpmn-moddle": "^7.0.1",
     "chai": "^4.5.0",
     "cross-env": "^7.0.3",

--- a/src/provider/zeebe/properties/TaskListener.js
+++ b/src/provider/zeebe/properties/TaskListener.js
@@ -6,11 +6,11 @@ import {
 
 import { ListenerType, Retries } from './shared/Listener';
 
-export const EVENT_TYPE = [ 'complete', 'assignment' ];
+export const EVENT_TYPE = [ 'completing', 'assigning' ];
 
 export const EVENT_TO_LABEL = {
-  complete: 'Complete',
-  assignment: 'Assignment'
+  completing: 'Completing',
+  assigning: 'Assigning'
 };
 
 export function TaskListenerEntries(props) {

--- a/src/provider/zeebe/properties/TaskListenersProps.js
+++ b/src/provider/zeebe/properties/TaskListenersProps.js
@@ -46,10 +46,15 @@ export function TaskListenersProps({ element, injector }) {
   const items = listeners.map((listener, index) => {
     const id = element.id + '-taskListener-' + index;
     const type = listener.get('type') || '<no type>';
+    const eventType = listener.get('eventType');
+    const label = translate('{eventType}: {type}', {
+      eventType: EVENT_TO_LABEL[eventType] || eventType,
+      type
+    });
 
     return {
       id,
-      label: translate(`${EVENT_TO_LABEL[listener.get('eventType')]}: {type}`, { type }),
+      label,
       entries: TaskListenerEntries({
         idPrefix: id,
         listener

--- a/test/spec/provider/zeebe/TaskListenerProps.bpmn
+++ b/test/spec/provider/zeebe/TaskListenerProps.bpmn
@@ -4,7 +4,7 @@
     <bpmn:userTask id="UserTask">
       <bpmn:extensionElements>
         <zeebe:taskListeners>
-          <zeebe:taskListener eventType="assignment" retries="2" type="assign_listener" />
+          <zeebe:taskListener eventType="assigning" retries="2" type="assign_listener" />
         </zeebe:taskListeners>
         <zeebe:userTask />
       </bpmn:extensionElements>
@@ -28,11 +28,6 @@
       </bpmn:userTask>
       <bpmn:boundaryEvent id="CompensationBoundaryEvent" attachedToRef="SubProcess">
         <bpmn:compensateEventDefinition id="Compensate" />
-        <bpmn:extensionElements>
-          <zeebe:taskListeners>
-            <zeebe:taskListener eventType="assignment" retries="4" type="assign_listener" />
-          </zeebe:taskListeners>
-        </bpmn:extensionElements>
       </bpmn:boundaryEvent>
       <bpmn:exclusiveGateway id="Gateway">
         <bpmn:extensionElements>
@@ -47,11 +42,23 @@
         </bpmn:extensionElements>
       </bpmn:userTask>
     </bpmn:subProcess>
+    <bpmn:userTask id="UserTaskLegacyEventTypes">
+      <bpmn:extensionElements>
+        <zeebe:taskListeners>
+          <zeebe:taskListener eventType="assignment" retries="2" type="assign_listener_legacy" />
+          <zeebe:taskListener eventType="complete" retries="2" type="complete_listener_legacy" />
+        </zeebe:taskListeners>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ZeebePropertiesTest">
       <bpmndi:BPMNShape id="UserTask_di" bpmnElement="UserTask">
         <dc:Bounds x="160" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTaskLegacyEventTypes_di" bpmnElement="UserTaskLegacyEventTypes">
+        <dc:Bounds x="160" y="200" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="SubProcess_di" bpmnElement="SubProcess" isExpanded="true">
         <dc:Bounds x="160" y="510" width="350" height="200" />

--- a/test/spec/provider/zeebe/TaskListenerProps.spec.js
+++ b/test/spec/provider/zeebe/TaskListenerProps.spec.js
@@ -137,7 +137,25 @@ describe('provider/zeebe - TaskListenerProps', function() {
     const label = domQuery('.bio-properties-panel-collapsible-entry-header-title', group);
 
     // then
-    expect(label).to.have.property('textContent', 'Assignment: assign_listener');
+    expect(label).to.have.property('textContent', 'Assigning: assign_listener');
+  }));
+
+
+  it('should display label with exact value for unknown event type', inject(async function(elementRegistry, selection) {
+
+    // given
+    const element = elementRegistry.get('UserTaskLegacyEventTypes');
+
+    await act(() => {
+      selection.select(element);
+    });
+
+    // when
+    const group = getTaskListenersGroup(container);
+    const label = domQuery('.bio-properties-panel-collapsible-entry-header-title', group);
+
+    // then
+    expect(label).to.have.property('textContent', 'assignment: assign_listener_legacy');
   }));
 
 
@@ -270,7 +288,7 @@ describe('provider/zeebe - TaskListenerProps', function() {
         const listeners = getListeners(element);
         const newListener = listeners[listeners.length - 1];
 
-        expect(newListener).to.have.property('eventType', 'complete');
+        expect(newListener).to.have.property('eventType', 'completing');
       })
     );
 
@@ -289,13 +307,13 @@ describe('provider/zeebe - TaskListenerProps', function() {
       const input = domQuery('select', eventType);
 
       // when
-      changeInput(input, 'complete');
+      changeInput(input, 'completing');
 
       // then
       const listeners = getListeners(element);
       const listener = listeners[0];
 
-      expect(listener).to.have.property('eventType', 'complete');
+      expect(listener).to.have.property('eventType', 'completing');
     }));
 
 
@@ -309,7 +327,7 @@ describe('provider/zeebe - TaskListenerProps', function() {
       const group = getTaskListenersGroup(container);
       const eventType = getEventType(group);
       const input = domQuery('select', eventType);
-      changeInput(input, 'complete');
+      changeInput(input, 'completing');
 
       // when
       await act(() => {
@@ -317,7 +335,7 @@ describe('provider/zeebe - TaskListenerProps', function() {
       });
 
       // then
-      expect(input).to.have.property('value', 'assignment');
+      expect(input).to.have.property('value', 'assigning');
     }));
   });
 


### PR DESCRIPTION
### Proposed Changes

https://github.com/user-attachments/assets/df186973-11e8-4a8c-a3d7-3198ed9931ad

This implements the event types change. The legacy name is displayed in a label and can be changed in a one-way manner.
We could consider displaying the unknown name in the select too, but this means it will still appear in the options to select.

Related to https://github.com/camunda/camunda-modeler/issues/4748

Requires https://github.com/camunda/camunda-bpmn-js-behaviors/pull/92 to be released and integrated.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
