### PR TITLE
Update tooltip to ad-hoc completion to jump to the completion section

### DIFF
--- a/src/contextProvider/zeebe/TooltipProvider.js
+++ b/src/contextProvider/zeebe/TooltipProvider.js
@@ -355,7 +355,7 @@ const TooltipProvider = {
     return (
       <div>
         {translate('Define the completion behavior of an ad-hoc subprocess. If no completion condition is set, it will be completed after all active elements have been completed. ')}
-        <a href="https://docs.camunda.io/docs/components/modeler/bpmn/ad-hoc" target="_blank" rel="noopener noreferrer" title={ translate('Ad-hoc subprocess documentation') }>
+        <a href="https://docs.camunda.io/docs/components/modeler/bpmn/ad-hoc#completion" target="_blank" rel="noopener noreferrer" title={ translate('Ad-hoc subprocess documentation') }>
           { translate('Learn more.') }
         </a>
       </div>


### PR DESCRIPTION
### Proposed Changes

Update the tooltip for the [recently introduced ad-hoc completion](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1114) to jump to the completion section which was added in https://github.com/camunda/camunda-docs/pull/5235.

Related to https://github.com/camunda/camunda-modeler/issues/4850

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
