### PR TITLE
fix: show `variableEvents` for conditional intermediate catch events

### DIFF
--- a/src/provider/zeebe/properties/EventConditionProps.js
+++ b/src/provider/zeebe/properties/EventConditionProps.js
@@ -44,22 +44,7 @@ export function EventConditionProps(props) {
     return [];
   }
 
-  // `variableEvents` are not applicable for root-level events
-  if (!is(element.parent, 'bpmn:SubProcess')) {
-    return [
-      {
-        id: 'condition',
-        component: Condition,
-        isEdited: isFeelEntryEdited
-      },
-      {
-        id: 'variableNames',
-        component: VariableNames,
-      },
-    ];
-  }
-
-  return [
+  const entries = [
     {
       id: 'condition',
       component: Condition,
@@ -69,11 +54,16 @@ export function EventConditionProps(props) {
       id: 'variableNames',
       component: VariableNames,
     },
-    {
+  ];
+
+  if (is(element.parent, 'bpmn:SubProcess') || is(element, 'bpmn:IntermediateCatchEvent')) {
+    entries.push({
       id: 'variableEvents',
       component: VariableEvents,
-    }
-  ];
+    });
+  }
+
+  return entries;
 }
 
 /**

--- a/test/spec/provider/zeebe/EventConditionProps.bpmn
+++ b/test/spec/provider/zeebe/EventConditionProps.bpmn
@@ -16,14 +16,13 @@
         <bpmn:condition xsi:type="bpmn:tFormalExpression">=foo &lt; bar</bpmn:condition>
       </bpmn:conditionalEventDefinition>
     </bpmn:startEvent>
-    <bpmn:startEvent id="Event_3">
-      <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_16we37r">
-      </bpmn:conditionalEventDefinition>
-    </bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="Event_3">
+      <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_02j8kp2" />
+    </bpmn:intermediateCatchEvent>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1dd1gi1">
-      <bpmndi:BPMNShape id="BPMNShape_04nb8mn" bpmnElement="Event_3">
+      <bpmndi:BPMNShape id="Event_1dwo39y_di" bpmnElement="Event_3">
         <dc:Bounds x="152" y="232" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1q8hsrq_di" bpmnElement="Activity_01gjpl1" isExpanded="true">

--- a/test/spec/provider/zeebe/EventConditionProps.spec.js
+++ b/test/spec/provider/zeebe/EventConditionProps.spec.js
@@ -214,7 +214,7 @@ describe('provider/zeebe - EventConditionProps', function() {
 
   describe('zeebe:ConditionalFilter#variableEvents', function() {
 
-    it('should display', inject(async function(elementRegistry, selection) {
+    it('should display inside subprocess', inject(async function(elementRegistry, selection) {
 
       // given
       const element = elementRegistry.get('Event_2');
@@ -233,7 +233,26 @@ describe('provider/zeebe - EventConditionProps', function() {
     }));
 
 
-    it('should not display on root level', inject(async function(elementRegistry, selection) {
+    it('should display for intermediate catch event', inject(async function(elementRegistry, selection) {
+
+      // given
+      const element = elementRegistry.get('Event_3');
+
+      // when
+      await act(() => {
+        selection.select(element);
+      });
+
+      const createCheckbox = domQuery('input[name=variableEvents-create]', container);
+      const updateCheckbox = domQuery('input[name=variableEvents-update]', container);
+
+      // then
+      expect(createCheckbox).to.exist;
+      expect(updateCheckbox).to.exist;
+    }));
+
+
+    it('should not display on process start event', inject(async function(elementRegistry, selection) {
 
       // given
       const element = elementRegistry.get('Event_1');


### PR DESCRIPTION
Related to https://camunda.slack.com/archives/GP70M0J6M/p1770218116928989

### Proposed Changes

Show `variableEvents` for conditional intermediate catch events.

<img width="892" height="545" alt="image" src="https://github.com/user-attachments/assets/38bd4e32-7b0f-4ae5-8930-7f131a580c37" />

### Try it

`npm start` and add a conditional intermediate catch event on the process root.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
