### PR TITLE
fix: update on import done

### DIFF
--- a/src/render/BpmnPropertiesPanel.js
+++ b/src/render/BpmnPropertiesPanel.js
@@ -135,20 +135,20 @@ export default function BpmnPropertiesPanel(props) {
     };
   }, [ selectedElement ]);
 
-  // (2c) root element changed
+  // (2c) import done
   useEffect(() => {
-    const onRootAdded = (e) => {
-      const element = e.element;
+    const onImportDone = () => {
+      const rootElement = canvas.getRootElement();
 
-      _update(element);
+      _update(rootElement);
     };
 
-    eventBus.on('root.added', onRootAdded);
+    eventBus.on('import.done', onImportDone);
 
     return () => {
-      eventBus.off('root.added', onRootAdded);
+      eventBus.off('import.done', onImportDone);
     };
-  }, [ selectedElement ]);
+  }, []);
 
   // (2d) provided entries changed
   useEffect(() => {

--- a/test/spec/BpmnPropertiesPanel.spec.js
+++ b/test/spec/BpmnPropertiesPanel.spec.js
@@ -225,7 +225,7 @@ describe('<BpmnPropertiesPanel>', function() {
     });
 
 
-    it('should update on root element changed', function() {
+    it('should update on import done', function() {
 
       // given
       const updateSpy = sinon.spy();
@@ -237,7 +237,7 @@ describe('<BpmnPropertiesPanel>', function() {
       createBpmnPropertiesPanel({ container, eventBus });
 
       // when
-      eventBus.fire('root.added', { element: noopElement });
+      eventBus.fire('import.done');
 
       // then
       expect(updateSpy).to.have.been.calledWith({
@@ -450,8 +450,15 @@ function createBpmnPropertiesPanel(options = {}) {
   } = options;
 
   let {
+    canvas,
     elementRegistry
   } = options;
+
+  if (!canvas) {
+    canvas = {
+      getRootElement: () => noopElement
+    };
+  }
 
   if (!elementRegistry) {
     elementRegistry = new elementRegistryMock();
@@ -460,6 +467,7 @@ function createBpmnPropertiesPanel(options = {}) {
 
   const injector = new injectorMock({
     ...options,
+    canvas,
     elementRegistry
   });
 

--- a/test/spec/mocks/index.js
+++ b/test/spec/mocks/index.js
@@ -60,7 +60,7 @@ export class Injector {
     }
 
     if (type === 'canvas') {
-      return new Canvas();
+      return this._options.canvas || new Canvas();
     }
   }
 }


### PR DESCRIPTION
Fixes the stale element issue by updating on `import.done`. I tried a [different approach](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1168) but [failed](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1168#issuecomment-3546523567). This is the only fix I found that doesn't inroduce significant changes like https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1159.

The fix can be verified using https://github.com/bpmn-io/bpmn-js-properties-panel/tree/1131-stale-element-tmp:

```
npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel#1131-stale-element-tmp
```


Fixes #1131

### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
