### PR TITLE
fix: ensure logical order of task listener event types

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,8 @@ jobs:
     - name: Install dependencies for integration test
       if: ${{ matrix.integration-deps != '' }}
       run: npm install ${{ matrix.integration-deps }}
+    - name: Project setup
+      uses: bpmn-io/actions/setup@latest
     - name: Build
       if: ${{ matrix.integration-deps != '' }}
       run: npm run all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: ensure logical order of task listener event types ([#1102](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1102))
+
 ## 5.30.0
 
 * `FEAT`: rename task listener event types ([#1098](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1098))

--- a/src/provider/zeebe/properties/TaskListener.js
+++ b/src/provider/zeebe/properties/TaskListener.js
@@ -6,11 +6,15 @@ import {
 
 import { ListenerType, Retries } from './shared/Listener';
 
-export const EVENT_TYPE = [ 'completing', 'assigning' ];
+// ensure types are in logical order
+export const EVENT_TYPE = [
+  'assigning',
+  'completing'
+];
 
 export const EVENT_TO_LABEL = {
-  completing: 'Completing',
-  assigning: 'Assigning'
+  assigning: 'Assigning',
+  completing: 'Completing'
 };
 
 export function TaskListenerEntries(props) {

--- a/test/spec/provider/zeebe/TaskListenerProps.spec.js
+++ b/test/spec/provider/zeebe/TaskListenerProps.spec.js
@@ -265,7 +265,7 @@ describe('provider/zeebe - TaskListenerProps', function() {
 
   describe('event type', function() {
 
-    it('should use a supported event type for a new listener', inject(
+    it('should use "assigning" as event type for a new listener', inject(
       async function(elementRegistry, selection) {
 
         // given
@@ -288,7 +288,7 @@ describe('provider/zeebe - TaskListenerProps', function() {
         const listeners = getListeners(element);
         const newListener = listeners[listeners.length - 1];
 
-        expect(newListener).to.have.property('eventType', 'completing');
+        expect(newListener).to.have.property('eventType', 'assigning');
       })
     );
 


### PR DESCRIPTION
### Proposed Changes

This PR ensures that event types are displayed in logical order (first assigning, then completing):

<img width="302" alt="image" src="https://github.com/user-attachments/assets/9c251af2-271c-4443-aebf-0d63890ecab0" />

Related to https://camunda.slack.com/archives/C0622NWC9LK/p1736529715729349?thread_ts=1736529030.781279&cid=C0622NWC9LK

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
