### PR TITLE
Bump dep properties-panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+## 5.34.2
+
+* `DEPS`: update to `@bpmn-io/properties-panel@3.26.4`
+* `FIX`: reverts trim trailing whitespaces from all input fields except expressions ([bpmn-io/properties-panel#309](https://github.com/bpmn-io/properties-panel/issues/309)) added in `5.33.0`
+
 ## 5.34.1
 
 * `FIX`: clarify wording for input/output groups ([#1115](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1115))

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@babel/core": "^7.25.2",
         "@babel/plugin-transform-react-jsx": "^7.25.2",
         "@bpmn-io/element-template-chooser": "^1.0.0",
-        "@bpmn-io/properties-panel": "^3.26.3",
+        "@bpmn-io/properties-panel": "^3.26.4",
         "@bpmn-io/variable-resolver": "^1.3.0",
         "@rollup/plugin-alias": "^5.1.1",
         "@rollup/plugin-babel": "^6.0.4",
@@ -562,9 +562,9 @@
       }
     },
     "node_modules/@bpmn-io/properties-panel": {
-      "version": "3.26.3",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.26.3.tgz",
-      "integrity": "sha512-iyBas5/Hn/+yZ/FPYpoGIpXe7os/rpwhnWqAwum0Lj/JSzlSfYEAfljZ++VHHDrnFo3DP8vSeRKkjKbXndP2jA==",
+      "version": "3.26.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.26.4.tgz",
+      "integrity": "sha512-nx4uAI9xSQJmfkuGhlMRFrS198sCegj8uwZs6O1KFFjOPrQgTM/m11YNY1rSGyD7hfZtSGO3nny7ODrN3KjNzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10386,9 +10386,9 @@
       }
     },
     "@bpmn-io/properties-panel": {
-      "version": "3.26.3",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.26.3.tgz",
-      "integrity": "sha512-iyBas5/Hn/+yZ/FPYpoGIpXe7os/rpwhnWqAwum0Lj/JSzlSfYEAfljZ++VHHDrnFo3DP8vSeRKkjKbXndP2jA==",
+      "version": "3.26.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.26.4.tgz",
+      "integrity": "sha512-nx4uAI9xSQJmfkuGhlMRFrS198sCegj8uwZs6O1KFFjOPrQgTM/m11YNY1rSGyD7hfZtSGO3nny7ODrN3KjNzg==",
       "dev": true,
       "requires": {
         "@bpmn-io/feel-editor": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@babel/core": "^7.25.2",
     "@babel/plugin-transform-react-jsx": "^7.25.2",
     "@bpmn-io/element-template-chooser": "^1.0.0",
-    "@bpmn-io/properties-panel": "^3.26.3",
+    "@bpmn-io/properties-panel": "^3.26.4",
     "@bpmn-io/variable-resolver": "^1.3.0",
     "@rollup/plugin-alias": "^5.1.1",
     "@rollup/plugin-babel": "^6.0.4",


### PR DESCRIPTION
### Proposed Changes

* `DEPS`: update to `@bpmn-io/properties-panel@3.26.4`
* `FIX`: reverts trim trailing whitespaces from all input fields except expressions ([bpmn-io/properties-panel#309](https://github.com/bpmn-io/properties-panel/issues/309)) added in `5.33.0`

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
