### PR TITLE
test: skip macOS-only failing tests

### DIFF
--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -250,3 +250,7 @@ document.addEventListener('keydown', function(event) {
     download(result.xml, 'test.bpmn', 'application/xml');
   });
 });
+
+export function isMac() {
+  return /mac/i.test(navigator.userAgent);
+}

--- a/test/spec/provider/zeebe/BusinessRuleImplementationProps.spec.js
+++ b/test/spec/provider/zeebe/BusinessRuleImplementationProps.spec.js
@@ -8,7 +8,8 @@ import {
 import {
   bootstrapPropertiesPanel,
   changeInput,
-  inject
+  inject,
+  isMac
 } from 'test/TestHelper';
 
 import {
@@ -122,7 +123,7 @@ describe('provider/zeebe - BusinessRuleImplementationProps', function() {
 
     // TODO(@barmac): this test is fails as false-positive when run locally on MacOS as part of the full test suite,
     // cf. https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1111#pullrequestreview-2635770727
-    it('should display dmn', inject(async function(elementRegistry, selection) {
+    (isMac() ? it.skip : it)('should display dmn', inject(async function(elementRegistry, selection) {
 
       // given
       const businessRuleTask = elementRegistry.get('BusinessRuleTask_2');
@@ -143,7 +144,7 @@ describe('provider/zeebe - BusinessRuleImplementationProps', function() {
 
     // TODO(@barmac): this test is fails as false-positive when run locally on MacOS as part of the full test suite,
     // cf. https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1111#pullrequestreview-2635770727
-    it('should display jobWorker', inject(async function(elementRegistry, selection) {
+    (isMac() ? it.skip : it)('should display jobWorker', inject(async function(elementRegistry, selection) {
 
       // given
       const businessRuleTask = elementRegistry.get('BusinessRuleTask_3');

--- a/test/spec/provider/zeebe/ScriptImplementationProps.spec.js
+++ b/test/spec/provider/zeebe/ScriptImplementationProps.spec.js
@@ -8,7 +8,8 @@ import {
 import {
   bootstrapPropertiesPanel,
   changeInput,
-  inject
+  inject,
+  isMac
 } from 'test/TestHelper';
 
 import {
@@ -123,7 +124,7 @@ describe('provider/zeebe - ScriptImplementationProps', function() {
 
     // TODO(@barmac): this test is fails as false-positive when run locally on MacOS as part of the full test suite,
     // cf. https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1111#pullrequestreview-2635770727
-    it('should display script', inject(async function(elementRegistry, selection) {
+    (isMac() ? it.skip : it)('should display script', inject(async function(elementRegistry, selection) {
 
       // given
       const scriptTask = elementRegistry.get('ScriptTask_2');
@@ -144,7 +145,7 @@ describe('provider/zeebe - ScriptImplementationProps', function() {
 
     // TODO(@barmac): this test is fails as false-positive when run locally on MacOS as part of the full test suite,
     // cf. https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1111#pullrequestreview-2635770727
-    it('should display jobWorker', inject(async function(elementRegistry, selection) {
+    (isMac() ? it.skip : it)('should display jobWorker', inject(async function(elementRegistry, selection) {
 
       // given
       const scriptTask = elementRegistry.get('ScriptTask_3');

--- a/test/spec/provider/zeebe/UserTaskImplementationProps.spec.js
+++ b/test/spec/provider/zeebe/UserTaskImplementationProps.spec.js
@@ -8,7 +8,8 @@ import {
 import {
   bootstrapPropertiesPanel,
   changeInput,
-  inject
+  inject,
+  isMac
 } from 'test/TestHelper';
 
 import {
@@ -103,7 +104,7 @@ describe('provider/zeebe - UserTaskImplementationProps', function() {
 
     // TODO(@barmac): this test is fails as false-positive when run locally on MacOS as part of the full test suite,
     // cf. https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1111#pullrequestreview-2635770727
-    it('should display zeebe user task', inject(async function(elementRegistry, selection) {
+    (isMac() ? it.skip : it)('should display zeebe user task', inject(async function(elementRegistry, selection) {
 
       // given
       const userTask = elementRegistry.get('ZeebeUserTask');


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1111#pullrequestreview-2635770727

### Proposed Changes

This PR ensures the tests are skipped. The behavior in test works correctly, but somehow the tests fail on macOS when the entire test suite is run.

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
