### PR TITLE
Adjust wording for inpout/output groups

### DIFF
--- a/src/contextProvider/zeebe/TooltipProvider.js
+++ b/src/contextProvider/zeebe/TooltipProvider.js
@@ -247,7 +247,7 @@ const TooltipProvider = {
 
     return (
       <div>
-        { translate('Add input mappings to control what is provided to the activity as local variables. ')}
+        { translate('Add input mappings to control what is passed to the activity as local variables. ')}
         <a href="https://docs.camunda.io/docs/components/concepts/variables/#input-mappings" target="_blank" rel="noopener noreferrer" title={ translate('Input mappings documentation') }>
           { translate('Learn more.') }
         </a>
@@ -260,7 +260,7 @@ const TooltipProvider = {
 
     return (
       <div>
-        { translate('Add output mappings to control what is merged back into the process scope. ')}
+        { translate('Add output mappings to control which variables are merged back into the process scope. ')}
         <a href="https://docs.camunda.io/docs/components/concepts/variables/#output-mappings" target="_blank" rel="noopener noreferrer" title={ translate('Output mappings documentation') }>
           { translate('Learn more.') }
         </a>

--- a/src/contextProvider/zeebe/TooltipProvider.js
+++ b/src/contextProvider/zeebe/TooltipProvider.js
@@ -247,7 +247,7 @@ const TooltipProvider = {
 
     return (
       <div>
-        { translate('Create a new local variable in the scope of this task. ')}
+        { translate('Add input mappings to control what is provided to the activity as local variables. ')}
         <a href="https://docs.camunda.io/docs/components/concepts/variables/#input-mappings" target="_blank" rel="noopener noreferrer" title={ translate('Input mappings documentation') }>
           { translate('Learn more.') }
         </a>
@@ -260,7 +260,7 @@ const TooltipProvider = {
 
     return (
       <div>
-        { translate('Customize how result variables are merged into the global scope of the process instance. ')}
+        { translate('Add output mappings to control what is merged back into the process scope. ')}
         <a href="https://docs.camunda.io/docs/components/concepts/variables/#output-mappings" target="_blank" rel="noopener noreferrer" title={ translate('Output mappings documentation') }>
           { translate('Learn more.') }
         </a>


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4889

### Proposed Changes

Adjust wording for input/output groups as proposed by @nikku in https://github.com/camunda/camunda-modeler/issues/4889#issuecomment-2711239895
<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

<!--
first draft
<img width="1198" alt="screenshot-adjusted-input-output-text" src="https://github.com/user-attachments/assets/9c963aae-0d81-4869-9d2c-beac53d08e6c" />
--> 



<img width="1301" alt="image" src="https://github.com/user-attachments/assets/e0c872a5-354c-4a9d-87ff-45c418be5a4f" />



### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
