### PR TITLE
deps!: require `@bpmn-io/properties-panel@3.36.0` or newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+## 6.0.0
+
+* `DEPS`: require `@bpmn-io/properties-panel@3.36.0` or newer
+
+### Breaking Changes
+
+* The library requires an update of the `@bpmn-io/properties-panel` dependency so that `CheckboxGroup` component can be used. Update it to migrate.
+
 ## 5.50.1
 
 * `FIX`: show `variableEvents` for conditional intermediate catch events ([#1189](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1189))

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "node": "*"
       },
       "peerDependencies": {
-        "@bpmn-io/properties-panel": ">= 3.7",
+        "@bpmn-io/properties-panel": ">= 3.36",
         "bpmn-js": ">= 11.5",
         "camunda-bpmn-js-behaviors": ">= 0.4",
         "diagram-js": ">= 11.9"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "zeebe-bpmn-moddle": "^1.12.0"
   },
   "peerDependencies": {
-    "@bpmn-io/properties-panel": ">= 3.7",
+    "@bpmn-io/properties-panel": ">= 3.36",
     "bpmn-js": ">= 11.5",
     "camunda-bpmn-js-behaviors": ">= 0.4",
     "diagram-js": ">= 11.9"


### PR DESCRIPTION
### Proposed Changes

In #1176, we started using a component which is only available in `@bpmn-io/properties-panel@3.36.0`. However, the `peerDependencies` field was not updated. This change fixes the problem.

Without the fix, downstream libraries report problem with bundling:

<img width="1025" height="446" alt="image" src="https://github.com/user-attachments/assets/8a38a8ab-6ce2-45d1-8002-869c8415658d" />

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
