### PR TITLE
Sticky list headers

### DIFF
--- a/src/provider/camunda-platform/properties/FormField.js
+++ b/src/provider/camunda-platform/properties/FormField.js
@@ -70,7 +70,8 @@ export default function FormField(props) {
       id: idPrefix + '-formFieldValues',
       component: ValueList,
       formField,
-      idPrefix
+      idPrefix,
+      headerNestingLevel: 1,
     });
   }
 
@@ -78,13 +79,15 @@ export default function FormField(props) {
     id: idPrefix + '-formFieldConstraints',
     component: ConstraintList,
     formField,
-    idPrefix
+    idPrefix,
+    headerNestingLevel: 1
   },
   {
     id: idPrefix + '-formFieldProperties',
     component: PropertiesList,
     formField,
-    idPrefix
+    idPrefix,
+    headerNestingLevel: 1
   });
 
   return entries;
@@ -321,7 +324,8 @@ function ValueList(props) {
   const {
     element,
     formField,
-    idPrefix
+    idPrefix,
+    headerNestingLevel
   } = props;
 
   const id = `${ idPrefix }-formFieldValues`;
@@ -368,6 +372,7 @@ function ValueList(props) {
     component={ Value }
     onAdd={ addValue }
     onRemove={ removeValue }
+    headerNestingLevel={ headerNestingLevel }
   />;
 }
 
@@ -403,7 +408,8 @@ function ConstraintList(props) {
   const {
     element,
     formField,
-    idPrefix
+    idPrefix,
+    headerNestingLevel
   } = props;
 
   const id = `${ idPrefix }-formFieldConstraints`;
@@ -482,7 +488,9 @@ function ConstraintList(props) {
       items={ constraints }
       component={ Constraint }
       onAdd={ addConstraint }
-      onRemove={ removeConstraint } />
+      onRemove={ removeConstraint }
+      headerNestingLevel={ headerNestingLevel }
+    />
   );
 }
 
@@ -518,7 +526,8 @@ function PropertiesList(props) {
   const {
     element,
     formField,
-    idPrefix
+    idPrefix,
+    headerNestingLevel
   } = props;
 
   const id = `${ idPrefix }-formFieldProperties`;
@@ -597,5 +606,6 @@ function PropertiesList(props) {
     component={ Property }
     onAdd={ addProperty }
     onRemove={ removeProperty }
+    headerNestingLevel={ headerNestingLevel }
   />;
 }

--- a/src/provider/camunda-platform/properties/InputOutputParameter.js
+++ b/src/provider/camunda-platform/properties/InputOutputParameter.js
@@ -93,7 +93,8 @@ export default function InputOutputParameter(props) {
       id: `${idPrefix}-list`,
       component: ListProps,
       idPrefix,
-      parameter
+      parameter,
+      headerNestingLevel: 1
     });
 
   // (4) Map
@@ -102,7 +103,8 @@ export default function InputOutputParameter(props) {
       id: `${idPrefix}-map`,
       component: MapProps,
       idPrefix,
-      parameter
+      parameter,
+      headerNestingLevel: 1
     });
   }
 

--- a/src/provider/camunda-platform/properties/ListProps.js
+++ b/src/provider/camunda-platform/properties/ListProps.js
@@ -38,7 +38,8 @@ export function ListProps(props) {
   const {
     idPrefix,
     element,
-    parameter
+    parameter,
+    headerNestingLevel
   } = props;
 
   const bpmnFactory = useService('bpmnFactory');
@@ -78,7 +79,8 @@ export function ListProps(props) {
     label: translate('List values'),
     onAdd: addItem,
     onRemove: removeItem,
-    component: ListProp
+    component: ListProp,
+    headerNestingLevel
   });
 }
 

--- a/src/provider/camunda-platform/properties/ListenerProps.js
+++ b/src/provider/camunda-platform/properties/ListenerProps.js
@@ -161,7 +161,8 @@ function ExecutionListener(props) {
   {
     id: `${idPrefix}-fields`,
     component: Fields,
-    listener
+    listener,
+    headerNestingLevel: 1
   } ];
 }
 
@@ -227,7 +228,8 @@ function TaskListener(props) {
   {
     id: `${idPrefix}-fields`,
     component: Fields,
-    listener
+    listener,
+    headerNestingLevel: 1
   } ];
 }
 
@@ -434,7 +436,8 @@ function Fields(props) {
   const {
     id,
     element,
-    listener
+    listener,
+    headerNestingLevel
   } = props;
 
   const bpmnFactory = useService('bpmnFactory');
@@ -474,6 +477,7 @@ function Fields(props) {
     onAdd={ addField }
     onRemove={ removeField }
     autoFocusEntry={ `[data-entry-id="${id}-field-${fields.length - 1}"] input` }
+    headerNestingLevel={ headerNestingLevel }
   />;
 }
 

--- a/src/provider/camunda-platform/properties/MapProps.js
+++ b/src/provider/camunda-platform/properties/MapProps.js
@@ -46,7 +46,8 @@ export function MapProps(props) {
   const {
     idPrefix,
     element,
-    parameter
+    parameter,
+    headerNestingLevel
   } = props;
 
   const bpmnFactory = useService('bpmnFactory');
@@ -88,6 +89,7 @@ export function MapProps(props) {
     onAdd: addEntry,
     onRemove: removeEntry,
     component: MapProp,
+    headerNestingLevel
   });
 }
 


### PR DESCRIPTION
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

* Depends on https://github.com/bpmn-io/properties-panel/pull/397  
* Closes https://github.com/bpmn-io/bpmn-js-properties-panel/issues/1103

This change incorporates the behavior implemented in [this merge request](https://github.com/bpmn-io/properties-panel/pull/397) and enables sticky list headers for the following elements:
* **Inputs and Outputs:** List and Map values
* **Execution listeners:** Field injection lists
* **Form fields:** Constraints, Properties and list-type Values

All these lists have only one nesting level, and as far as I know, there are no cases where deeper nesting is used.

#### How it will look like

![Sticky list headers 2](https://github.com/user-attachments/assets/b0d9df1c-67d7-43aa-8cba-109d0ce78b18)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
