### PR TITLE
fix: subscription coorelation key tooltip added

### DIFF
--- a/src/contextProvider/zeebe/TooltipProvider.js
+++ b/src/contextProvider/zeebe/TooltipProvider.js
@@ -361,6 +361,19 @@ const TooltipProvider = {
       </div>
     );
   },
+  'messageSubscriptionCorrelationKey': (element) => {
+    const translate = useService('translate');
+
+    return (
+      <div>
+        <p>
+          { translate('Identifier computed from the process context that is used to correlate an incoming message (e.g. ')}<code>= orderId</code>{translate('). ')}
+          <a href="https://docs.camunda.io/docs/8.7/components/modeler/bpmn/message-events/#messages" target="_blank" rel="noopener noreferrer" title={ translate('Subscription correlation key documentation') }>
+            { translate('Learn more.') }
+          </a>        </p>
+      </div>
+    );
+  }
 };
 
 export default TooltipProvider;

--- a/test/spec/provider/zeebe/MessageProps.spec.js
+++ b/test/spec/provider/zeebe/MessageProps.spec.js
@@ -80,9 +80,9 @@ describe('provider/zeebe - MessageProps', function() {
     clock.restore();
   });
 
-  function openTooltip() {
+  function openTooltip(customWrapper = null) {
     return act(() => {
-      const wrapper = domQuery('.bio-properties-panel-tooltip-wrapper', container);
+      const wrapper = customWrapper || domQuery('.bio-properties-panel-tooltip-wrapper', container);
       mouseEnter(wrapper);
       clock.tick(200);
     });
@@ -542,6 +542,28 @@ describe('provider/zeebe - MessageProps', function() {
       expect(documentationLinkGroups).to.have.length(2);
       expect(documentationLinkGroups[0].title).to.equal('Send task documentation');
       expect(documentationLinkGroups[1].title).to.equal('Receive task documentation');
+    }));
+
+
+    it('should display correct documentation for subscription correlation key', inject(async function(elementRegistry, selection) {
+
+      // given
+      const messageEvent = elementRegistry.get('IntermediateEvent_1');
+
+      await act(() => {
+        selection.select(messageEvent);
+      });
+
+      const susbscriptionKeyWrapper = domQuery('label[for="bio-properties-panel-messageSubscriptionCorrelationKey"] div', container);
+
+      // when
+      await openTooltip(susbscriptionKeyWrapper);
+
+      const documentationLinkGroup = domQuery('.bio-properties-panel-tooltip-content a', container);
+
+      // then
+      expect(documentationLinkGroup).to.exist;
+      expect(documentationLinkGroup.title).to.equal('Subscription correlation key documentation');
     }));
 
   });


### PR DESCRIPTION
Related to camunda-modeler: [#4833](https://github.com/camunda/camunda-modeler/issues/4833)

### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 


steps to try out your changes.

--> 

Added tooltip for Subscription correlation key

<img width="620" alt="Screenshot 2025-02-19 at 16 54 43" src="https://github.com/user-attachments/assets/b45c0d42-955c-48df-ae66-e553cdfcfff4" />

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
