### PR TITLE
fix: flip user task implementation type isEdited default

### DIFF
--- a/src/provider/zeebe/properties/UserTaskImplementationProps.js
+++ b/src/provider/zeebe/properties/UserTaskImplementationProps.js
@@ -115,7 +115,7 @@ function removeZeebeUserTask(element, commandStack) {
 }
 
 function isUserTaskImplementationEdited(element) {
-  return getZeebeUserTask(element);
+  return !getZeebeUserTask(element);
 }
 
 function getZeebeUserTask(element) {

--- a/test/spec/provider/zeebe/UserTaskImplementationProps.spec.js
+++ b/test/spec/provider/zeebe/UserTaskImplementationProps.spec.js
@@ -118,7 +118,7 @@ describe('provider/zeebe - UserTaskImplementationProps', function() {
       expect(implementation.value).to.equal('zeebeUserTask');
 
       // and also
-      return expectEdited(container, true);
+      return expectEdited(container, false);
     }));
 
 


### PR DESCRIPTION
Closes #1135

### Proposed Changes

Inverses the implementation type for which the isEdited dot shows in user tasks. 

<img width="504" height="282" alt="image" src="https://github.com/user-attachments/assets/effe5534-f29d-435e-ac28-a732b53b2b15" />

Above is the before state. I tested via yalc in web modeler and the fix worked, although I forgot to take a screenshot.

To test, yalc publish this branch, yalc add in desktop or web modeler, then add a user task.


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

