### PR TITLE
Ability to load BPMN file with CTRL/CMD+O

### DIFF
--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -269,7 +269,7 @@ document.addEventListener('keydown', function(event) {
   // Create a hidden file input
   const input = document.createElement('input');
   input.type = 'file';
-  input.accept = '.bpmn';
+  input.accept = '.bpmn,.xml,application/xml,text/xml';
   input.style.display = 'none';
 
   input.addEventListener('change', function(e) {

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -249,6 +249,10 @@ document.addEventListener('keydown', function(event) {
   });
 });
 
+
+// be able to load diagrams using CTRL/CMD+O
+// This will open a file dialog and import the selected BPMN file
+// into the current bpmn-js modeler instance.
 document.addEventListener('keydown', function(event) {
   const bpmnJS = getBpmnJS();
 

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -248,3 +248,42 @@ document.addEventListener('keydown', function(event) {
     download(result.xml, 'test.bpmn', 'application/xml');
   });
 });
+
+document.addEventListener('keydown', function(event) {
+  const bpmnJS = getBpmnJS();
+
+  if (!bpmnJS) {
+    return;
+  }
+
+  if (!(event.ctrlKey || event.metaKey) || event.code !== 'KeyO') {
+    return;
+  }
+
+  event.preventDefault();
+
+  // Create a hidden file input
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = '.bpmn';
+  input.style.display = 'none';
+
+  input.addEventListener('change', function(e) {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = function(evt) {
+      const xml = evt.target.result;
+      bpmnJS.importXML(xml);
+    };
+    reader.readAsText(file);
+  });
+
+  document.body.appendChild(input);
+  input.click();
+
+  // Clean up after file dialog
+  input.addEventListener('blur', function() {
+    document.body.removeChild(input);
+  });
+});


### PR DESCRIPTION
### Proposed Changes
### Checklist

To ensure you provided everything we need to look at your PR:

* [Ability to load BPMN file with CTRL/CMD+O. Current CTRL/CMD+O just opens file without loading it in the modeler] **Brief textual description** of the changes present
* 
<img width="1826" height="953" alt="Screenshot 2025-09-03 at 16 57 26" src="https://github.com/user-attachments/assets/6fdbf26b-b0d2-436e-9fb3-b2bb163f8c9d" />

**Visual demo** attached
* [ CTRL/CMD+O] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
