### PR TITLE
Integration tests for trimmed inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+* `DEPS`: update to `@bpmn-io/properties-panel@3.27.3`
+
 ## 5.36.1
 
 * `FIX`: show literal values in FEEL suggestions

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@babel/core": "^7.25.2",
         "@babel/plugin-transform-react-jsx": "^7.25.2",
         "@bpmn-io/element-template-chooser": "^2.0.0",
-        "@bpmn-io/properties-panel": "^3.27.2",
+        "@bpmn-io/properties-panel": "^3.27.3",
         "@bpmn-io/variable-resolver": "^1.3.0",
         "@rollup/plugin-alias": "^5.1.1",
         "@rollup/plugin-babel": "^6.0.4",
@@ -553,9 +553,9 @@
       }
     },
     "node_modules/@bpmn-io/properties-panel": {
-      "version": "3.27.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.27.2.tgz",
-      "integrity": "sha512-vFCl18XTqjYy4DBz4l+cvu/q0Sj2Px8tTufOFEkEqelaBVlMhepIoHvG8J0nqy/zu3YoHf+c2UihrbmwA+TGuQ==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.27.3.tgz",
+      "integrity": "sha512-uGHdm63C/l97pEIKEcgJs8cusBxvjdGWQUwEgpgIIVKZpXtXJ7EyT5BV76+OoRby9MTZIoRRcHoTGTdm7U0lDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10380,9 +10380,9 @@
       }
     },
     "@bpmn-io/properties-panel": {
-      "version": "3.27.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.27.2.tgz",
-      "integrity": "sha512-vFCl18XTqjYy4DBz4l+cvu/q0Sj2Px8tTufOFEkEqelaBVlMhepIoHvG8J0nqy/zu3YoHf+c2UihrbmwA+TGuQ==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.27.3.tgz",
+      "integrity": "sha512-uGHdm63C/l97pEIKEcgJs8cusBxvjdGWQUwEgpgIIVKZpXtXJ7EyT5BV76+OoRby9MTZIoRRcHoTGTdm7U0lDA==",
       "dev": true,
       "requires": {
         "@bpmn-io/feel-editor": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@babel/core": "^7.25.2",
     "@babel/plugin-transform-react-jsx": "^7.25.2",
     "@bpmn-io/element-template-chooser": "^2.0.0",
-    "@bpmn-io/properties-panel": "^3.27.2",
+    "@bpmn-io/properties-panel": "^3.27.3",
     "@bpmn-io/variable-resolver": "^1.3.0",
     "@rollup/plugin-alias": "^5.1.1",
     "@rollup/plugin-babel": "^6.0.4",

--- a/src/provider/camunda-platform/properties/ConditionProps.js
+++ b/src/provider/camunda-platform/properties/ConditionProps.js
@@ -330,7 +330,7 @@ function Resource(props) {
   };
 
   return <TextFieldEntry
-    element
+    element={ element }
     id="conditionScriptResource"
     label={ translate('Resource') }
     getValue={ getValue }

--- a/test/fixtures/integration.bpmn
+++ b/test/fixtures/integration.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1k9gocq" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.34.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_0bjswkx" isExecutable="true">
+    <bpmn:task id="Task_1" name="Task 1" />
+    <bpmn:task id="Task_2" name="Task 2" />
+    <bpmn:serviceTask id="ServiceTask_1" name="Service Task 1">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_2" name="Service Task 2">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="bar" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:intermediateCatchEvent id="LinkEvent_1" name="Link Event 1">
+      <bpmn:linkEventDefinition name="name" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="LinkEvent_2" name="Link Event 2">
+      <bpmn:linkEventDefinition name="name" />
+    </bpmn:intermediateThrowEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0bjswkx">
+      <bpmndi:BPMNShape id="Activity_1xnx3pj_di" bpmnElement="Task_1">
+        <dc:Bounds x="160" y="240" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13ftmyc" bpmnElement="Task_2">
+        <dc:Bounds x="360" y="240" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1tf1eey_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_012sk28_di" bpmnElement="ServiceTask_2">
+        <dc:Bounds x="360" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="LinkEvent_1_di" bpmnElement="LinkEvent_1">
+        <dc:Bounds x="160" y="400" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="LinkEvent_2_di" bpmnElement="LinkEvent_2">
+        <dc:Bounds x="360" y="400" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
> [!NOTE]
>   The issue was found in `@bpmn-io/properties-panel v3.26.3`

Related to: https://github.com/bpmn-io/properties-panel/issues/404
Discussion: https://github.com/bpmn-io/properties-panel/issues/404#issuecomment-2724827682, https://camunda.slack.com/archives/GP70M0J6M/p1742391873712439

Upstream PR: https://github.com/bpmn-io/properties-panel/pull/405 (merged and released)
- Issue was resolved but was not able to reproduce the test case where input propogate from one element to other in properties-panel ([ref.](https://github.com/camunda/web-modeler/issues/13599) )
- Added a fix where element was not provided as props to the textfield, since the input callback now depends on element after https://github.com/bpmn-io/properties-panel/pull/416#issuecomment-2911632188
### Proposed Changes
<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

Following integration tests are added:
- The input value should be trimmed if there exists trailing spaces.
- To check input FEEL field value when switching fields. The value should not propagate to other same field when switching. (Issue found in https://github.com/camunda/web-modeler/issues/13599)

https://github.com/user-attachments/assets/7b7b2d5f-9745-4bf7-9112-69602dde4b27

You can test the implementation by running `npm start`
### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
