### PR TITLE
feat: allow `zeebe:input` source to be a static value

### DIFF
--- a/src/provider/zeebe/properties/InputOutputParameter.js
+++ b/src/provider/zeebe/properties/InputOutputParameter.js
@@ -15,7 +15,8 @@ export default function InputOutputParameter(props) {
 
   const {
     idPrefix,
-    parameter
+    parameter,
+    feel = 'required'
   } = props;
 
   const entries = [ {
@@ -27,7 +28,8 @@ export default function InputOutputParameter(props) {
     id: idPrefix + '-source',
     component: SourceProperty,
     idPrefix,
-    parameter
+    parameter,
+    feel
   } ];
 
   return entries;
@@ -72,7 +74,8 @@ function SourceProperty(props) {
   const {
     idPrefix,
     element,
-    parameter
+    parameter,
+    feel
   } = props;
 
   const commandStack = useService('commandStack');
@@ -98,7 +101,7 @@ function SourceProperty(props) {
     element: parameter,
     id: idPrefix + '-source',
     label: translate('Variable assignment value'),
-    feel: 'required',
+    feel,
     getValue,
     setValue,
     debounce

--- a/src/provider/zeebe/properties/InputProps.js
+++ b/src/provider/zeebe/properties/InputProps.js
@@ -39,7 +39,8 @@ export function InputProps({ element, injector }) {
       entries: InputOutputParameter({
         idPrefix: id,
         element,
-        parameter
+        parameter,
+        feel: 'optional'
       }),
       autoFocusEntry: id + '-target',
       remove: removeFactory({ commandStack, element, parameter })

--- a/test/spec/provider/zeebe/InputOutputParameter.spec.js
+++ b/test/spec/provider/zeebe/InputOutputParameter.spec.js
@@ -183,6 +183,28 @@ describe('provider/zeebe - InputOutputParameter', function() {
     }));
 
 
+    it('should allow toggle (static vs. dynamic)', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const inputGroup = getGroup(container, 'inputs');
+
+      const feelToggle = domQuery(
+        '[data-entry-id="ServiceTask_1-input-0"] button.bio-properties-panel-feel-icon.optional',
+        inputGroup
+      );
+
+      // then
+      expect(feelToggle).to.exist;
+    }));
+
+
     it('should update', inject(async function(elementRegistry, selection) {
 
       // given
@@ -247,11 +269,11 @@ describe('provider/zeebe - InputOutputParameter', function() {
             addEntry.click();
           });
 
-          const sourceInput = domQuery('[name=ServiceTask_empty-input-0-source] [role="textbox"]', inputGroup);
-          await setEditorValue(sourceInput, 'newValue');
+          const sourceInput = domQuery('input[name=ServiceTask_empty-input-0-source]', inputGroup);
+          changeInput(sourceInput, 'newValue');
 
           // assume
-          expect(getInput(serviceTask, 0).get('source')).to.eql('=newValue');
+          expect(getInput(serviceTask, 0).get('source')).to.eql('newValue');
 
           // when
           commandStack.undo();
@@ -280,12 +302,11 @@ describe('provider/zeebe - InputOutputParameter', function() {
             addEntry.click();
           });
 
-          const sourceInput = domQuery('[name=ServiceTask_empty-input-0-source] [role="textbox"]', inputGroup);
-
-          await setEditorValue(sourceInput, 'newValue');
+          const sourceInput = domQuery('input[name=ServiceTask_empty-input-0-source]', inputGroup);
+          changeInput(sourceInput, 'newValue');
 
           // assume
-          expect(getInput(serviceTask, 0).get('source')).to.eql('=newValue');
+          expect(getInput(serviceTask, 0).get('source')).to.eql('newValue');
 
           // when
           commandStack.undo();
@@ -294,7 +315,7 @@ describe('provider/zeebe - InputOutputParameter', function() {
           await nextTick();
 
           // then
-          expect(getInput(serviceTask, 0).get('source')).to.eql('=newValue');
+          expect(getInput(serviceTask, 0).get('source')).to.eql('newValue');
 
         })
       );


### PR DESCRIPTION
### Proposed Changes

Changes `zeebe:input#source` to accept an optional FEEL expression:

![capture gHiyX3_optimized](https://github.com/user-attachments/assets/93914214-7c40-4902-baae-ae8469d53955)

The source binding of `zeebe:output` remains unaffected (does not support static values).

Related to https://github.com/camunda/camunda-modeler/issues/3333


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
