### PR TITLE
Fix broken tests

### DIFF
--- a/test/spec/provider/bpmn/EscalationProps.spec.js
+++ b/test/spec/provider/bpmn/EscalationProps.spec.js
@@ -78,7 +78,7 @@ describe('provider/bpmn - EscalationProps', function() {
         elementRegistry.get('EscalationIntermediateEvent_1')
       ];
 
-      escalationElements.forEach(async (element) => {
+      for (const element of escalationElements) {
 
         // when
         await act(() => {
@@ -87,9 +87,14 @@ describe('provider/bpmn - EscalationProps', function() {
 
         // then
         const select = domQuery('select[name=escalationRef]', container);
-        expect(select.value).to.eql(getEscalation(element).get('id'));
-      });
+        const escalation = getEscalation(element);
 
+        expect(select).to.exist;
+
+        if (escalation) {
+          expect(select.value).to.eql(escalation.get('id'));
+        }
+      }
     }));
 
 

--- a/test/spec/provider/bpmn/SignalProps.spec.js
+++ b/test/spec/provider/bpmn/SignalProps.spec.js
@@ -67,7 +67,7 @@ describe('provider/bpmn - SignalProps', function() {
           elementRegistry.get('IntermediateThrowEvent_1')
         ];
 
-        plainElements.forEach(async (ele) => {
+        for (const ele of plainElements) {
 
           // when
           await act(() => {
@@ -77,7 +77,7 @@ describe('provider/bpmn - SignalProps', function() {
           // then
           const signalRefSelect = domQuery('select[name=signalRef]', container);
           expect(signalRefSelect).to.be.null;
-        });
+        }
 
       })
     );
@@ -94,7 +94,7 @@ describe('provider/bpmn - SignalProps', function() {
         elementRegistry.get('SignalCatchEvent_1')
       ];
 
-      signalElements.forEach(async (ele) => {
+      for (const ele of signalElements) {
 
         // when
         await act(() => {
@@ -104,7 +104,7 @@ describe('provider/bpmn - SignalProps', function() {
         // then
         const signalRefSelect = domQuery('select[name=signalRef]', container);
         expect(signalRefSelect.value).to.eql(getSignal(ele).get('id'));
-      });
+      }
     }));
 
 
@@ -290,7 +290,7 @@ describe('provider/bpmn - SignalProps', function() {
           elementRegistry.get('IntermediateThrowEvent_1')
         ];
 
-        plainElements.forEach(async (ele) => {
+        for (const ele of plainElements) {
 
           // when
           await act(() => {
@@ -301,7 +301,7 @@ describe('provider/bpmn - SignalProps', function() {
           const signalNameInput = domQuery('input[name=signalName]', container);
 
           expect(signalNameInput).to.be.null;
-        });
+        }
       })
     );
 
@@ -317,7 +317,7 @@ describe('provider/bpmn - SignalProps', function() {
         elementRegistry.get('SignalCatchEvent_1')
       ];
 
-      signalElements.forEach(async (ele) => {
+      for (const ele of signalElements) {
         await act(() => {
           selection.select(ele);
         });
@@ -327,7 +327,7 @@ describe('provider/bpmn - SignalProps', function() {
 
         // then
         expect(signalNameInput.value).to.eql(getSignal(ele).get('name'));
-      });
+      }
     }));
 
 

--- a/test/spec/provider/zeebe/BusinessRuleImplementationProps.spec.js
+++ b/test/spec/provider/zeebe/BusinessRuleImplementationProps.spec.js
@@ -120,6 +120,8 @@ describe('provider/zeebe - BusinessRuleImplementationProps', function() {
     }));
 
 
+    // TODO(@barmac): this test is fails as false-positive when run locally on MacOS as part of the full test suite,
+    // cf. https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1111#pullrequestreview-2635770727
     it('should display dmn', inject(async function(elementRegistry, selection) {
 
       // given
@@ -139,6 +141,8 @@ describe('provider/zeebe - BusinessRuleImplementationProps', function() {
     }));
 
 
+    // TODO(@barmac): this test is fails as false-positive when run locally on MacOS as part of the full test suite,
+    // cf. https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1111#pullrequestreview-2635770727
     it('should display jobWorker', inject(async function(elementRegistry, selection) {
 
       // given

--- a/test/spec/provider/zeebe/BusinessRuleImplementationProps.spec.js
+++ b/test/spec/provider/zeebe/BusinessRuleImplementationProps.spec.js
@@ -1,7 +1,8 @@
 import TestContainer from 'mocha-test-container-support';
 
 import {
-  act
+  act,
+  waitFor
 } from '@testing-library/preact';
 
 import {
@@ -367,19 +368,14 @@ function getTaskHeaders(element) {
   return getExtensionElementsList(businessObject, 'zeebe:TaskHeaders')[ 0 ];
 }
 
-async function expectEdited(container, exists) {
+function expectEdited(container, exists) {
+  return waitFor(() => {
+    const indicator = domQuery(`${GROUP_SELECTOR} .bio-properties-panel-dot`, container);
 
-  await wait(50);
-
-  const indicator = domQuery(`${GROUP_SELECTOR} .bio-properties-panel-dot`, container);
-
-  if (exists) {
-    expect(indicator).to.exist;
-  } else {
-    expect(indicator).not.to.exist;
-  }
-}
-
-function wait(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+    if (exists) {
+      expect(indicator).to.exist;
+    } else {
+      expect(indicator).not.to.exist;
+    }
+  });
 }

--- a/test/spec/provider/zeebe/ConditionProps.spec.js
+++ b/test/spec/provider/zeebe/ConditionProps.spec.js
@@ -61,7 +61,11 @@ describe('provider/zeebe - ConditionProps', function() {
     it('should display', inject(async function(elementRegistry, selection) {
 
       // given
-      const elements = [ 'Flow2', 'Flow3', 'Flow4' ];
+      const elements = [
+        'Flow2',
+        'Flow3',
+        'Flow4'
+      ];
 
       for (const ele of elements) {
         const sequenceFlow = elementRegistry.get(ele);
@@ -71,7 +75,7 @@ describe('provider/zeebe - ConditionProps', function() {
           selection.select(sequenceFlow);
         });
 
-        const conditionExpressionInput = domQuery('input[name=conditionExpression]', container);
+        const conditionExpressionInput = domQuery('[id=bio-properties-panel-conditionExpression]', container);
 
         // then
         expect(conditionExpressionInput).to.exist;

--- a/test/spec/provider/zeebe/ConditionProps.spec.js
+++ b/test/spec/provider/zeebe/ConditionProps.spec.js
@@ -63,7 +63,7 @@ describe('provider/zeebe - ConditionProps', function() {
       // given
       const elements = [ 'Flow2', 'Flow3', 'Flow4' ];
 
-      elements.forEach(async ele => {
+      for (const ele of elements) {
         const sequenceFlow = elementRegistry.get(ele);
 
         // when
@@ -75,7 +75,7 @@ describe('provider/zeebe - ConditionProps', function() {
 
         // then
         expect(conditionExpressionInput).to.exist;
-      });
+      }
     }));
 
 

--- a/test/spec/provider/zeebe/ScriptImplementationProps.spec.js
+++ b/test/spec/provider/zeebe/ScriptImplementationProps.spec.js
@@ -1,7 +1,8 @@
 import TestContainer from 'mocha-test-container-support';
 
 import {
-  act
+  act,
+  waitFor
 } from '@testing-library/preact';
 
 import {
@@ -346,19 +347,14 @@ function getTaskHeaders(element) {
   return getExtensionElementsList(businessObject, 'zeebe:TaskHeaders')[ 0 ];
 }
 
-async function expectEdited(container, exists) {
+function expectEdited(container, exists) {
+  return waitFor(() => {
+    const indicator = domQuery(`${GROUP_SELECTOR} .bio-properties-panel-dot`, container);
 
-  await wait(50);
-
-  const indicator = domQuery(`${GROUP_SELECTOR} .bio-properties-panel-dot`, container);
-
-  if (exists) {
-    expect(indicator).to.exist;
-  } else {
-    expect(indicator).not.to.exist;
-  }
-}
-
-function wait(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+    if (exists) {
+      expect(indicator).to.exist;
+    } else {
+      expect(indicator).not.to.exist;
+    }
+  });
 }

--- a/test/spec/provider/zeebe/ScriptImplementationProps.spec.js
+++ b/test/spec/provider/zeebe/ScriptImplementationProps.spec.js
@@ -121,6 +121,8 @@ describe('provider/zeebe - ScriptImplementationProps', function() {
     }));
 
 
+    // TODO(@barmac): this test is fails as false-positive when run locally on MacOS as part of the full test suite,
+    // cf. https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1111#pullrequestreview-2635770727
     it('should display script', inject(async function(elementRegistry, selection) {
 
       // given
@@ -140,6 +142,8 @@ describe('provider/zeebe - ScriptImplementationProps', function() {
     }));
 
 
+    // TODO(@barmac): this test is fails as false-positive when run locally on MacOS as part of the full test suite,
+    // cf. https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1111#pullrequestreview-2635770727
     it('should display jobWorker', inject(async function(elementRegistry, selection) {
 
       // given

--- a/test/spec/provider/zeebe/UserTaskImplementationProps.spec.js
+++ b/test/spec/provider/zeebe/UserTaskImplementationProps.spec.js
@@ -1,7 +1,8 @@
 import TestContainer from 'mocha-test-container-support';
 
 import {
-  act
+  act,
+  waitFor
 } from '@testing-library/preact';
 
 import {
@@ -242,19 +243,14 @@ function getZeebeUserTask(element) {
 }
 
 
-async function expectEdited(container, exists) {
+function expectEdited(container, exists) {
+  return waitFor(() => {
+    const indicator = domQuery(`${GROUP_SELECTOR} .bio-properties-panel-dot`, container);
 
-  await wait(50);
-
-  const indicator = domQuery(`${GROUP_SELECTOR} .bio-properties-panel-dot`, container);
-
-  if (exists) {
-    expect(indicator).to.exist;
-  } else {
-    expect(indicator).not.to.exist;
-  }
-}
-
-function wait(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+    if (exists) {
+      expect(indicator).to.exist;
+    } else {
+      expect(indicator).not.to.exist;
+    }
+  });
 }

--- a/test/spec/provider/zeebe/UserTaskImplementationProps.spec.js
+++ b/test/spec/provider/zeebe/UserTaskImplementationProps.spec.js
@@ -101,6 +101,8 @@ describe('provider/zeebe - UserTaskImplementationProps', function() {
     }));
 
 
+    // TODO(@barmac): this test is fails as false-positive when run locally on MacOS as part of the full test suite,
+    // cf. https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1111#pullrequestreview-2635770727
     it('should display zeebe user task', inject(async function(elementRegistry, selection) {
 
       // given


### PR DESCRIPTION
### Proposed Changes

This fixes some tests which used to throw uncaught promise exceptions.

I propose also to stop testing for the edited dot existence. These assertions are super flaky and slow (`wait 50 ms` included), and a rewrite to `waitFor` did not resolve flakiness on my machine. I don't think this is a crucial feature, and we tested for it only in some places in the code base.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
