### PR TITLE
Add an input JSON schema property to activities within an ad-hoc subprocess

### DIFF
--- a/src/provider/zeebe/ZeebePropertiesProvider.js
+++ b/src/provider/zeebe/ZeebePropertiesProvider.js
@@ -5,6 +5,7 @@ import { findIndex } from 'min-dash';
 import {
   ActiveElementsProps,
   AdHocCompletionProps,
+  AdHocActivityInputSchemaProps,
   AssignmentDefinitionProps,
   BusinessRuleImplementationProps,
   CalledDecisionProps,
@@ -81,6 +82,7 @@ export default class ZeebePropertiesProvider {
 
       // (2) update existing groups with zeebe specific properties
       updateGeneralGroup(groups, element);
+      updateDocumentationGroup(groups, element);
       updateErrorGroup(groups, element);
       updateEscalationGroup(groups, element);
       updateMessageGroup(groups, element);
@@ -389,6 +391,18 @@ function updateGeneralGroup(groups, element) {
   const insertIndex = executableEntry >= 0 ? executableEntry : entries.length;
 
   entries.splice(insertIndex, 0, ...VersionTagProps({ element }));
+}
+
+function updateDocumentationGroup(groups, element) {
+  const documentationGroup = findGroup(groups, 'documentation');
+  if (!documentationGroup) {
+    return;
+  }
+
+  documentationGroup.entries = replaceEntries(
+    documentationGroup.entries,
+    AdHocActivityInputSchemaProps({ element })
+  );
 }
 
 function updateErrorGroup(groups, element) {

--- a/src/provider/zeebe/ZeebePropertiesProvider.js
+++ b/src/provider/zeebe/ZeebePropertiesProvider.js
@@ -45,6 +45,7 @@ import { isMessageEndEvent, isMessageThrowEvent } from './utils/ZeebeServiceTask
 const LOW_PRIORITY = 500;
 
 const ZEEBE_GROUPS = [
+  AdHocActivityGroup,
   BusinessRuleImplementationGroup,
   CalledDecisionGroup,
   ScriptImplementationGroup,
@@ -63,7 +64,7 @@ const ZEEBE_GROUPS = [
   HeaderGroup,
   TaskListenersGroup,
   ExecutionListenersGroup,
-  ExtensionPropertiesGroup
+  ExtensionPropertiesGroup,
 ];
 
 export default class ZeebePropertiesProvider {
@@ -82,7 +83,6 @@ export default class ZeebePropertiesProvider {
 
       // (2) update existing groups with zeebe specific properties
       updateGeneralGroup(groups, element);
-      updateDocumentationGroup(groups, element);
       updateErrorGroup(groups, element);
       updateEscalationGroup(groups, element);
       updateMessageGroup(groups, element);
@@ -377,6 +377,20 @@ function ExtensionPropertiesGroup(element, injector) {
   return null;
 }
 
+function AdHocActivityGroup(element, injector) {
+  const translate = injector.get('translate');
+  const group = {
+    id: 'adHocActivity',
+    label: translate('Ad-hoc activity'),
+    entries: [
+      ...AdHocActivityInputSchemaProps({ element })
+    ],
+    component: Group
+  };
+
+  return group.entries.length ? group : null;
+}
+
 function updateGeneralGroup(groups, element) {
 
   const generalGroup = findGroup(groups, 'general');
@@ -391,18 +405,6 @@ function updateGeneralGroup(groups, element) {
   const insertIndex = executableEntry >= 0 ? executableEntry : entries.length;
 
   entries.splice(insertIndex, 0, ...VersionTagProps({ element }));
-}
-
-function updateDocumentationGroup(groups, element) {
-  const documentationGroup = findGroup(groups, 'documentation');
-  if (!documentationGroup) {
-    return;
-  }
-
-  documentationGroup.entries = replaceEntries(
-    documentationGroup.entries,
-    AdHocActivityInputSchemaProps({ element })
-  );
 }
 
 function updateErrorGroup(groups, element) {

--- a/src/provider/zeebe/properties/AdHocActivityInputSchemaProps.js
+++ b/src/provider/zeebe/properties/AdHocActivityInputSchemaProps.js
@@ -1,0 +1,190 @@
+import {
+  isFeelEntryEdited
+} from '@bpmn-io/properties-panel';
+
+import { is, getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+import { useService } from '../../../hooks';
+import { FeelTextAreaEntry } from '../../../entries/FeelEntryWithContext';
+import { createElement } from '../../../utils/ElementUtil';
+import { getExtensionElementsList } from '../../../utils/ExtensionElementsUtil';
+
+const INPUT_SCHEMA_PROPERTY_NAME = 'camunda:adHocActivityInputSchema';
+
+/**
+ * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
+ */
+
+/**
+ * @returns {Array<Entry>} entries
+ */
+export function AdHocActivityInputSchemaProps(props) {
+  const {
+    element
+  } = props;
+
+  // only add the input schema documentation field if the element is a root activity inside an ad-hoc subprocess
+  if (!is(element.parent, 'bpmn:AdHocSubProcess') || element.incoming.length > 0) {
+    return [];
+  }
+
+  return [
+    {
+      id: 'adHocActivityInputSchema',
+      component: AdHocActivityInputSchemaProperty,
+      isEdited: isFeelEntryEdited
+    }
+  ];
+}
+
+/**
+ * Allows to edit the activity input schema JSON of an activity within an ad-hoc subprocess. Stores the data
+ * in a zeebe:Property named `camunda:adHocActivityInputSchema`.
+ */
+const AdHocActivityInputSchemaProperty = (props) => {
+  const {
+    element
+  } = props;
+
+  const commandStack = useService('commandStack');
+  const bpmnFactory = useService('bpmnFactory');
+  const translate = useService('translate');
+  const debounce = useService('debounceInput');
+
+  const getValue = () => {
+    const property = getZeebeProperty(element, INPUT_SCHEMA_PROPERTY_NAME);
+    if (property) {
+      return property.get('value');
+    }
+  };
+
+  const setValue = (value) => {
+    const commands = [];
+
+    const businessObject = getBusinessObject(element);
+
+    let extensionElements = businessObject.get('extensionElements');
+
+    // (1) ensure extension elements
+    if (!extensionElements) {
+      extensionElements = createElement(
+        'bpmn:ExtensionElements',
+        { values: [] },
+        businessObject,
+        bpmnFactory
+      );
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: businessObject,
+          properties: { extensionElements }
+        }
+      });
+    }
+
+    // (2) ensure zeebe:properties
+    let zeebeProperties = getZeebeProperties(businessObject);
+
+    if (!zeebeProperties) {
+      const parent = extensionElements;
+
+      zeebeProperties = createElement('zeebe:Properties', {
+        properties: []
+      }, parent, bpmnFactory);
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: extensionElements,
+          properties: {
+            values: [ ...extensionElements.get('values'), zeebeProperties ]
+          }
+        }
+      });
+    }
+
+    // (3) update or create zeebe property
+    const existingProperty = getZeebeProperty(element, INPUT_SCHEMA_PROPERTY_NAME);
+    if (existingProperty) {
+      if (value) {
+
+        // Update existing zeebe property
+        commands.push({
+          cmd: 'element.updateModdleProperties',
+          context: {
+            element,
+            moddleElement: existingProperty,
+            properties: {
+              value
+            }
+          }
+        });
+      } else {
+
+        // Remove empty zeebe property
+        commands.push({
+          cmd: 'element.updateModdleProperties',
+          context: {
+            element,
+            moddleElement: zeebeProperties,
+            properties: {
+              properties: zeebeProperties.get('properties').filter(p => p.get('name') !== INPUT_SCHEMA_PROPERTY_NAME)
+            }
+          }
+        });
+      }
+    } else {
+
+      // Create new zeebe property
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: zeebeProperties,
+          properties: {
+            properties: [
+              ...zeebeProperties.get('properties'),
+              createElement('zeebe:Property', {
+                name: INPUT_SCHEMA_PROPERTY_NAME,
+                value
+              }, zeebeProperties, bpmnFactory),
+            ]
+          }
+        }
+      });
+    }
+
+    commandStack.execute('properties-panel.multi-command-executor', commands);
+  };
+
+  return FeelTextAreaEntry({
+    element,
+    id: 'adHocActivityInputSchema',
+    label: translate('Input JSON Schema'),
+    feel: 'required',
+    getValue,
+    setValue,
+    debounce
+  });
+};
+
+
+// --------
+
+// helper ///////////////////////
+
+function getZeebeProperties(element) {
+  const businessObject = getBusinessObject(element);
+  return getExtensionElementsList(businessObject, 'zeebe:Properties')[0];
+}
+
+function getZeebeProperty(element, propertyName) {
+  const properties = getZeebeProperties(element);
+  if (!properties) {
+    return;
+  }
+
+  return properties.get('properties').find(p => p.get('name') === propertyName);
+}

--- a/src/provider/zeebe/properties/AdHocActivityInputSchemaProps.js
+++ b/src/provider/zeebe/properties/AdHocActivityInputSchemaProps.js
@@ -163,7 +163,7 @@ const AdHocActivityInputSchemaProperty = (props) => {
     element,
     id: 'adHocActivityInputSchema',
     label: translate('Input JSON Schema'),
-    feel: 'required',
+    feel: 'optional',
     getValue,
     setValue,
     debounce

--- a/src/provider/zeebe/properties/AdHocActivityInputSchemaProps.js
+++ b/src/provider/zeebe/properties/AdHocActivityInputSchemaProps.js
@@ -162,7 +162,8 @@ const AdHocActivityInputSchemaProperty = (props) => {
   return FeelTextAreaEntry({
     element,
     id: 'adHocActivityInputSchema',
-    label: translate('Input JSON Schema'),
+    label: translate('Input Schema'),
+    description: translate('JSON schema describing the input data of this activity.'),
     feel: 'optional',
     getValue,
     setValue,

--- a/src/provider/zeebe/properties/index.js
+++ b/src/provider/zeebe/properties/index.js
@@ -1,5 +1,6 @@
 export { ActiveElementsProps } from './ActiveElementsProps';
 export { AdHocCompletionProps } from './AdHocCompletionProps';
+export { AdHocActivityInputSchemaProps } from './AdHocActivityInputSchemaProps';
 export { AssignmentDefinitionProps } from './AssignmentDefinitionProps';
 export { BusinessRuleImplementationProps } from './BusinessRuleImplementationProps';
 export { CalledDecisionProps } from './CalledDecisionProps';

--- a/test/spec/provider/zeebe/AdHocActivityInputSchemaProps.bpmn
+++ b/test/spec/provider/zeebe/AdHocActivityInputSchemaProps.bpmn
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1gx9y68" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.33.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_1yhuxuj" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1lbh2cw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Normal_Task" name="Normal task">
+      <bpmn:documentation>A normal task outside the ad-hoc subprocess</bpmn:documentation>
+      <bpmn:incoming>Flow_1lbh2cw</bpmn:incoming>
+      <bpmn:outgoing>Flow_1odpnug</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1lbh2cw" sourceRef="StartEvent_1" targetRef="Normal_Task" />
+    <bpmn:sequenceFlow id="Flow_1odpnug" sourceRef="Normal_Task" targetRef="Ad_Hoc_Subprocess" />
+    <bpmn:endEvent id="Event_02o8gff">
+      <bpmn:incoming>Flow_1sfbbbp</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1sfbbbp" sourceRef="Ad_Hoc_Subprocess" targetRef="Event_02o8gff" />
+    <bpmn:adHocSubProcess id="Ad_Hoc_Subprocess" name="Ad-hoc subprocess">
+      <bpmn:incoming>Flow_1odpnug</bpmn:incoming>
+      <bpmn:outgoing>Flow_1sfbbbp</bpmn:outgoing>
+      <bpmn:task id="Task_With_Input_Schema" name="Task with input schema">
+        <bpmn:documentation>A task with defined input schema</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:properties>
+            <zeebe:property name="camunda:adHocActivityInputSchema" value="={&#34;type&#34;: &#34;object&#34;}" />
+          </zeebe:properties>
+        </bpmn:extensionElements>
+      </bpmn:task>
+      <bpmn:task id="Task_Without_Input_Schema" name="Task without input schema">
+        <bpmn:documentation>A task without input schema</bpmn:documentation>
+      </bpmn:task>
+      <bpmn:task id="First_Task" name="First task">
+        <bpmn:outgoing>Flow_095717l</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:task id="Second_Task" name="Second task">
+        <bpmn:incoming>Flow_095717l</bpmn:incoming>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_095717l" sourceRef="First_Task" targetRef="Second_Task" />
+      <bpmn:intermediateThrowEvent id="An_Event" name="An event!">
+        <bpmn:extensionElements />
+        <bpmn:outgoing>Flow_0v33lmt</bpmn:outgoing>
+      </bpmn:intermediateThrowEvent>
+      <bpmn:task id="Event_Follow_Up_Task" name="Event follow-up task">
+        <bpmn:incoming>Flow_0v33lmt</bpmn:incoming>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_0v33lmt" sourceRef="An_Event" targetRef="Event_Follow_Up_Task" />
+    </bpmn:adHocSubProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1yhuxuj">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lxvmhq_di" bpmnElement="Normal_Task">
+        <dc:Bounds x="260" y="140" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02o8gff_di" bpmnElement="Event_02o8gff">
+        <dc:Bounds x="812" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_005wn4n_di" bpmnElement="Ad_Hoc_Subprocess" isExpanded="true">
+        <dc:Bounds x="410" y="40" width="350" height="380" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0o9evha_di" bpmnElement="Task_With_Input_Schema">
+        <dc:Bounds x="460" y="90" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0wzvf2t" bpmnElement="Task_Without_Input_Schema">
+        <dc:Bounds x="600" y="90" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0b1o3hz_di" bpmnElement="Second_Task">
+        <dc:Bounds x="600" y="190" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0bb8bvc_di" bpmnElement="First_Task">
+        <dc:Bounds x="460" y="190" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02hr6cv_di" bpmnElement="An_Event">
+        <dc:Bounds x="492" y="312" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="488" y="355" width="47" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_17rjl26_di" bpmnElement="Event_Follow_Up_Task">
+        <dc:Bounds x="600" y="290" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_095717l_di" bpmnElement="Flow_095717l">
+        <di:waypoint x="560" y="230" />
+        <di:waypoint x="600" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0v33lmt_di" bpmnElement="Flow_0v33lmt">
+        <di:waypoint x="528" y="330" />
+        <di:waypoint x="600" y="330" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1lbh2cw_di" bpmnElement="Flow_1lbh2cw">
+        <di:waypoint x="218" y="180" />
+        <di:waypoint x="260" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1odpnug_di" bpmnElement="Flow_1odpnug">
+        <di:waypoint x="360" y="180" />
+        <di:waypoint x="410" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1sfbbbp_di" bpmnElement="Flow_1sfbbbp">
+        <di:waypoint x="760" y="180" />
+        <di:waypoint x="812" y="180" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/zeebe/AdHocActivityInputSchemaProps.bpmn
+++ b/test/spec/provider/zeebe/AdHocActivityInputSchemaProps.bpmn
@@ -18,8 +18,8 @@
     <bpmn:adHocSubProcess id="Ad_Hoc_Subprocess" name="Ad-hoc subprocess">
       <bpmn:incoming>Flow_1odpnug</bpmn:incoming>
       <bpmn:outgoing>Flow_1sfbbbp</bpmn:outgoing>
-      <bpmn:task id="Task_With_Input_Schema" name="Task with input schema">
-        <bpmn:documentation>A task with defined input schema</bpmn:documentation>
+      <bpmn:task id="Task_With_FEEL_Input_Schema" name="Task with FEEL input schema">
+        <bpmn:documentation>A task with defined input schema (FEEL)</bpmn:documentation>
         <bpmn:extensionElements>
           <zeebe:properties>
             <zeebe:property name="camunda:adHocActivityInputSchema" value="={&#34;type&#34;: &#34;object&#34;}" />
@@ -29,13 +29,19 @@
       <bpmn:task id="Task_Without_Input_Schema" name="Task without input schema">
         <bpmn:documentation>A task without input schema</bpmn:documentation>
       </bpmn:task>
-      <bpmn:task id="First_Task" name="First task">
+      <bpmn:task id="Task_With_Text_Input_Schema" name="Task with text input schema">
+        <bpmn:documentation>A task with defined input schema (text)</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:properties>
+            <zeebe:property name="camunda:adHocActivityInputSchema" value="{&#34;type&#34;: &#34;object&#34;}" />
+          </zeebe:properties>
+        </bpmn:extensionElements>
         <bpmn:outgoing>Flow_095717l</bpmn:outgoing>
       </bpmn:task>
-      <bpmn:task id="Second_Task" name="Second task">
+      <bpmn:task id="Follow_Up_Task" name="Follow-up task">
         <bpmn:incoming>Flow_095717l</bpmn:incoming>
       </bpmn:task>
-      <bpmn:sequenceFlow id="Flow_095717l" sourceRef="First_Task" targetRef="Second_Task" />
+      <bpmn:sequenceFlow id="Flow_095717l" sourceRef="Task_With_Text_Input_Schema" targetRef="Follow_Up_Task" />
       <bpmn:intermediateThrowEvent id="An_Event" name="An event!">
         <bpmn:extensionElements />
         <bpmn:outgoing>Flow_0v33lmt</bpmn:outgoing>
@@ -62,7 +68,7 @@
         <dc:Bounds x="410" y="40" width="350" height="380" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0o9evha_di" bpmnElement="Task_With_Input_Schema">
+      <bpmndi:BPMNShape id="Activity_0o9evha_di" bpmnElement="Task_With_FEEL_Input_Schema">
         <dc:Bounds x="460" y="90" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -70,12 +76,12 @@
         <dc:Bounds x="600" y="90" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0b1o3hz_di" bpmnElement="Second_Task">
-        <dc:Bounds x="600" y="190" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_0bb8bvc_di" bpmnElement="Task_With_Text_Input_Schema">
+        <dc:Bounds x="460" y="190" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0bb8bvc_di" bpmnElement="First_Task">
-        <dc:Bounds x="460" y="190" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_0b1o3hz_di" bpmnElement="Follow_Up_Task">
+        <dc:Bounds x="600" y="190" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_02hr6cv_di" bpmnElement="An_Event">

--- a/test/spec/provider/zeebe/AdHocActivityInputSchemaProps.spec.js
+++ b/test/spec/provider/zeebe/AdHocActivityInputSchemaProps.spec.js
@@ -83,6 +83,7 @@ describe('provider/zeebe - AdHocActivityInputSchema', function() {
           });
 
           // then
+          expect(getGroup(container, 'adHocActivity')).to.exist;
           expect(getAdHocActivityInputSchemaExpressionInput(container)).to.exist;
         }));
       }
@@ -104,6 +105,7 @@ describe('provider/zeebe - AdHocActivityInputSchema', function() {
           });
 
           // then
+          expect(getGroup(container, 'adHocActivity')).to.exist;
           expect(getAdHocActivityInputSchemaTextarea(container)).to.exist;
         }));
       }
@@ -125,6 +127,7 @@ describe('provider/zeebe - AdHocActivityInputSchema', function() {
           });
 
           // then
+          expect(getGroup(container, 'adHocActivity')).not.to.exist;
           expect(getAdHocActivityInputSchemaTextarea(container)).not.to.exist;
           expect(getAdHocActivityInputSchemaExpressionInput(container)).not.to.exist;
         }));
@@ -145,6 +148,7 @@ describe('provider/zeebe - AdHocActivityInputSchema', function() {
       });
 
       // then
+      expect(getGroup(container, 'adHocActivity')).not.to.exist;
       expect(getAdHocActivityInputSchemaTextarea(container)).not.to.exist;
       expect(getAdHocActivityInputSchemaExpressionInput(container)).not.to.exist;
     }));
@@ -322,6 +326,10 @@ describe('provider/zeebe - AdHocActivityInputSchema', function() {
 
 
 // DOM helpers ////////////////////////////
+
+function getGroup(container, id) {
+  return domQuery(`[data-group-id="group-${id}"]`, container);
+}
 
 function getAdHocActivityInputSchemaTextarea(container) {
   return domQuery('textarea[name=adHocActivityInputSchema]', container);

--- a/test/spec/provider/zeebe/AdHocActivityInputSchemaProps.spec.js
+++ b/test/spec/provider/zeebe/AdHocActivityInputSchemaProps.spec.js
@@ -83,8 +83,6 @@ describe('provider/zeebe - AdHocActivityInputSchema', function() {
           });
 
           // then
-          const group = getGroup(container, 'documentation');
-          expect(group).to.exist;
           expect(getAdHocActivityInputSchemaExpressionInput(container)).to.exist;
         }));
       }
@@ -106,8 +104,6 @@ describe('provider/zeebe - AdHocActivityInputSchema', function() {
           });
 
           // then
-          const group = getGroup(container, 'documentation');
-          expect(group).to.exist;
           expect(getAdHocActivityInputSchemaTextarea(container)).to.exist;
         }));
       }
@@ -129,8 +125,6 @@ describe('provider/zeebe - AdHocActivityInputSchema', function() {
           });
 
           // then
-          const group = getGroup(container, 'documentation');
-          expect(group).to.exist;
           expect(getAdHocActivityInputSchemaTextarea(container)).not.to.exist;
           expect(getAdHocActivityInputSchemaExpressionInput(container)).not.to.exist;
         }));
@@ -151,8 +145,6 @@ describe('provider/zeebe - AdHocActivityInputSchema', function() {
       });
 
       // then
-      const group = getGroup(container, 'documentation');
-      expect(group).to.exist;
       expect(getAdHocActivityInputSchemaTextarea(container)).not.to.exist;
       expect(getAdHocActivityInputSchemaExpressionInput(container)).not.to.exist;
     }));
@@ -194,7 +186,7 @@ describe('provider/zeebe - AdHocActivityInputSchema', function() {
 
       const input = getAdHocActivityInputSchemaExpressionInput(container);
       expect(input).to.exist;
-      expect('=' + getEditorValue(input)).to.equal(getAdHocActivityInputSchemaValue(activity));
+      expect('=' + input.textContent).to.equal(getAdHocActivityInputSchemaValue(activity));
     }));
 
     it('should show the expected value when an input schema is configured (text)', inject(async function(
@@ -330,14 +322,6 @@ describe('provider/zeebe - AdHocActivityInputSchema', function() {
 
 
 // DOM helpers ////////////////////////////
-
-function getEditorValue(input) {
-  return input.textContent;
-}
-
-function getGroup(container, id) {
-  return domQuery(`[data-group-id="group-${id}"`, container);
-}
 
 function getAdHocActivityInputSchemaTextarea(container) {
   return domQuery('textarea[name=adHocActivityInputSchema]', container);

--- a/test/spec/provider/zeebe/AdHocActivityInputSchemaProps.spec.js
+++ b/test/spec/provider/zeebe/AdHocActivityInputSchemaProps.spec.js
@@ -1,0 +1,305 @@
+import TestContainer from 'mocha-test-container-support';
+import { act } from '@testing-library/preact';
+
+import { bootstrapPropertiesPanel, inject } from 'test/TestHelper';
+
+import { query as domQuery } from 'min-dom';
+
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+import BpmnPropertiesPanel from 'src/render';
+import BpmnPropertiesProvider from 'src/provider/bpmn';
+import ZeebePropertiesProvider from 'src/provider/zeebe';
+import TooltipProvider from 'src/contextProvider/zeebe/TooltipProvider';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import diagramXML from './AdHocActivityInputSchemaProps.bpmn';
+import { setEditorValue } from '../../../TestHelper';
+import { getExtensionElementsList } from '../../../../src/utils/ExtensionElementsUtil';
+
+describe('provider/zeebe - AdHocActivityInputSchema', function() {
+
+  const testModules = [
+    CoreModule,
+    ModelingModule,
+    SelectionModule,
+    BpmnPropertiesPanel,
+    BpmnPropertiesProvider,
+    ZeebePropertiesProvider
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    modules: testModules,
+    moddleExtensions,
+    propertiesPanel: {
+      tooltip: TooltipProvider
+    },
+    debounceInput: false
+  }));
+
+
+  describe('bpmn:FlowNode#camunda:adHocActivityInputSchema', function() {
+    const rootActivities = {
+      'Task_With_Input_Schema': 'Task with input schema',
+      'Task_Without_Input_Schema': 'Task without input schema',
+      'First_Task': 'Task with follow-up task',
+      'An_Event': 'Intermediate event'
+    };
+
+    const nonRootActivities = {
+      'Second_Task': 'Follow-up task to First_Task',
+      'Event_Follow_Up_Task': 'Follow-up task to An_Event',
+    };
+
+    describe('should display the input schema field on root activities within an ad-hoc subprocess', function() {
+      for (const [ activityId, testCaseDescription ] of Object.entries(rootActivities)) {
+        it(testCaseDescription, inject(async function(
+            elementRegistry,
+            selection
+        ) {
+
+          // given
+          const activity = elementRegistry.get(activityId);
+
+          // when
+          await act(() => {
+            selection.select(activity);
+          });
+
+          // then
+          const group = getGroup(container, 'documentation');
+          expect(group).to.exist;
+          expect(getAdHocActivityInputSchemaInput(container)).to.exist;
+        }));
+      }
+    });
+
+    describe('should NOT display the input schema field on non-root activities within an ad-hoc subprocess', function() {
+      for (const [ activityId, testCaseDescription ] of Object.entries(nonRootActivities)) {
+        it(testCaseDescription, inject(async function(
+            elementRegistry,
+            selection
+        ) {
+
+          // given
+          const activity = elementRegistry.get(activityId);
+
+          // when
+          await act(() => {
+            selection.select(activity);
+          });
+
+          // then
+          const group = getGroup(container, 'documentation');
+          expect(group).to.exist;
+          expect(getAdHocActivityInputSchemaInput(container)).not.to.exist;
+        }));
+      }
+    });
+
+    it('should NOT display the input schema field on activities outside an ad-hoc subprocess', inject(async function(
+        elementRegistry,
+        selection
+    ) {
+
+      // given
+      const activity = elementRegistry.get('Normal_Task');
+
+      // when
+      await act(() => {
+        selection.select(activity);
+      });
+
+      // then
+      const group = getGroup(container, 'documentation');
+      expect(group).to.exist;
+      expect(getAdHocActivityInputSchemaInput(container)).not.to.exist;
+    }));
+
+
+    it('should show the expected value when an input schema is configured', inject(async function(
+        elementRegistry,
+        selection
+    ) {
+
+      // given
+      const activity = elementRegistry.get('Task_With_Input_Schema');
+
+      // when
+      await act(() => {
+        selection.select(activity);
+      });
+
+      // then
+      expect(getAdHocActivityInputSchemaProperty(activity)).to.exist;
+
+      const input = getAdHocActivityInputSchemaInput(container);
+      expect(input).to.exist;
+      expect('=' + getEditorValue(input)).to.equal(getAdHocActivityInputSchemaValue(activity));
+    }));
+
+    it('should be empty when no input schema is configured', inject(async function(
+        elementRegistry,
+        selection
+    ) {
+
+      // given
+      const activity = elementRegistry.get('Task_Without_Input_Schema');
+
+      // when
+      await act(() => {
+        selection.select(activity);
+      });
+
+      // then
+      expect(getAdHocActivityInputSchemaProperty(activity)).not.to.exist;
+
+      const input = getAdHocActivityInputSchemaInput(container);
+      expect(input).to.exist;
+      expect(getEditorValue(input)).to.be.empty;
+    }));
+
+    it('should update - reusing existing property', inject(async function(
+        elementRegistry,
+        selection
+    ) {
+
+      // given
+      const activity = elementRegistry.get('Task_With_Input_Schema');
+
+      await act(() => {
+        selection.select(activity);
+      });
+
+      // when
+      const input = getAdHocActivityInputSchemaInput(container);
+      await setEditorValue(input, '{"type": "array"}');
+
+      // then
+      expect(getAdHocActivityInputSchemaValue(activity)).to.equal('={"type": "array"}');
+    }));
+
+
+    it('should update - creating new property', inject(async function(
+        elementRegistry,
+        selection
+    ) {
+
+      // given
+      const activity = elementRegistry.get('Task_Without_Input_Schema');
+
+      await act(() => {
+        selection.select(activity);
+      });
+
+      // when
+      const input = getAdHocActivityInputSchemaInput(container);
+      await setEditorValue(input, '{"type": "array"}');
+
+      // then
+      expect(getAdHocActivityInputSchemaValue(activity)).to.equal('={"type": "array"}');
+    }));
+
+    it('should update - remove property', inject(async function(
+        elementRegistry,
+        selection
+    ) {
+
+      // given
+      const activity = elementRegistry.get('Task_With_Input_Schema');
+
+      await act(() => {
+        selection.select(activity);
+      });
+
+      // when
+      const input = getAdHocActivityInputSchemaInput(container);
+      await setEditorValue(input, '');
+
+      // then
+      expect(getAdHocActivityInputSchemaProperty(activity)).not.to.exist;
+    }));
+
+    it('should update on external change', inject(async function(
+        elementRegistry,
+        selection,
+        commandStack
+    ) {
+
+      // given
+      const activity = elementRegistry.get('Task_With_Input_Schema');
+      const originalValue = getAdHocActivityInputSchemaValue(activity);
+
+      await act(() => {
+        selection.select(activity);
+      });
+      const input = getAdHocActivityInputSchemaInput(container);
+      await setEditorValue(input, '{"type": "array"}');
+      expect(getAdHocActivityInputSchemaValue(activity)).to.equal('={"type": "array"}');
+
+      // when
+      await act(() => {
+        commandStack.undo();
+      });
+
+      // then
+      expect(getAdHocActivityInputSchemaValue(activity)).to.equal(originalValue);
+    }));
+  });
+});
+
+
+// DOM helpers ////////////////////////////
+
+function getEditorValue(input) {
+  return input.textContent;
+}
+
+function getGroup(container, id) {
+  return domQuery(`[data-group-id="group-${id}"`, container);
+}
+
+function getAdHocActivityInputSchemaInput(container) {
+  return domQuery('[name=adHocActivityInputSchema] [role="textbox"]', container);
+}
+
+// model helpers ////////////////////////////
+
+function getZeebeProperties(element) {
+  const businessObject = getBusinessObject(element);
+  return getExtensionElementsList(businessObject, 'zeebe:Properties')[0];
+}
+
+function getZeebeProperty(element, propertyName) {
+  const properties = getZeebeProperties(element);
+  if (!properties) {
+    return;
+  }
+
+  return properties.get('properties').find(p => p.get('name') === propertyName);
+}
+
+function getAdHocActivityInputSchemaProperty(element) {
+  return getZeebeProperty(element, 'camunda:adHocActivityInputSchema');
+}
+
+function getAdHocActivityInputSchemaValue(element) {
+  const property = getAdHocActivityInputSchemaProperty(element);
+  if (property) {
+    return property.get('value');
+  }
+}

--- a/test/spec/provider/zeebe/AdHocCompletionProps.spec.js
+++ b/test/spec/provider/zeebe/AdHocCompletionProps.spec.js
@@ -355,7 +355,7 @@ function getEditorValue(input) {
 }
 
 function getGroup(container, id) {
-  return domQuery(`[data-group-id="group-${id}"`, container);
+  return domQuery(`[data-group-id="group-${id}"]`, container);
 }
 
 function getInputNames(container) {


### PR DESCRIPTION
This input schema definition can be consumed by external integrations. Example use case is an agentic AI integration providing input parameters to individual tasks with in the ad-hoc subprocess.

Closes https://github.com/camunda/camunda-modeler/issues/4961

### Proposed Changes

Adds a new input field (FEEL) in a dedicated "Ad-hoc activity" group if the activity is a _root activity_ (no incoming flows) within an ad-hoc subprocess. The content of the field are stored in a `zeebe:property` named `camunda:adHocActivityInputSchema`.

<img width="1008" alt="image" src="https://github.com/user-attachments/assets/a04b5551-f8bd-462e-964f-fb2b3c08e354" />

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
