### PR TITLE
feat: hide `<bpmn:CallActivity>` Output group if `zeebe:propagateAllChildVariables` is true

### DIFF
--- a/src/provider/zeebe/utils/InputOutputUtil.js
+++ b/src/provider/zeebe/utils/InputOutputUtil.js
@@ -21,6 +21,8 @@ import {
   getEventDefinition
 } from '../../bpmn/utils/EventDefinitionUtil';
 
+import { isPropagateAllChildVariables } from '../properties/OutputPropagationProps';
+
 function getElements(bo, type, prop) {
   const elems = getExtensionElementsList(bo, type);
   return !prop ? elems : (elems[0] || {})[prop] || [];
@@ -86,12 +88,15 @@ export function areOutputParametersSupported(element) {
     return false;
   }
 
+  if (is(element, 'bpmn:CallActivity')) {
+    return !isPropagateAllChildVariables(element);
+  }
+
   return isAny(element, [
     'zeebe:ZeebeServiceTask',
     'bpmn:UserTask',
     'bpmn:SubProcess',
     'bpmn:ReceiveTask',
-    'bpmn:CallActivity',
     'bpmn:Event',
     'bpmn:BusinessRuleTask'
   ]);

--- a/test/spec/provider/zeebe/OutputProps.bpmn
+++ b/test/spec/provider/zeebe/OutputProps.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.20.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.41.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:serviceTask id="ServiceTask_1" name="ServiceTask_1">
       <bpmn:extensionElements>
@@ -36,6 +36,11 @@
     <bpmn:endEvent id="TerminateEvent">
       <bpmn:terminateEventDefinition id="TerminateEventDefinition_0278au4" />
     </bpmn:endEvent>
+    <bpmn:callActivity id="CallActivity_1" name="CallActivity_1">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -65,6 +70,10 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1mzhhj5_di" bpmnElement="TerminateEvent">
         <dc:Bounds x="362" y="382" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cpmy7k_di" bpmnElement="CallActivity_1">
+        <dc:Bounds x="280" y="260" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/zeebe/OutputProps.spec.js
+++ b/test/spec/provider/zeebe/OutputProps.spec.js
@@ -315,6 +315,57 @@ describe('provider/zeebe - OutputProps', function() {
       expect(outputGroup).to.not.exist;
     }));
   });
+
+
+  describe('bpmn:CallActivity#output', function() {
+
+    it('should display if `propagateAllChildVariables` is false',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const callActivity = elementRegistry.get('CallActivity_1');
+
+        // when
+        await act(() => {
+          selection.select(callActivity);
+        });
+
+        // then
+        const outputGroup = getGroup(container, 'outputs');
+        expect(outputGroup).to.exist;
+      })
+    );
+
+
+    it('should not display if `propagateAllChildVariables` is true',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const callActivity = elementRegistry.get('CallActivity_1');
+
+        // when
+        await act(() => {
+          selection.select(callActivity);
+        });
+
+        const outputPropagationGroup = getGroup(container, 'outputPropagation');
+        const outputPropagationGroupHeader = domQuery('.bio-properties-panel-group-header', outputPropagationGroup);
+
+        await act(() => {
+          outputPropagationGroupHeader.click();
+        });
+
+        const propagateAllChildVariablesToggle = domQuery('#bio-properties-panel-propagateAllChildVariables', container);
+        await act(() => {
+          propagateAllChildVariablesToggle.click();
+        });
+
+        // then
+        const outputGroup = getGroup(container, 'outputs');
+        expect(outputGroup).to.not.exist;
+      })
+    );
+  });
 });
 
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5402

### Proposed Changes

For `<bpmn:CallActivity>`, hide the Output group if `zeebe:propagateAllChildVariables` is true.

![call-activity](https://github.com/user-attachments/assets/9c6ae040-f5e1-4028-8b1a-ecf79b1d56ea)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
