### PR TITLE
feat: load bpmn file

### DIFF
--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -248,3 +248,45 @@ document.addEventListener('keydown', function(event) {
     download(result.xml, 'test.bpmn', 'application/xml');
   });
 });
+
+// be able to load diagrams using CTRL/CMD+F
+// This will open a file dialog and import the selected BPMN file
+// into the current bpmn-js modeler instance.
+document.addEventListener('keydown', function(event) {
+  const bpmnJS = getBpmnJS();
+
+  if (!bpmnJS) {
+    return;
+  }
+
+  if (!(event.ctrlKey || event.metaKey) || event.code !== 'KeyF') {
+    return;
+  }
+
+  event.preventDefault();
+
+  // Create a hidden file input
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = '.bpmn,.xml,application/xml,text/xml';
+  input.style.display = 'none';
+
+  input.addEventListener('change', function(e) {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = function(evt) {
+      const xml = evt.target.result;
+      bpmnJS.importXML(xml);
+    };
+    reader.readAsText(file);
+  });
+
+  document.body.appendChild(input);
+  input.click();
+
+  // Clean up after file dialog
+  input.addEventListener('blur', function() {
+    document.body.removeChild(input);
+  });
+});


### PR DESCRIPTION

### Proposed Changes

This PR adds support for loading BPMN diagrams using the CTRL/CMD + F keyboard shortcut. When triggered, a file dialog opens allowing the user to select a .bpmn or .xml file. The selected file is read and imported into the current bpmn-js modeler instance using bpmnJS.importXML.

This feature enhances user experience by allowing quick file import without needing to interact with UI buttons.

### Checklist

To ensure you provided everything we need to look at your PR:
Steps to try out
[ 
        1.       Load the app with the BPMN modeler initialized.
	2.	Press CTRL + F (or CMD + F on Mac).
	3.	Choose a valid .bpmn or .xml file in the file dialog.
	4.	Confirm the diagram loads correctly in the modeler.
] 