### PR TITLE
deps: update `@bpmn-io/properties-panel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+## 5.39.0
+
+* `FEAT`: update `camunda` built-ins
+* `FIX`: show tooltip on number fields
+* `DEPS`: update to `@bpmn-io/properties-panel@3.31.0`
+
 ## 5.38.1
 
 * `FIX`: report Camunda user task as default implementation ([#1135](https://github.com/bpmn-io/bpmn-js-properties-panel/issues/1135))

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@babel/core": "^7.25.2",
         "@babel/plugin-transform-react-jsx": "^7.25.2",
         "@bpmn-io/element-template-chooser": "^2.0.0",
-        "@bpmn-io/properties-panel": "^3.30.0",
+        "@bpmn-io/properties-panel": "^3.31.0",
         "@bpmn-io/variable-resolver": "^1.3.0",
         "@rollup/plugin-alias": "^5.1.1",
         "@rollup/plugin-babel": "^6.0.4",
@@ -518,13 +518,14 @@
       }
     },
     "node_modules/@bpmn-io/feel-editor": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-1.10.1.tgz",
-      "integrity": "sha512-Kq3TFKaCovDchb++WwS8yUvIke947pjW7k4Cu0zJXPnoMBbsbzMPXUDvtrHRP7/1D40wEqBAjIpElugFdpQM4g==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-1.11.0.tgz",
+      "integrity": "sha512-yjVCvKYRyl6wCrlgvfxsyg+96VbDsIkPVXpCxVbSHHQV/ATszrQpNrCWN8LKKcvowV8iankQxcm+tpWvxD7QhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/feel-lint": "^1.4.0",
+        "@camunda/feel-builtins": "^0.2.0",
         "@codemirror/autocomplete": "^6.16.2",
         "@codemirror/commands": "^6.8.0",
         "@codemirror/language": "^6.10.2",
@@ -553,13 +554,13 @@
       }
     },
     "node_modules/@bpmn-io/properties-panel": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.30.0.tgz",
-      "integrity": "sha512-f4LWYS3mqD9x2tloj98e220uI/hkbmI31pNU9JurcnX9yaOxktBFheT7NSmXNnCkCDWBLDQ/xWCD7GAFSwjqSw==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.31.0.tgz",
+      "integrity": "sha512-7GhIhSSAW/E3jGTu4EOvqf403BLqKfKwoDOw7eh6dbrQHZPyh7eypnd9u4SaWKgW6o5ZWTqhEXrfIG5EmVkxZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/feel-editor": "^1.10.1",
+        "@bpmn-io/feel-editor": "^1.11.0",
         "@codemirror/view": "^6.28.1",
         "classnames": "^2.3.1",
         "feelers": "^1.4.0",
@@ -585,6 +586,13 @@
       "peerDependencies": {
         "bpmn-js": "*"
       }
+    },
+    "node_modules/@camunda/feel-builtins": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@camunda/feel-builtins/-/feel-builtins-0.2.0.tgz",
+      "integrity": "sha512-Jusm8x3Onqze9E5Y0lGGdPj66bnFKLYNwDz+uG4otsEXgSL0FpF+koGHK48LkF9Jqo67KaP1y3zr2y/HIWRePw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.18.6",
@@ -10352,12 +10360,13 @@
       }
     },
     "@bpmn-io/feel-editor": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-1.10.1.tgz",
-      "integrity": "sha512-Kq3TFKaCovDchb++WwS8yUvIke947pjW7k4Cu0zJXPnoMBbsbzMPXUDvtrHRP7/1D40wEqBAjIpElugFdpQM4g==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-1.11.0.tgz",
+      "integrity": "sha512-yjVCvKYRyl6wCrlgvfxsyg+96VbDsIkPVXpCxVbSHHQV/ATszrQpNrCWN8LKKcvowV8iankQxcm+tpWvxD7QhQ==",
       "dev": true,
       "requires": {
         "@bpmn-io/feel-lint": "^1.4.0",
+        "@camunda/feel-builtins": "^0.2.0",
         "@codemirror/autocomplete": "^6.16.2",
         "@codemirror/commands": "^6.8.0",
         "@codemirror/language": "^6.10.2",
@@ -10380,12 +10389,12 @@
       }
     },
     "@bpmn-io/properties-panel": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.30.0.tgz",
-      "integrity": "sha512-f4LWYS3mqD9x2tloj98e220uI/hkbmI31pNU9JurcnX9yaOxktBFheT7NSmXNnCkCDWBLDQ/xWCD7GAFSwjqSw==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.31.0.tgz",
+      "integrity": "sha512-7GhIhSSAW/E3jGTu4EOvqf403BLqKfKwoDOw7eh6dbrQHZPyh7eypnd9u4SaWKgW6o5ZWTqhEXrfIG5EmVkxZg==",
       "dev": true,
       "requires": {
-        "@bpmn-io/feel-editor": "^1.10.1",
+        "@bpmn-io/feel-editor": "^1.11.0",
         "@codemirror/view": "^6.28.1",
         "classnames": "^2.3.1",
         "feelers": "^1.4.0",
@@ -10405,6 +10414,12 @@
         "lezer-feel": "^1.2.4",
         "min-dash": "^4.2.1"
       }
+    },
+    "@camunda/feel-builtins": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@camunda/feel-builtins/-/feel-builtins-0.2.0.tgz",
+      "integrity": "sha512-Jusm8x3Onqze9E5Y0lGGdPj66bnFKLYNwDz+uG4otsEXgSL0FpF+koGHK48LkF9Jqo67KaP1y3zr2y/HIWRePw==",
+      "dev": true
     },
     "@codemirror/autocomplete": {
       "version": "6.18.6",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@babel/core": "^7.25.2",
     "@babel/plugin-transform-react-jsx": "^7.25.2",
     "@bpmn-io/element-template-chooser": "^2.0.0",
-    "@bpmn-io/properties-panel": "^3.30.0",
+    "@bpmn-io/properties-panel": "^3.31.0",
     "@bpmn-io/variable-resolver": "^1.3.0",
     "@rollup/plugin-alias": "^5.1.1",
     "@rollup/plugin-babel": "^6.0.4",


### PR DESCRIPTION
### Proposed Changes


* `FEAT`: update `camunda` built-ins
* `FIX`: show tooltip on number fields
* `DEPS`: update to `@bpmn-io/properties-panel@3.31.0`

<img width="1122" height="943" alt="image" src="https://github.com/user-attachments/assets/129423f0-ba9c-4737-ad09-11f8f77f584a" />

@Buckwich The documentation on the function sounds odd "in addition to previous overload" given that the ordering is reversed. Any idea what's going on? This is not a blocker.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
