### PR TITLE
feat: add completionCondition + cancelRemainingInstances properties to ad-hoc subprocess

### DIFF
--- a/src/contextProvider/zeebe/TooltipProvider.js
+++ b/src/contextProvider/zeebe/TooltipProvider.js
@@ -349,6 +349,18 @@ const TooltipProvider = {
       </div>
     );
   },
+  'group-adHocCompletion': (element) => {
+    const translate = useService('translate');
+
+    return (
+      <div>
+        {translate('Define the completion behavior of an ad-hoc subprocess. If no completion condition is set, it will be completed after all active elements have been completed. ')}
+        <a href="https://docs.camunda.io/docs/components/modeler/bpmn/ad-hoc" target="_blank" rel="noopener noreferrer" title={ translate('Ad-hoc subprocess documentation') }>
+          { translate('Learn more.') }
+        </a>
+      </div>
+    );
+  },
   'group-activeElements': (element) => {
     const translate = useService('translate');
 

--- a/src/provider/bpmn/BpmnPropertiesProvider.js
+++ b/src/provider/bpmn/BpmnPropertiesProvider.js
@@ -1,6 +1,7 @@
 import { Group } from '@bpmn-io/properties-panel';
 
 import {
+  AdHocCompletionProps,
   CompensationProps,
   DocumentationProps,
   ErrorProps,
@@ -195,6 +196,24 @@ function MultiInstanceGroup(element, injector) {
   return null;
 }
 
+function AdHocCompletionGroup(element, injector) {
+  const translate = injector.get('translate');
+  const group = {
+    label: translate('Completion'),
+    id: 'adHocCompletion',
+    component: Group,
+    entries: [
+      ...AdHocCompletionProps({ element })
+    ]
+  };
+
+  if (group.entries.length) {
+    return group;
+  }
+
+  return null;
+}
+
 function getGroups(element, injector) {
 
   const groups = [
@@ -205,6 +224,7 @@ function getGroups(element, injector) {
     LinkGroup(element, injector),
     MessageGroup(element, injector),
     MultiInstanceGroup(element, injector),
+    AdHocCompletionGroup(element, injector),
     SignalGroup(element, injector),
     EscalationGroup(element, injector),
     TimerGroup(element, injector)

--- a/src/provider/bpmn/properties/AdHocCompletionProps.js
+++ b/src/provider/bpmn/properties/AdHocCompletionProps.js
@@ -6,9 +6,8 @@ import {
   TextFieldEntry,
 } from '@bpmn-io/properties-panel';
 
-import { createElement } from '../../../utils/ElementUtil';
-
 import { useService } from '../../../hooks';
+import { createOrUpdateFormalExpression } from '../../../utils/FormalExpressionUtil';
 
 /**
  * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
@@ -52,9 +51,13 @@ function CompletionCondition(props) {
   };
 
   const setValue = (value) => {
-    return commandStack.execute(
-      'element.updateModdleProperties',
-      updateFormalExpression(element, 'completionCondition', value, bpmnFactory)
+    return createOrUpdateFormalExpression(
+      element,
+      getBusinessObject(element),
+      'completionCondition',
+      value,
+      bpmnFactory,
+      commandStack
     );
   };
 
@@ -97,60 +100,4 @@ function CancelRemainingInstances(props) {
     getValue,
     setValue,
   });
-}
-
-// helper ////////////////////////////
-
-// formal expression /////////////////
-
-/**
- * updateFormalExpression - updates a specific formal expression
- *
- * @param {djs.model.Base} element
- * @param {string} propertyName
- * @param {string} newValue
- * @param {BpmnFactory} bpmnFactory
- */
-function updateFormalExpression(element, propertyName, newValue, bpmnFactory) {
-  const businessObject = getBusinessObject(element);
-  const expressionProps = {};
-
-  if (!newValue) {
-
-    // remove formal expression
-    expressionProps[propertyName] = undefined;
-
-    return {
-      element,
-      moddleElement: businessObject,
-      properties: expressionProps,
-    };
-  }
-
-  const existingExpression = businessObject.get(propertyName);
-  if (!existingExpression) {
-
-    // add formal expression
-    expressionProps[propertyName] = createElement(
-      'bpmn:FormalExpression',
-      { body: newValue },
-      businessObject,
-      bpmnFactory
-    );
-
-    return {
-      element,
-      moddleElement: businessObject,
-      properties: expressionProps,
-    };
-  }
-
-  // edit existing formal expression
-  return {
-    element,
-    moddleElement: existingExpression,
-    properties: {
-      body: newValue,
-    },
-  };
 }

--- a/src/provider/bpmn/properties/AdHocCompletionProps.js
+++ b/src/provider/bpmn/properties/AdHocCompletionProps.js
@@ -1,0 +1,156 @@
+import { is, getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  CheckboxEntry,
+  isTextFieldEntryEdited,
+  TextFieldEntry,
+} from '@bpmn-io/properties-panel';
+
+import { createElement } from '../../../utils/ElementUtil';
+
+import { useService } from '../../../hooks';
+
+/**
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
+ */
+
+/**
+ * @returns {Array<Entry>} entries
+ */
+export function AdHocCompletionProps(props) {
+  const { element } = props;
+
+  if (!is(element, 'bpmn:AdHocSubProcess')) {
+    return [];
+  }
+
+  return [
+    {
+      id: 'completionCondition',
+      component: CompletionCondition,
+      isEdited: isTextFieldEntryEdited,
+    },
+    {
+      id: 'cancelRemainingInstances',
+      component: CancelRemainingInstances,
+      isEdited: (node) => node && !node.checked // the default value is true
+    },
+  ];
+}
+
+function CompletionCondition(props) {
+  const { element } = props;
+
+  const bpmnFactory = useService('bpmnFactory');
+  const debounce = useService('debounceInput');
+  const commandStack = useService('commandStack');
+  const translate = useService('translate');
+
+  const getValue = () => {
+    const expression = getBusinessObject(element).get('completionCondition');
+    return expression && expression.get('body');
+  };
+
+  const setValue = (value) => {
+    return commandStack.execute(
+      'element.updateModdleProperties',
+      updateFormalExpression(element, 'completionCondition', value, bpmnFactory)
+    );
+  };
+
+  return TextFieldEntry({
+    element,
+    id: 'completionCondition',
+    label: translate('Completion condition'),
+    getValue,
+    setValue,
+    debounce
+  });
+}
+
+function CancelRemainingInstances(props) {
+  const { element } = props;
+
+  const commandStack = useService('commandStack');
+  const translate = useService('translate');
+
+  const businessObject = getBusinessObject(element);
+
+  const getValue = () => {
+    return businessObject.get('cancelRemainingInstances');
+  };
+
+  const setValue = (value) => {
+    commandStack.execute('element.updateModdleProperties', {
+      element,
+      moddleElement: businessObject,
+      properties: {
+        cancelRemainingInstances: value,
+      },
+    });
+  };
+
+  return CheckboxEntry({
+    element,
+    id: 'cancelRemainingInstances',
+    label: translate('Cancel remaining instances'),
+    getValue,
+    setValue,
+  });
+}
+
+// helper ////////////////////////////
+
+// formal expression /////////////////
+
+/**
+ * updateFormalExpression - updates a specific formal expression
+ *
+ * @param {djs.model.Base} element
+ * @param {string} propertyName
+ * @param {string} newValue
+ * @param {BpmnFactory} bpmnFactory
+ */
+function updateFormalExpression(element, propertyName, newValue, bpmnFactory) {
+  const businessObject = getBusinessObject(element);
+  const expressionProps = {};
+
+  if (!newValue) {
+
+    // remove formal expression
+    expressionProps[propertyName] = undefined;
+
+    return {
+      element,
+      moddleElement: businessObject,
+      properties: expressionProps,
+    };
+  }
+
+  const existingExpression = businessObject.get(propertyName);
+  if (!existingExpression) {
+
+    // add formal expression
+    expressionProps[propertyName] = createElement(
+      'bpmn:FormalExpression',
+      { body: newValue },
+      businessObject,
+      bpmnFactory
+    );
+
+    return {
+      element,
+      moddleElement: businessObject,
+      properties: expressionProps,
+    };
+  }
+
+  // edit existing formal expression
+  return {
+    element,
+    moddleElement: existingExpression,
+    properties: {
+      body: newValue,
+    },
+  };
+}

--- a/src/provider/bpmn/properties/MultiInstanceProps.js
+++ b/src/provider/bpmn/properties/MultiInstanceProps.js
@@ -10,8 +10,8 @@ import {
 } from '../../../hooks';
 
 import {
-  createElement
-} from '../../../utils/ElementUtil';
+  createOrUpdateFormalExpression
+} from '../../../utils/FormalExpressionUtil';
 
 /**
  * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
@@ -58,9 +58,13 @@ function LoopCardinality(props) {
   };
 
   const setValue = (value) => {
-    return commandStack.execute(
-      'element.updateModdleProperties',
-      updateFormalExpression(element, 'loopCardinality', value, bpmnFactory)
+    return createOrUpdateFormalExpression(
+      element,
+      getLoopCharacteristics(element),
+      'loopCardinality',
+      value,
+      bpmnFactory,
+      commandStack
     );
   };
 
@@ -87,9 +91,13 @@ function CompletionCondition(props) {
   };
 
   const setValue = (value) => {
-    return commandStack.execute(
-      'element.updateModdleProperties',
-      updateFormalExpression(element, 'completionCondition', value, bpmnFactory)
+    return createOrUpdateFormalExpression(
+      element,
+      getLoopCharacteristics(element),
+      'completionCondition',
+      value,
+      bpmnFactory,
+      commandStack
     );
   };
 
@@ -151,68 +159,6 @@ function getProperty(element, propertyName) {
 function getLoopCharacteristics(element) {
   const bo = getBusinessObject(element);
   return bo.loopCharacteristics;
-}
-
-/**
- * createFormalExpression - creates a 'bpmn:FormalExpression' element.
- *
- * @param {ModdleElement} parent
- * @param {string} body
- * @param {BpmnFactory} bpmnFactory
- *
- * @result {ModdleElement<bpmn:FormalExpression>} a formal expression
- */
-function createFormalExpression(parent, body, bpmnFactory) {
-  return createElement('bpmn:FormalExpression', { body: body }, parent, bpmnFactory);
-}
-
-/**
- * updateFormalExpression - updates a specific formal expression of the loop characteristics.
- *
- * @param {djs.model.Base} element
- * @param {string} propertyName
- * @param {string} newValue
- * @param {BpmnFactory} bpmnFactory
- */
-function updateFormalExpression(element, propertyName, newValue, bpmnFactory) {
-  const loopCharacteristics = getLoopCharacteristics(element);
-
-  const expressionProps = {};
-
-  if (!newValue) {
-
-    // remove formal expression
-    expressionProps[ propertyName ] = undefined;
-
-    return {
-      element,
-      moddleElement: loopCharacteristics,
-      properties: expressionProps
-    };
-  }
-
-  const existingExpression = loopCharacteristics.get(propertyName);
-
-  if (!existingExpression) {
-
-    // add formal expression
-    expressionProps[ propertyName ] = createFormalExpression(loopCharacteristics, newValue, bpmnFactory);
-
-    return {
-      element,
-      moddleElement: loopCharacteristics,
-      properties: expressionProps
-    };
-  }
-
-  // edit existing formal expression
-  return {
-    element,
-    moddleElement: existingExpression,
-    properties: {
-      body: newValue
-    }
-  };
 }
 
 // loopCardinality

--- a/src/provider/bpmn/properties/index.js
+++ b/src/provider/bpmn/properties/index.js
@@ -1,3 +1,4 @@
+export { AdHocCompletionProps } from './AdHocCompletionProps';
 export { CompensationProps } from './CompensationProps';
 export { DocumentationProps } from './DocumentationProps';
 export { ErrorProps } from './ErrorProps';

--- a/src/provider/zeebe/properties/AdHocCompletionProps.js
+++ b/src/provider/zeebe/properties/AdHocCompletionProps.js
@@ -1,0 +1,121 @@
+import { is, getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  isFeelEntryEdited,
+} from '@bpmn-io/properties-panel';
+
+import { createElement } from '../../../utils/ElementUtil';
+
+import { useService } from '../../../hooks';
+
+import { FeelEntryWithVariableContext } from '../../../entries/FeelEntryWithContext';
+
+/**
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
+ */
+
+/**
+ * @returns {Array<Entry>} entries
+ */
+export function AdHocCompletionProps(props) {
+  const { element } = props;
+
+  if (!is(element, 'bpmn:AdHocSubProcess')) {
+    return [];
+  }
+
+  return [
+    {
+      id: 'completionCondition',
+      component: CompletionCondition,
+      isEdited: isFeelEntryEdited,
+    }
+  ];
+}
+
+function CompletionCondition(props) {
+  const { element } = props;
+
+  const bpmnFactory = useService('bpmnFactory');
+  const debounce = useService('debounceInput');
+  const commandStack = useService('commandStack');
+  const translate = useService('translate');
+
+  const getValue = () => {
+    const expression = getBusinessObject(element).get('completionCondition');
+    return expression && expression.get('body');
+  };
+
+  const setValue = (value) => {
+    return commandStack.execute(
+      'element.updateModdleProperties',
+      updateFormalExpression(element, 'completionCondition', value, bpmnFactory)
+    );
+  };
+
+  return FeelEntryWithVariableContext({
+    element,
+    id: 'completionCondition',
+    label: translate('Completion condition'),
+    feel: 'required',
+    getValue,
+    setValue,
+    debounce,
+  });
+}
+
+// helper ////////////////////////////
+
+// formal expression /////////////////
+
+/**
+ * updateFormalExpression - updates a specific formal expression
+ *
+ * @param {djs.model.Base} element
+ * @param {string} propertyName
+ * @param {string} newValue
+ * @param {BpmnFactory} bpmnFactory
+ */
+function updateFormalExpression(element, propertyName, newValue, bpmnFactory) {
+  const businessObject = getBusinessObject(element);
+  const expressionProps = {};
+
+  if (!newValue) {
+
+    // remove formal expression
+    expressionProps[propertyName] = undefined;
+
+    return {
+      element,
+      moddleElement: businessObject,
+      properties: expressionProps,
+    };
+  }
+
+  const existingExpression = businessObject.get(propertyName);
+  if (!existingExpression) {
+
+    // add formal expression
+    expressionProps[propertyName] = createElement(
+      'bpmn:FormalExpression',
+      { body: newValue },
+      businessObject,
+      bpmnFactory
+    );
+
+    return {
+      element,
+      moddleElement: businessObject,
+      properties: expressionProps,
+    };
+  }
+
+  // edit existing formal expression
+  return {
+    element,
+    moddleElement: existingExpression,
+    properties: {
+      body: newValue,
+    },
+  };
+}

--- a/src/provider/zeebe/properties/AdHocCompletionProps.js
+++ b/src/provider/zeebe/properties/AdHocCompletionProps.js
@@ -4,11 +4,9 @@ import {
   isFeelEntryEdited,
 } from '@bpmn-io/properties-panel';
 
-import { createElement } from '../../../utils/ElementUtil';
-
 import { useService } from '../../../hooks';
-
 import { FeelEntryWithVariableContext } from '../../../entries/FeelEntryWithContext';
+import { createOrUpdateFormalExpression } from '../../../utils/FormalExpressionUtil';
 
 /**
  * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
@@ -47,9 +45,13 @@ function CompletionCondition(props) {
   };
 
   const setValue = (value) => {
-    return commandStack.execute(
-      'element.updateModdleProperties',
-      updateFormalExpression(element, 'completionCondition', value, bpmnFactory)
+    return createOrUpdateFormalExpression(
+      element,
+      getBusinessObject(element),
+      'completionCondition',
+      value,
+      bpmnFactory,
+      commandStack
     );
   };
 
@@ -62,60 +64,4 @@ function CompletionCondition(props) {
     setValue,
     debounce,
   });
-}
-
-// helper ////////////////////////////
-
-// formal expression /////////////////
-
-/**
- * updateFormalExpression - updates a specific formal expression
- *
- * @param {djs.model.Base} element
- * @param {string} propertyName
- * @param {string} newValue
- * @param {BpmnFactory} bpmnFactory
- */
-function updateFormalExpression(element, propertyName, newValue, bpmnFactory) {
-  const businessObject = getBusinessObject(element);
-  const expressionProps = {};
-
-  if (!newValue) {
-
-    // remove formal expression
-    expressionProps[propertyName] = undefined;
-
-    return {
-      element,
-      moddleElement: businessObject,
-      properties: expressionProps,
-    };
-  }
-
-  const existingExpression = businessObject.get(propertyName);
-  if (!existingExpression) {
-
-    // add formal expression
-    expressionProps[propertyName] = createElement(
-      'bpmn:FormalExpression',
-      { body: newValue },
-      businessObject,
-      bpmnFactory
-    );
-
-    return {
-      element,
-      moddleElement: businessObject,
-      properties: expressionProps,
-    };
-  }
-
-  // edit existing formal expression
-  return {
-    element,
-    moddleElement: existingExpression,
-    properties: {
-      body: newValue,
-    },
-  };
 }

--- a/src/provider/zeebe/properties/MultiInstanceProps.js
+++ b/src/provider/zeebe/properties/MultiInstanceProps.js
@@ -14,11 +14,13 @@ import {
 import {
   createElement
 } from '../../../utils/ElementUtil';
+import {
+  createOrUpdateFormalExpression
+} from '../../../utils/FormalExpressionUtil';
 
 import { useService } from '../../../hooks';
 
 import { FeelEntryWithVariableContext } from '../../../entries/FeelEntryWithContext';
-
 
 export function MultiInstanceProps(props) {
   const {
@@ -188,18 +190,14 @@ function CompletionCondition(props) {
   };
 
   const setValue = (value) => {
-    if (value && value !== '') {
-      const loopCharacteristics = getLoopCharacteristics(element);
-      const completionCondition = createElement(
-        'bpmn:FormalExpression',
-        { body: value },
-        loopCharacteristics,
-        bpmnFactory
-      );
-      setCompletionCondition(element, commandStack, completionCondition);
-    } else {
-      setCompletionCondition(element, commandStack, undefined);
-    }
+    return createOrUpdateFormalExpression(
+      element,
+      getLoopCharacteristics(element),
+      'completionCondition',
+      value,
+      bpmnFactory,
+      commandStack
+    );
   };
 
   return FeelEntryWithVariableContext({
@@ -232,16 +230,6 @@ function supportsMultiInstances(element) {
 
 function getCompletionCondition(element) {
   return getLoopCharacteristics(element).get('completionCondition');
-}
-
-function setCompletionCondition(element, commandStack, completionCondition = undefined) {
-  commandStack.execute('element.updateModdleProperties', {
-    element,
-    moddleElement: getLoopCharacteristics(element),
-    properties: {
-      completionCondition
-    }
-  });
 }
 
 function getProperty(element, propertyName) {

--- a/src/provider/zeebe/properties/index.js
+++ b/src/provider/zeebe/properties/index.js
@@ -1,4 +1,5 @@
 export { ActiveElementsProps } from './ActiveElementsProps';
+export { AdHocCompletionProps } from './AdHocCompletionProps';
 export { AssignmentDefinitionProps } from './AssignmentDefinitionProps';
 export { BusinessRuleImplementationProps } from './BusinessRuleImplementationProps';
 export { CalledDecisionProps } from './CalledDecisionProps';

--- a/src/utils/FormalExpressionUtil.js
+++ b/src/utils/FormalExpressionUtil.js
@@ -1,0 +1,93 @@
+import { createElement } from './ElementUtil';
+
+/**
+ * createOrUpdateFormalExpression - upserts a specific formal expression
+ *
+ * If the value is falsy, the formal expression is removed.
+ *
+ * @param {djs.model.Base} element
+ * @param {ModdleElement} moddleElement
+ * @param {string} propertyName
+ * @param {string} newValue
+ * @param {BpmnFactory} bpmnFactory
+ * @param {CommandStack} commandStack
+ */
+export function createOrUpdateFormalExpression(
+    element,
+    moddleElement,
+    propertyName,
+    newValue,
+    bpmnFactory,
+    commandStack
+) {
+  return commandStack.execute(
+    'element.updateModdleProperties',
+    createOrUpdateFormalExpressionCommand(
+      element,
+      moddleElement,
+      propertyName,
+      newValue,
+      bpmnFactory
+    )
+  );
+}
+
+/**
+ * createOrUpdateFormalExpressionCommand - creates a command to upsert a specific formal expression
+ *
+ * If the value is falsy, the formal expression is removed.
+ *
+ * @param {djs.model.Base} element
+ * @param {ModdleElement} moddleElement
+ * @param {string} propertyName
+ * @param {string} newValue
+ * @param {BpmnFactory} bpmnFactory
+ */
+export function createOrUpdateFormalExpressionCommand(
+    element,
+    moddleElement,
+    propertyName,
+    newValue,
+    bpmnFactory
+) {
+  const expressionProps = {};
+
+  if (!newValue) {
+
+    // remove formal expression
+    expressionProps[propertyName] = undefined;
+
+    return {
+      element,
+      moddleElement,
+      properties: expressionProps,
+    };
+  }
+
+  const existingExpression = moddleElement.get(propertyName);
+  if (existingExpression) {
+
+    // edit existing formal expression
+    return {
+      element,
+      moddleElement: existingExpression,
+      properties: {
+        body: newValue,
+      },
+    };
+  }
+
+  // add formal expression
+  expressionProps[propertyName] = createElement(
+    'bpmn:FormalExpression',
+    { body: newValue },
+    moddleElement,
+    bpmnFactory
+  );
+
+  return {
+    element,
+    moddleElement,
+    properties: expressionProps,
+  };
+}

--- a/test/spec/provider/bpmn/AdHocCompletionProps.bpmn
+++ b/test/spec/provider/bpmn/AdHocCompletionProps.bpmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1rk4hoy" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.32.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_1sk4u1k" isExecutable="true">
+    <bpmn:adHocSubProcess id="Subprocess_1" cancelRemainingInstances="false">
+      <bpmn:task id="Activity_167ttdt" />
+      <bpmn:task id="Activity_0cxw94m" />
+      <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">myCondition</bpmn:completionCondition>
+    </bpmn:adHocSubProcess>
+    <bpmn:adHocSubProcess id="Subprocess_2">
+      <bpmn:task id="Activity_1qb8yya" />
+      <bpmn:task id="Activity_1i2ek76" />
+    </bpmn:adHocSubProcess>
+    <bpmn:subProcess id="Subprocess_3">
+      <bpmn:task id="Activity_0zq4nsm" />
+      <bpmn:task id="Activity_0lm8w2j" />
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1sk4u1k">
+      <bpmndi:BPMNShape id="Activity_1hitopu_di" bpmnElement="Subprocess_1" isExpanded="true">
+        <dc:Bounds x="160" y="70" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_167ttdt_di" bpmnElement="Activity_167ttdt">
+        <dc:Bounds x="210" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cxw94m_di" bpmnElement="Activity_0cxw94m">
+        <dc:Bounds x="360" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_06ihycz" bpmnElement="Subprocess_2" isExpanded="true">
+        <dc:Bounds x="540" y="70" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0c1eh57" bpmnElement="Activity_1qb8yya">
+        <dc:Bounds x="590" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1g9skdj" bpmnElement="Activity_1i2ek76">
+        <dc:Bounds x="740" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0yx7vzw_di" bpmnElement="Subprocess_3" isExpanded="true">
+        <dc:Bounds x="920" y="70" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_15yw4jq" bpmnElement="Activity_0zq4nsm">
+        <dc:Bounds x="970" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1qxgz7m" bpmnElement="Activity_0lm8w2j">
+        <dc:Bounds x="1120" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/bpmn/AdHocCompletionProps.spec.js
+++ b/test/spec/provider/bpmn/AdHocCompletionProps.spec.js
@@ -1,0 +1,339 @@
+import TestContainer from 'mocha-test-container-support';
+import { act } from '@testing-library/preact';
+
+import { bootstrapPropertiesPanel, changeInput, clickInput, inject } from 'test/TestHelper';
+
+import { query as domQuery } from 'min-dom';
+
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+import BpmnPropertiesPanel from 'src/render';
+import BpmnPropertiesProvider from 'src/provider/bpmn';
+
+import diagramXML from './AdHocCompletionProps.bpmn';
+
+describe('provider/bpmn - AdHocCompletion', function() {
+
+  const testModules = [
+    BpmnPropertiesPanel,
+    BpmnPropertiesProvider,
+    CoreModule,
+    ModelingModule,
+    SelectionModule,
+  ];
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(
+    bootstrapPropertiesPanel(diagramXML, {
+      modules: testModules,
+      debounceInput: false,
+    })
+  );
+
+
+  describe('bpmn:AdHocSubProcess', function() {
+
+    it('should display completion group on ad-hoc subprocess', inject(async function(
+        elementRegistry,
+        selection
+    ) {
+
+      // given
+      const subprocess = elementRegistry.get('Subprocess_1');
+
+      // when
+      await act(() => {
+        selection.select(subprocess);
+      });
+
+      // then
+      const group = getGroup(container, 'adHocCompletion');
+      expect(group).to.exist;
+      expect(getCompletionConditionInput(container)).to.exist;
+      expect(getCancelRemainingInstancesCheckbox(container)).to.exist;
+    }));
+
+
+    it('should NOT display completion group on a normal subprocess', inject(async function(
+        elementRegistry,
+        selection
+    ) {
+
+      // given
+      const subprocess = elementRegistry.get('Subprocess_3');
+
+      // when
+      await act(() => {
+        selection.select(subprocess);
+      });
+
+      // then
+      const group = getGroup(container, 'adHocCompletion');
+      expect(group).not.to.exist;
+    }));
+
+
+    describe('#completionCondition', function() {
+
+      it('should show the expected value when a condition is configured', inject(async function(elementRegistry, selection) {
+
+        // given
+        const subprocess = elementRegistry.get('Subprocess_1');
+
+        // when
+        await act(() => {
+          selection.select(subprocess);
+        });
+
+        // then
+        const completionConditionInput = getCompletionConditionInput(container);
+        expect(completionConditionInput).to.exist;
+        expect(completionConditionInput.value).to.equal(getCompletionConditionValue(subprocess));
+      }));
+
+
+      it('should be empty when no condition is configured', inject(async function(elementRegistry, selection) {
+
+        // given
+        const subprocess = elementRegistry.get('Subprocess_2');
+
+        // when
+        await act(() => {
+          selection.select(subprocess);
+        });
+
+        // then
+        const completionConditionInput = getCompletionConditionInput(container);
+        expect(completionConditionInput).to.exist;
+        expect(completionConditionInput.value).to.be.empty;
+      }));
+
+
+      it('should update - reusing existing FormalExpression',
+        inject(async function(elementRegistry, selection) {
+
+          // given
+          const subprocess = elementRegistry.get('Subprocess_1');
+
+          await act(() => {
+            selection.select(subprocess);
+          });
+
+          // when
+          const completionConditionInput = getCompletionConditionInput(container);
+          changeInput(completionConditionInput, 'newValue');
+
+          // then
+          expect(getCompletionConditionValue(subprocess)).to.equal('newValue');
+        })
+      );
+
+
+      it('should update - creating new FormalExpression',
+        inject(async function(elementRegistry, selection) {
+
+          // given
+          const subprocess = elementRegistry.get('Subprocess_2');
+
+          await act(() => {
+            selection.select(subprocess);
+          });
+
+          // when
+          const completionConditionInput = getCompletionConditionInput(container);
+          changeInput(completionConditionInput, 'newValue');
+
+          // then
+          expect(getCompletionConditionValue(subprocess)).to.equal('newValue');
+        })
+      );
+
+
+      it('should update - set property to undefined',
+        inject(async function(elementRegistry, selection) {
+
+          // given
+          const subprocess = elementRegistry.get('Subprocess_1');
+
+          await act(() => {
+            selection.select(subprocess);
+          });
+
+          // when
+          const completionConditionInput = getCompletionConditionInput(container);
+          changeInput(completionConditionInput, '');
+
+          // then
+          expect(getCompletionCondition(subprocess)).to.be.undefined;
+        })
+      );
+
+
+      it('should update on external change',
+        inject(async function(elementRegistry, selection, commandStack) {
+
+          // given
+          const subprocess = elementRegistry.get('Subprocess_1');
+          const originalValue = getCompletionConditionValue(subprocess);
+
+          await act(() => {
+            selection.select(subprocess);
+          });
+          const completionConditionInput = getCompletionConditionInput(container);
+          changeInput(completionConditionInput, 'newValue');
+          expect(getCompletionConditionValue(subprocess)).not.to.equal(originalValue);
+
+          // when
+          await act(() => {
+            commandStack.undo();
+          });
+
+          // then
+          expect(getCompletionConditionValue(subprocess)).to.equal(originalValue);
+        })
+      );
+    });
+
+    describe('#cancelRemainingInstances', function() {
+
+      it('should be checked when not explicitely configured on the process', inject(async function(elementRegistry, selection) {
+
+        // given
+        const subprocess = elementRegistry.get('Subprocess_2');
+        expect(getCancelRemainingInstancesValue(subprocess)).to.be.true;
+
+        // when
+        await act(() => {
+          selection.select(subprocess);
+        });
+
+        // then
+        const cancelRemainingInstancesCheckbox = getCancelRemainingInstancesCheckbox(container);
+        expect(cancelRemainingInstancesCheckbox).to.exist;
+        expect(cancelRemainingInstancesCheckbox.checked).be.true;
+      }));
+
+
+      it('should be unchecked when set to false on the process', inject(async function(
+          elementRegistry, selection
+      ) {
+
+        // given
+        const subprocess = elementRegistry.get('Subprocess_1');
+        expect(getCancelRemainingInstancesValue(subprocess)).to.be.false;
+
+        // when
+        await act(() => {
+          selection.select(subprocess);
+        });
+
+        // then
+        const cancelRemainingInstancesCheckbox = getCancelRemainingInstancesCheckbox(container);
+        expect(cancelRemainingInstancesCheckbox).to.exist;
+        expect(cancelRemainingInstancesCheckbox.checked).be.false;
+      }));
+
+
+      it('should update', inject(async function(elementRegistry, selection) {
+
+        // given
+        const subprocess = elementRegistry.get('Subprocess_1');
+
+        // when
+        await act(() => {
+          selection.select(subprocess);
+        });
+
+        const cancelRemainingInstancesCheckbox = getCancelRemainingInstancesCheckbox(container);
+        clickInput(cancelRemainingInstancesCheckbox);
+
+        // then
+        expect(getCancelRemainingInstancesValue(subprocess)).to.be.true;
+      }));
+
+
+      it('should update on external change',
+        inject(async function(elementRegistry, selection, commandStack) {
+
+          // given
+          const subprocess = elementRegistry.get('Subprocess_1');
+          const originalValue = getCancelRemainingInstancesValue(subprocess);
+
+          await act(() => {
+            selection.select(subprocess);
+          });
+
+          const cancelRemainingInstancesCheckbox = getCancelRemainingInstancesCheckbox(container);
+          clickInput(cancelRemainingInstancesCheckbox);
+          expect(getCancelRemainingInstancesValue(subprocess)).not.to.equal(originalValue);
+
+          // when
+          await act(() => {
+            commandStack.undo();
+          });
+
+          // then
+          expect(getCancelRemainingInstancesValue(subprocess)).to.equal(originalValue);
+        })
+      );
+    });
+  });
+});
+
+// DOM helpers ////////////////////////////
+
+function getGroup(container, id) {
+  return domQuery(`[data-group-id="group-${id}"`, container);
+}
+
+function getCompletionConditionInput(container) {
+  return domQuery('[name=completionCondition]', container);
+}
+
+function getCancelRemainingInstancesCheckbox(container) {
+  return domQuery('[name=cancelRemainingInstances]', container);
+}
+
+// model helpers ////////////////////////////
+
+/**
+ * getCompletionCondition - get the completion condition of of the ad-hoc subprocess.
+ *
+ * @param {djs.model.Base} element
+ *
+ * @return {ModdleElement<bpmn:FormalExpression>} an expression representing the completion condition
+ */
+function getCompletionCondition(element) {
+  return getBusinessObject(element).get('completionCondition');
+}
+
+/**
+ * getCompletionConditionValue - get the completion condition value of of the ad-hoc subprocess.
+ *
+ * @param {djs.model.Base} element
+ *
+ * @return {string} the completion condition value
+ */
+function getCompletionConditionValue(element) {
+  const completionCondition = getCompletionCondition(element);
+  return completionCondition && completionCondition.get('body');
+}
+
+/**
+ * getCancelRemainingInstancesValue - get the cancel remaining instances value of the ad-hoc subprocess.
+ *
+ * @param {djs.model.Base} element
+ *
+ * @return {boolean} the cancel remaining instances value
+ */
+function getCancelRemainingInstancesValue(element) {
+  return getBusinessObject(element).get('cancelRemainingInstances');
+}

--- a/test/spec/provider/zeebe/AdHocCompletionProps.bpmn
+++ b/test/spec/provider/zeebe/AdHocCompletionProps.bpmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1rk4hoy" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.32.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_1sk4u1k" isExecutable="true">
+    <bpmn:adHocSubProcess id="Subprocess_1" cancelRemainingInstances="false">
+      <bpmn:task id="Activity_167ttdt" />
+      <bpmn:task id="Activity_0cxw94m" />
+      <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">=myCondition</bpmn:completionCondition>
+    </bpmn:adHocSubProcess>
+    <bpmn:adHocSubProcess id="Subprocess_2">
+      <bpmn:task id="Activity_1qb8yya" />
+      <bpmn:task id="Activity_1i2ek76" />
+    </bpmn:adHocSubProcess>
+    <bpmn:subProcess id="Subprocess_3">
+      <bpmn:task id="Activity_0zq4nsm" />
+      <bpmn:task id="Activity_0lm8w2j" />
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1sk4u1k">
+      <bpmndi:BPMNShape id="Activity_1hitopu_di" bpmnElement="Subprocess_1" isExpanded="true">
+        <dc:Bounds x="160" y="70" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_167ttdt_di" bpmnElement="Activity_167ttdt">
+        <dc:Bounds x="210" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cxw94m_di" bpmnElement="Activity_0cxw94m">
+        <dc:Bounds x="360" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_06ihycz" bpmnElement="Subprocess_2" isExpanded="true">
+        <dc:Bounds x="540" y="70" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0c1eh57" bpmnElement="Activity_1qb8yya">
+        <dc:Bounds x="590" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1g9skdj" bpmnElement="Activity_1i2ek76">
+        <dc:Bounds x="740" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0yx7vzw_di" bpmnElement="Subprocess_3" isExpanded="true">
+        <dc:Bounds x="920" y="70" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_15yw4jq" bpmnElement="Activity_0zq4nsm">
+        <dc:Bounds x="970" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1qxgz7m" bpmnElement="Activity_0lm8w2j">
+        <dc:Bounds x="1120" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/zeebe/AdHocCompletionProps.spec.js
+++ b/test/spec/provider/zeebe/AdHocCompletionProps.spec.js
@@ -1,0 +1,417 @@
+import TestContainer from 'mocha-test-container-support';
+import { act } from '@testing-library/preact';
+
+import { bootstrapPropertiesPanel, clickInput, inject } from 'test/TestHelper';
+
+import { query as domQuery, queryAll } from 'min-dom';
+
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+import BpmnPropertiesPanel from 'src/render';
+import BpmnPropertiesProvider from 'src/provider/bpmn';
+import ZeebePropertiesProvider from 'src/provider/zeebe';
+import TooltipProvider from 'src/contextProvider/zeebe/TooltipProvider';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import diagramXML from './AdHocCompletionProps.bpmn';
+import { setEditorValue } from '../../../TestHelper';
+
+describe('provider/zeebe - AdHocCompletion', function() {
+
+  const testModules = [
+    CoreModule,
+    ModelingModule,
+    SelectionModule,
+    BpmnPropertiesPanel,
+    BpmnPropertiesProvider,
+    ZeebePropertiesProvider
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    modules: testModules,
+    moddleExtensions,
+    propertiesPanel: {
+      tooltip: TooltipProvider
+    },
+    debounceInput: false
+  }));
+
+
+  describe('bpmn:AdHocSubProcess', function() {
+
+    it('should display completion group on ad-hoc subprocess', inject(async function(
+        elementRegistry,
+        selection
+    ) {
+
+      // given
+      const subprocess = elementRegistry.get('Subprocess_1');
+
+      // when
+      await act(() => {
+        selection.select(subprocess);
+      });
+
+      // then
+      const group = getGroup(container, 'adHocCompletion');
+      expect(group).to.exist;
+      expect(getCompletionConditionInput(container)).to.exist;
+      expect(getCancelRemainingInstancesCheckbox(container)).to.exist;
+    }));
+
+
+    it('completion group should be added after active elements group', inject(async function(
+        elementRegistry,
+        selection
+    ) {
+
+      // given
+      const subprocess = elementRegistry.get('Subprocess_1');
+
+      // when
+      await act(() => {
+        selection.select(subprocess);
+      });
+
+      // then
+      const expectedGroupOrder = [
+        'group-activeElements',
+        'group-adHocCompletion'
+      ];
+
+      expect(getGroupIds(container).filter(id => expectedGroupOrder.includes(id))).to.eql(expectedGroupOrder);
+    }));
+
+
+    it('inputs should be in the expected order despite overriding BPMN attribute', inject(async function(
+        elementRegistry,
+        selection
+    ) {
+
+      // given
+      const subprocess = elementRegistry.get('Subprocess_1');
+
+      // when
+      await act(() => {
+        selection.select(subprocess);
+      });
+
+      // then
+      const group = getGroup(container, 'adHocCompletion');
+      expect(getInputNames(group)).to.eql([
+        'completionCondition',
+        'cancelRemainingInstances'
+      ]);
+    }));
+
+
+    it('should NOT display completion group on a normal subprocess', inject(async function(
+        elementRegistry,
+        selection
+    ) {
+
+      // given
+      const subprocess = elementRegistry.get('Subprocess_3');
+
+      // when
+      await act(() => {
+        selection.select(subprocess);
+      });
+
+      // then
+      const group = getGroup(container, 'adHocCompletion');
+      expect(group).not.to.exist;
+    }));
+
+
+    describe('#completionCondition', function() {
+
+      it('should show the expected value when a condition is configured', inject(async function(
+          elementRegistry, selection
+      ) {
+
+        // given
+        const subprocess = elementRegistry.get('Subprocess_1');
+
+        // when
+        await act(() => {
+          selection.select(subprocess);
+        });
+
+        // then
+        const completionConditionInput = getCompletionConditionInput(container);
+        expect(completionConditionInput).to.exist;
+        expect('=' + getEditorValue(completionConditionInput)).to.equal(getCompletionConditionValue(subprocess));
+      }));
+
+
+      it('should be empty when no condition is configured', inject(async function(elementRegistry, selection) {
+
+        // given
+        const subprocess = elementRegistry.get('Subprocess_2');
+
+        // when
+        await act(() => {
+          selection.select(subprocess);
+        });
+
+        // then
+        const completionConditionInput = getCompletionConditionInput(container);
+        expect(completionConditionInput).to.exist;
+        expect(getEditorValue(completionConditionInput)).to.be.empty;
+      }));
+
+
+      it('should update - reusing existing FormalExpression',
+        inject(async function(elementRegistry, selection) {
+
+          // given
+          const subprocess = elementRegistry.get('Subprocess_1');
+
+          await act(() => {
+            selection.select(subprocess);
+          });
+
+          // when
+          const completionConditionInput = getCompletionConditionInput(container);
+          await setEditorValue(completionConditionInput, 'newValue');
+
+          // then
+          expect(getCompletionConditionValue(subprocess)).to.equal('=newValue');
+        })
+      );
+
+
+      it('should update - creating new FormalExpression',
+        inject(async function(elementRegistry, selection) {
+
+          // given
+          const subprocess = elementRegistry.get('Subprocess_2');
+
+          await act(() => {
+            selection.select(subprocess);
+          });
+
+          // when
+          const completionConditionInput = getCompletionConditionInput(container);
+          await setEditorValue(completionConditionInput, 'newValue');
+
+          // then
+          expect(getCompletionConditionValue(subprocess)).to.equal('=newValue');
+        })
+      );
+
+
+      it('should update - set property to undefined',
+        inject(async function(elementRegistry, selection) {
+
+          // given
+          const subprocess = elementRegistry.get('Subprocess_1');
+
+          await act(() => {
+            selection.select(subprocess);
+          });
+
+          // when
+          const completionConditionInput = getCompletionConditionInput(container);
+          await setEditorValue(completionConditionInput, '');
+
+          // then
+          expect(getCompletionCondition(subprocess)).to.be.undefined;
+        })
+      );
+
+
+      it('should update on external change',
+        inject(async function(elementRegistry, selection, commandStack) {
+
+          // given
+          const subprocess = elementRegistry.get('Subprocess_1');
+          const originalValue = getCompletionConditionValue(subprocess);
+
+          await act(() => {
+            selection.select(subprocess);
+          });
+          const completionConditionInput = getCompletionConditionInput(container);
+          await setEditorValue(completionConditionInput, 'newValue');
+          expect(getCompletionConditionValue(subprocess)).not.to.equal(originalValue);
+
+          // when
+          await act(() => {
+            commandStack.undo();
+          });
+
+          // then
+          expect(getCompletionConditionValue(subprocess)).to.equal(originalValue);
+        })
+      );
+    });
+
+
+    describe('#cancelRemainingInstances', function() {
+
+      it('should be checked when not explicitely configured on the process', inject(async function(
+          elementRegistry, selection
+      ) {
+
+        // given
+        const subprocess = elementRegistry.get('Subprocess_2');
+        expect(getCancelRemainingInstancesValue(subprocess)).to.be.true;
+
+        // when
+        await act(() => {
+          selection.select(subprocess);
+        });
+
+        // then
+        const cancelRemainingInstancesCheckbox = getCancelRemainingInstancesCheckbox(container);
+        expect(cancelRemainingInstancesCheckbox).to.exist;
+        expect(cancelRemainingInstancesCheckbox.checked).be.true;
+      }));
+
+
+      it('should be unchecked when set to false on the process', inject(async function(elementRegistry, selection) {
+
+        // given
+        const subprocess = elementRegistry.get('Subprocess_1');
+        expect(getCancelRemainingInstancesValue(subprocess)).to.be.false;
+
+        // when
+        await act(() => {
+          selection.select(subprocess);
+        });
+
+        // then
+        const cancelRemainingInstancesCheckbox = getCancelRemainingInstancesCheckbox(container);
+        expect(cancelRemainingInstancesCheckbox).to.exist;
+        expect(cancelRemainingInstancesCheckbox.checked).be.false;
+      }));
+
+
+      it('should update', inject(async function(elementRegistry, selection) {
+
+        // given
+        const subprocess = elementRegistry.get('Subprocess_1');
+
+        // when
+        await act(() => {
+          selection.select(subprocess);
+        });
+
+        const cancelRemainingInstancesCheckbox = getCancelRemainingInstancesCheckbox(container);
+        clickInput(cancelRemainingInstancesCheckbox);
+
+        // then
+        expect(getCancelRemainingInstancesValue(subprocess)).to.be.true;
+      }));
+
+
+      it('should update on external change',
+        inject(async function(elementRegistry, selection, commandStack) {
+
+          // given
+          const subprocess = elementRegistry.get('Subprocess_1');
+          const originalValue = getCancelRemainingInstancesValue(subprocess);
+
+          await act(() => {
+            selection.select(subprocess);
+          });
+
+          const cancelRemainingInstancesCheckbox = getCancelRemainingInstancesCheckbox(container);
+          clickInput(cancelRemainingInstancesCheckbox);
+          expect(getCancelRemainingInstancesValue(subprocess)).not.to.equal(originalValue);
+
+          // when
+          await act(() => {
+            commandStack.undo();
+          });
+
+          // then
+          expect(getCancelRemainingInstancesValue(subprocess)).to.equal(originalValue);
+        })
+      );
+    });
+  });
+});
+
+// DOM helpers ////////////////////////////
+
+function getEditorValue(input) {
+  return input.textContent;
+}
+
+function getGroup(container, id) {
+  return domQuery(`[data-group-id="group-${id}"`, container);
+}
+
+function getInputNames(container) {
+  const inputs = queryAll('[name]', container);
+  const inputNames = Array.from(inputs).map(input => input.getAttribute('name'));
+
+  return inputNames;
+}
+
+function getGroupIds(container) {
+  const groups = queryAll('[data-group-id]', container);
+  const groupIds = Array.from(groups).map(group => group.getAttribute('data-group-id'));
+
+  return groupIds;
+}
+
+function getCompletionConditionInput(container) {
+  return domQuery('[name=completionCondition] [role="textbox"]', container);
+}
+
+function getCancelRemainingInstancesCheckbox(container) {
+  return domQuery('[name=cancelRemainingInstances]', container);
+}
+
+// model helpers ////////////////////////////
+
+/**
+ * getCompletionCondition - get the completion condition of of the ad-hoc subprocess.
+ *
+ * @param {djs.model.Base} element
+ *
+ * @return {ModdleElement<bpmn:FormalExpression>} an expression representing the completion condition
+ */
+function getCompletionCondition(element) {
+  return getBusinessObject(element).get('completionCondition');
+}
+
+/**
+ * getCompletionConditionValue - get the completion condition value of of the ad-hoc subprocess.
+ *
+ * @param {djs.model.Base} element
+ *
+ * @return {string} the completion condition value
+ */
+function getCompletionConditionValue(element) {
+  const completionCondition = getCompletionCondition(element);
+  return completionCondition && completionCondition.get('body');
+}
+
+/**
+ * getCancelRemainingInstancesValue - get the cancel remaining instances value of the ad-hoc subprocess.
+ *
+ * @param {djs.model.Base} element
+ *
+ * @return {boolean} the cancel remaining instances value
+ */
+function getCancelRemainingInstancesValue(element) {
+  return getBusinessObject(element).get('cancelRemainingInstances');
+}


### PR DESCRIPTION
### Proposed Changes

Adds support to configure `completionCondition` (expression) and `cancelRemainingInstances` (boolean) for ad-hoc subprocesses.

**BPMN implementation**
![image](https://github.com/user-attachments/assets/4bb26ac1-607f-42a0-8ab0-7aac650fcb36)

**Zeebe specific implementation**
![image](https://github.com/user-attachments/assets/ae318cd7-6a08-4864-8158-8d4081f693ff)

Related to https://github.com/camunda/camunda-modeler/issues/4850.

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
