### PR TITLE
fix: update element state on element prop changed

### DIFF
--- a/src/render/BpmnPropertiesPanel.js
+++ b/src/render/BpmnPropertiesPanel.js
@@ -81,6 +81,13 @@ export default function BpmnPropertiesPanel(props) {
     });
   };
 
+  // TODO: this implements getDerivedStateFromProps and should be replaced with
+  // a better solution
+  // https://legacy.reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#when-to-use-derived-state
+  if (element !== state.selectedElement) {
+    _update(element);
+  }
+
   // (2) react on element changes
 
   // (2a) selection changed


### PR DESCRIPTION
### Proposed Changes

Fixes issue with properties panel updating with stale element which can happen after import which triggers [(re)render of `BpmnPropertiesPanel`](https://github.com/bpmn-io/bpmn-js-properties-panel/blob/main/src/render/BpmnPropertiesPanelRenderer.js#L64). While this fixes the issue we might want to find a better solution in the future.

Closes #1131
Related to https://github.com/camunda/web-modeler/issues/12388

In the recording below a BPMN is imported, then after 5 seconds another BPMN with the same process ID is imported and an `elementTemplates.changed` event is fired immediately. After the fix the process ID field does not show an error anymore.

![brave_GwTMLpfGCt](https://github.com/user-attachments/assets/c59536db-a3b3-4da2-b089-1a1d1935176f)

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
