### PR TITLE
Desktop modeler start form

### DIFF
--- a/src/provider/zeebe/properties/FormProps.js
+++ b/src/provider/zeebe/properties/FormProps.js
@@ -34,6 +34,7 @@ import {
   getFormType,
   getRootElement,
   getUserTaskForm,
+  isFormSupported,
   isZeebeUserTask,
   userTaskFormIdToFormKey
 } from '../utils/FormUtil';
@@ -50,8 +51,7 @@ const NONE_VALUE = 'none';
 
 export function FormProps(props) {
   const { element } = props;
-
-  if (!is(element, 'bpmn:UserTask')) {
+  if (!isFormSupported(element)) {
     return [];
   }
 

--- a/src/provider/zeebe/utils/FormUtil.js
+++ b/src/provider/zeebe/utils/FormUtil.js
@@ -105,3 +105,8 @@ export function isZeebeUserTask(element) {
 
   return getExtensionElementsList(bo, 'zeebe:UserTask').length > 0;
 }
+
+export function isFormSupported(element) {
+  return (is(element, 'bpmn:StartEvent') && !is(element.parent, 'bpmn:SubProcess'))
+    || is(element, 'bpmn:UserTask');
+}

--- a/test/spec/provider/zeebe/Forms.bpmn
+++ b/test/spec/provider/zeebe/Forms.bpmn
@@ -59,6 +59,9 @@
         <zeebe:formDefinition formId="foo" bindingType="versionTag" versionTag="v1.0.0" />
       </bpmn:extensionElements>
     </bpmn:userTask>
+    <bpmn:subProcess id="SUB_PROCESS">
+      <bpmn:startEvent id="START_EVENT_SUB_PROCESS" name="START_EVENT_SUB_PROCESS" />
+    </bpmn:subProcess>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -117,6 +120,14 @@
           <dc:Bounds x="159" y="405" width="83" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SUB_PROCESS" bpmnElement="SUB_PROCESS" isExpanded="true">
+        <dc:Bounds x="140" y="580" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="START_EVENT_SUB_PROCESS" bpmnElement="START_EVENT_SUB_PROCESS">
+        <dc:Bounds x="180" y="662" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="154" y="705" width="89" height="27" />
+        </bpmndi:BPMNLabel>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/spec/provider/zeebe/Forms.bpmn
+++ b/test/spec/provider/zeebe/Forms.bpmn
@@ -96,7 +96,7 @@
       <bpmndi:BPMNShape id="Activity_0q4ulf7_di" bpmnElement="CAMUNDA_FORM_LINKED_VERSION_TAG">
         <dc:Bounds x="490" y="190" width="100" height="80" />
       </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape id="START_EVENT_FORM_EMBEDDED_DI" bpmnElement="START_EVENT_FORM_EMBEDDED">
+      <bpmndi:BPMNShape id="START_EVENT_FORM_EMBEDDED_DI" bpmnElement="START_EVENT_FORM_EMBEDDED">
         <dc:Bounds x="182" y="192" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="159" y="235" width="83" height="40" />
@@ -128,6 +128,7 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="154" y="705" width="89" height="27" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/spec/provider/zeebe/Forms.bpmn
+++ b/test/spec/provider/zeebe/Forms.bpmn
@@ -3,7 +3,24 @@
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:extensionElements>
       <zeebe:userTaskForm id="UserTaskForm_1">{}</zeebe:userTaskForm>
+      <zeebe:userTaskForm id="UserTaskForm_2">{}</zeebe:userTaskForm>
     </bpmn:extensionElements>
+    <bpmn:startEvent id="START_EVENT_NO_FORM" name="START_EVENT_NO_FORM" />
+    <bpmn:startEvent id="START_EVENT_FORM_EMBEDDED" name="START_EVENT_FORM_EMBEDDED">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="camunda-forms:bpmn:UserTaskForm_2" />
+      </bpmn:extensionElements>
+    </bpmn:startEvent>
+    <bpmn:startEvent id="START_EVENT_FORM_LINKED" name="START_EVENT_FORM_LINKED">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="foo" />
+      </bpmn:extensionElements>
+    </bpmn:startEvent>
+    <bpmn:startEvent id="START_EVENT_CUSTOM_FORM" name="START_EVENT_CUSTOM_FORM">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="foo" />
+      </bpmn:extensionElements>
+    </bpmn:startEvent>
     <bpmn:userTask id="CAMUNDA_FORM_EMBEDDED" name="CAMUNDA_FORM_EMBEDDED">
       <bpmn:extensionElements>
         <zeebe:formDefinition formKey="camunda-forms:bpmn:UserTaskForm_1" />
@@ -75,6 +92,30 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0q4ulf7_di" bpmnElement="CAMUNDA_FORM_LINKED_VERSION_TAG">
         <dc:Bounds x="490" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="START_EVENT_FORM_EMBEDDED_DI" bpmnElement="START_EVENT_FORM_EMBEDDED">
+        <dc:Bounds x="182" y="192" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="159" y="235" width="83" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="START_EVENT_NO_FORM_DI" bpmnElement="START_EVENT_NO_FORM">
+        <dc:Bounds x="182" y="112" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="161" y="155" width="79" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="START_EVENT_FORM_LINKED_DI" bpmnElement="START_EVENT_FORM_LINKED">
+        <dc:Bounds x="182" y="282" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="158" y="325" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="START_EVENT_CUSTOM_FORM_DI" bpmnElement="START_EVENT_CUSTOM_FORM">
+        <dc:Bounds x="182" y="362" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="159" y="405" width="83" height="40" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/zeebe/Forms.spec.js
+++ b/test/spec/provider/zeebe/Forms.spec.js
@@ -66,445 +66,28 @@ describe('provider/zeebe - Forms', function() {
     debounceInput: false
   }));
 
+  describe('user tasks', function () {
+    describe('form type', function () {
+      it('should display - embedded form', inject(async function (elementRegistry, selection) {
 
-  describe('form type', function() {
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
 
-    it('should display - embedded form', inject(async function(elementRegistry, selection) {
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
 
-      // given
-      const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
+        const formTypeSelect = getFormTypeSelect(container);
 
-      // when
-      await act(() => {
-        selection.select(userTask);
-      });
+        // then
+        expect(formTypeSelect).to.exist;
 
-      const formTypeSelect = getFormTypeSelect(container);
+        expect(formTypeSelect.value).to.equal(FORM_TYPES.CAMUNDA_FORM_EMBEDDED);
+      }));
 
-      // then
-      expect(formTypeSelect).to.exist;
 
-      expect(formTypeSelect.value).to.equal(FORM_TYPES.CAMUNDA_FORM_EMBEDDED);
-    }));
-
-
-    it('should display - linked form', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
-
-      // when
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formTypeSelect = getFormTypeSelect(container);
-
-      // then
-      expect(formTypeSelect).to.exist;
-
-      expect(formTypeSelect.value).to.equal(FORM_TYPES.CAMUNDA_FORM_LINKED);
-    }));
-
-
-    it('should display - custom form', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CUSTOM_FORM');
-
-      // when
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formTypeSelect = getFormTypeSelect(container);
-
-      // then
-      expect(formTypeSelect).to.exist;
-
-      expect(formTypeSelect.value).to.equal(FORM_TYPES.CUSTOM_FORM);
-    }));
-
-
-    it('should display - external reference', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
-
-      // when
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formTypeSelect = getFormTypeSelect(container);
-
-      // then
-      expect(formTypeSelect).to.exist;
-
-      expect(formTypeSelect.value).to.equal(FORM_TYPES.EXTERNAL_REFERENCE);
-    }));
-
-
-    it('should display - empty', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('NO_FORM');
-
-      // when
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formTypeSelect = getFormTypeSelect(container);
-
-      // then
-      expect(formTypeSelect).to.exist;
-
-      expect(formTypeSelect.value).to.equal('none');
-    }));
-
-
-    it('should update - empty', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formTypeSelect = getFormTypeSelect(container);
-
-      // when
-      changeInput(formTypeSelect, '');
-
-      // then
-
-      const formDefinition = getFormDefinition(userTask);
-      expect(formDefinition).to.not.exist;
-
-      const rootElement = getRootElement(userTask);
-      const userTaskForms = getExtensionElementsList(rootElement, 'zeebe:UserTaskForm');
-      expect(userTaskForms).to.have.lengthOf(0);
-    }));
-
-
-    it('should update - embedded form', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('NO_FORM');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formTypeSelect = getFormTypeSelect(container);
-
-      // when
-      changeInput(formTypeSelect, FORM_TYPES.CAMUNDA_FORM_EMBEDDED);
-
-      // then
-      expectUserTaskForm(userTask, '');
-    }));
-
-
-    it('should update - linked form', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('NO_FORM');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formTypeSelect = getFormTypeSelect(container);
-
-      // when
-      changeInput(formTypeSelect, FORM_TYPES.CAMUNDA_FORM_LINKED);
-
-      // then
-      expectFormId(userTask, '');
-    }));
-
-
-    it('should update - custom form', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('NO_FORM');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formTypeSelect = getFormTypeSelect(container);
-
-      // when
-      changeInput(formTypeSelect, FORM_TYPES.CUSTOM_FORM);
-
-      // then
-      expectFormKey(userTask, '');
-    }));
-
-
-    it('should update - external reference', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('NO_FORM_ZEEBE_USER_TASK');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formTypeSelect = getFormTypeSelect(container);
-
-      // when
-      changeInput(formTypeSelect, FORM_TYPES.EXTERNAL_REFERENCE);
-
-      // then
-      expectExternalReference(userTask, '');
-    }));
-
-
-    it('should update on external change', inject(async function(commandStack, elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('NO_FORM');
-      const rootElement = getRootElement(userTask);
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formTypeSelect = getFormTypeSelect(container);
-      const initialTaskForms = getExtensionElementsList(rootElement, 'zeebe:UserTaskForm').length;
-
-      changeInput(formTypeSelect, FORM_TYPES.CAMUNDA_FORM_EMBEDDED);
-      expectUserTaskForm(userTask, '');
-
-      // when
-      await act(() => {
-        commandStack.undo();
-      });
-
-      // expect user task form not to exist
-      const formDefinition = getFormDefinition(userTask);
-      expect(formDefinition).to.not.exist;
-
-      const forms = getExtensionElementsList(rootElement, 'zeebe:UserTaskForm');
-      expect(forms).to.have.lengthOf(initialTaskForms);
-    }));
-
-  });
-
-
-  describe('embedded form', function() {
-
-    it('should display', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
-
-      // when
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formConfigurationTextarea = getFormConfigurationTextarea(container);
-
-      // then
-      expect(formConfigurationTextarea).to.exist;
-    }));
-
-
-    it('should update', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formConfigurationTextarea = getFormConfigurationTextarea(container);
-
-      // when
-      changeInput(formConfigurationTextarea, '{ "a": 1 }');
-
-      // then
-      expectUserTaskForm(userTask, '{ "a": 1 }');
-    }));
-
-
-    it('should not delete if empty', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formConfigurationTextarea = getFormConfigurationTextarea(container);
-
-      // when
-      changeInput(formConfigurationTextarea, '');
-
-      // then
-      expectUserTaskForm(userTask, '');
-    }));
-
-
-    it('should update on external change', inject(async function(commandStack, elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formConfigurationTextarea = getFormConfigurationTextarea(container);
-      const initialConfig = formConfigurationTextarea.value;
-
-      changeInput(formConfigurationTextarea, '{ "a": 1 }');
-      expectUserTaskForm(userTask, '{ "a": 1 }');
-
-      // when
-      await act(() => {
-        commandStack.undo();
-      });
-
-      expectUserTaskForm(userTask, initialConfig);
-    }));
-
-  });
-
-
-  describe('linked form', function() {
-
-    it('should display', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
-
-      // when
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formIdInput = getFormIdInput(container);
-
-      // then
-      expect(formIdInput).to.exist;
-    }));
-
-
-    it('should display - Zeebe User Task', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED_ZEEBE_USER_TASK');
-
-      // when
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formIdInput = getFormIdInput(container);
-
-      // then
-      expect(formIdInput).to.exist;
-    }));
-
-
-    it('should update', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formIdInput = getFormIdInput(container);
-
-      // when
-      changeInput(formIdInput, 'bar');
-
-      // then
-      expectFormId(userTask, 'bar');
-    }));
-
-
-    it('should not delete if empty', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formIdInput = getFormIdInput(container);
-
-      // when
-      changeInput(formIdInput, '');
-
-      // then
-      expectFormId(userTask, '');
-    }));
-
-
-    it('should update on external change', inject(async function(commandStack, elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const formIdInput = getFormIdInput(container);
-      const initialFormId = formIdInput.value;
-
-      changeInput(formIdInput, 'bar');
-      expectFormId(userTask, 'bar');
-
-      // when
-      await act(() => {
-        commandStack.undo();
-      });
-
-      expectFormId(userTask, initialFormId);
-    }));
-
-
-    it('should update Form ID field with FEEL expression', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      // when
-      let formIdInput = getFormIdInput(container);
-
-      // clear existing value
-      changeInput(formIdInput, '=');
-
-      // update value in FEEL editor
-      const formIdEditor = domQuery('[name=formId] [role=textbox]', container);
-      await setEditorValue(formIdEditor, 'newFormId');
-
-      // then
-      expect(getFormDefinition(userTask).get('formId')).to.equal('=newFormId');
-    }));
-
-
-    describe('binding type', function() {
-
-      it('should display', inject(async function(elementRegistry, selection) {
+      it('should display - linked form', inject(async function (elementRegistry, selection) {
 
         // given
         const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
@@ -514,323 +97,739 @@ describe('provider/zeebe - Forms', function() {
           selection.select(userTask);
         });
 
-        const bindingTypeSelect = getBindingTypeSelect(container);
+        const formTypeSelect = getFormTypeSelect(container);
 
         // then
-        expect(bindingTypeSelect).to.exist;
+        expect(formTypeSelect).to.exist;
+
+        expect(formTypeSelect.value).to.equal(FORM_TYPES.CAMUNDA_FORM_LINKED);
       }));
 
 
-      it('should update', inject(async function(elementRegistry, selection) {
+      it('should display - custom form', inject(async function (elementRegistry, selection) {
 
         // given
-        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
-
-        await act(() => {
-          selection.select(userTask);
-        });
-
-        const bindingTypeSelect = getBindingTypeSelect(container);
+        const userTask = elementRegistry.get('CUSTOM_FORM');
 
         // when
-        changeInput(bindingTypeSelect, 'deployment');
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
 
         // then
-        expectBindingType(userTask, 'deployment');
+        expect(formTypeSelect).to.exist;
+
+        expect(formTypeSelect.value).to.equal(FORM_TYPES.CUSTOM_FORM);
       }));
 
 
-      it('should update on external change', inject(async function(commandStack, elementRegistry, selection) {
+      it('should display - external reference', inject(async function (elementRegistry, selection) {
 
         // given
-        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+        const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // then
+        expect(formTypeSelect).to.exist;
+
+        expect(formTypeSelect.value).to.equal(FORM_TYPES.EXTERNAL_REFERENCE);
+      }));
+
+
+      it('should display - empty', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('NO_FORM');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // then
+        expect(formTypeSelect).to.exist;
+
+        expect(formTypeSelect.value).to.equal('none');
+      }));
+
+
+      it('should update - empty', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
 
         await act(() => {
           selection.select(userTask);
         });
 
-        const bindingTypeSelect = getBindingTypeSelect(container);
-        const initialBindingType = bindingTypeSelect.value;
+        const formTypeSelect = getFormTypeSelect(container);
 
-        changeInput(bindingTypeSelect, 'deployment');
-        expectBindingType(userTask, 'deployment');
+        // when
+        changeInput(formTypeSelect, '');
+
+        // then
+
+        const formDefinition = getFormDefinition(userTask);
+        expect(formDefinition).to.not.exist;
+
+        const rootElement = getRootElement(userTask);
+        const userTaskForms = getExtensionElementsList(rootElement, 'zeebe:UserTaskForm');
+        expect(userTaskForms).to.have.lengthOf(0);
+    }));
+
+
+      it('should update - embedded form', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('NO_FORM');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // when
+        changeInput(formTypeSelect, FORM_TYPES.CAMUNDA_FORM_EMBEDDED);
+
+        // then
+        expectUserTaskForm(userTask, '');
+      }));
+
+
+      it('should update - linked form', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('NO_FORM');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // when
+        changeInput(formTypeSelect, FORM_TYPES.CAMUNDA_FORM_LINKED);
+
+        // then
+        expectFormId(userTask, '');
+      }));
+
+
+      it('should update - custom form', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('NO_FORM');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // when
+        changeInput(formTypeSelect, FORM_TYPES.CUSTOM_FORM);
+
+        // then
+        expectFormKey(userTask, '');
+      }));
+
+
+      it('should update - external reference', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('NO_FORM_ZEEBE_USER_TASK');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // when
+        changeInput(formTypeSelect, FORM_TYPES.EXTERNAL_REFERENCE);
+
+        // then
+        expectExternalReference(userTask, '');
+      }));
+
+
+      it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('NO_FORM');
+        const rootElement = getRootElement(userTask);
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+        const initialTaskForms = getExtensionElementsList(rootElement, 'zeebe:UserTaskForm').length;
+
+        changeInput(formTypeSelect, FORM_TYPES.CAMUNDA_FORM_EMBEDDED);
+        expectUserTaskForm(userTask, '');
 
         // when
         await act(() => {
           commandStack.undo();
         });
 
-        expectBindingType(userTask, initialBindingType);
+        // expect user task form not to exist
+        const formDefinition = getFormDefinition(userTask);
+        expect(formDefinition).to.not.exist;
+
+        const forms = getExtensionElementsList(rootElement, 'zeebe:UserTaskForm');
+        expect(forms).to.have.lengthOf(initialTaskForms);
       }));
 
     });
 
 
-    describe('version tag', function() {
+    describe('embedded form', function () {
 
-      it('should display', inject(async function(elementRegistry, selection) {
+      it('should display', inject(async function (elementRegistry, selection) {
 
         // given
-        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED_VERSION_TAG');
+        const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
 
         // when
         await act(() => {
           selection.select(userTask);
         });
 
-        const versionTagInput = getVersionTagInput(container);
+        const formConfigurationTextarea = getFormConfigurationTextarea(container);
 
         // then
-        expect(versionTagInput).to.exist;
+        expect(formConfigurationTextarea).to.exist;
       }));
 
 
-      it('should update', inject(async function(elementRegistry, selection) {
+      it('should update', inject(async function (elementRegistry, selection) {
 
         // given
-        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED_VERSION_TAG');
+        const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
 
         await act(() => {
           selection.select(userTask);
         });
 
-        const versionTagInput = getVersionTagInput(container);
+        const formConfigurationTextarea = getFormConfigurationTextarea(container);
 
         // when
-        changeInput(versionTagInput, 'v2.0.0');
+        changeInput(formConfigurationTextarea, '{ "a": 1 }');
 
         // then
-        expectVersionTag(userTask, 'v2.0.0');
+        expectUserTaskForm(userTask, '{ "a": 1 }');
       }));
 
 
-      it('should update on external change', inject(async function(commandStack, elementRegistry, selection) {
+      it('should not delete if empty', inject(async function (elementRegistry, selection) {
 
         // given
-        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED_VERSION_TAG');
+        const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
 
         await act(() => {
           selection.select(userTask);
         });
 
-        const versionTagInput = getVersionTagInput(container);
-        const initialVersionTag = versionTagInput.value;
+        const formConfigurationTextarea = getFormConfigurationTextarea(container);
 
-        changeInput(versionTagInput, 'v2.0.0');
-        expectVersionTag(userTask, 'v2.0.0');
+        // when
+        changeInput(formConfigurationTextarea, '');
+
+        // then
+        expectUserTaskForm(userTask, '');
+      }));
+
+
+      it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formConfigurationTextarea = getFormConfigurationTextarea(container);
+        const initialConfig = formConfigurationTextarea.value;
+
+        changeInput(formConfigurationTextarea, '{ "a": 1 }');
+        expectUserTaskForm(userTask, '{ "a": 1 }');
 
         // when
         await act(() => {
           commandStack.undo();
         });
 
-        expectVersionTag(userTask, initialVersionTag);
+        expectUserTaskForm(userTask, initialConfig);
       }));
 
     });
 
+
+    describe('linked form', function () {
+
+      it('should display', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formIdInput = getFormIdInput(container);
+
+        // then
+        expect(formIdInput).to.exist;
+      }));
+
+
+      it('should display - Zeebe User Task', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED_ZEEBE_USER_TASK');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formIdInput = getFormIdInput(container);
+
+        // then
+        expect(formIdInput).to.exist;
+      }));
+
+
+      it('should update', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formIdInput = getFormIdInput(container);
+
+        // when
+        changeInput(formIdInput, 'bar');
+
+        // then
+        expectFormId(userTask, 'bar');
+      }));
+
+
+      it('should not delete if empty', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formIdInput = getFormIdInput(container);
+
+        // when
+        changeInput(formIdInput, '');
+
+        // then
+        expectFormId(userTask, '');
+      }));
+
+
+      it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formIdInput = getFormIdInput(container);
+        const initialFormId = formIdInput.value;
+
+        changeInput(formIdInput, 'bar');
+        expectFormId(userTask, 'bar');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        expectFormId(userTask, initialFormId);
+      }));
+
+
+      it('should update Form ID field with FEEL expression', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        // when
+        let formIdInput = getFormIdInput(container);
+
+        // clear existing value
+        changeInput(formIdInput, '=');
+
+        // update value in FEEL editor
+        const formIdEditor = domQuery('[name=formId] [role=textbox]', container);
+        await setEditorValue(formIdEditor, 'newFormId');
+
+        // then
+        expect(getFormDefinition(userTask).get('formId')).to.equal('=newFormId');
+      }));
+
+
+      describe('binding type', function () {
+
+        it('should display', inject(async function (elementRegistry, selection) {
+
+          // given
+          const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+          // when
+          await act(() => {
+            selection.select(userTask);
+          });
+
+          const bindingTypeSelect = getBindingTypeSelect(container);
+
+          // then
+          expect(bindingTypeSelect).to.exist;
+        }));
+
+
+        it('should update', inject(async function (elementRegistry, selection) {
+
+          // given
+          const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+          await act(() => {
+            selection.select(userTask);
+          });
+
+          const bindingTypeSelect = getBindingTypeSelect(container);
+
+          // when
+          changeInput(bindingTypeSelect, 'deployment');
+
+          // then
+          expectBindingType(userTask, 'deployment');
+        }));
+
+
+        it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+          // given
+          const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+          await act(() => {
+            selection.select(userTask);
+          });
+
+          const bindingTypeSelect = getBindingTypeSelect(container);
+          const initialBindingType = bindingTypeSelect.value;
+
+          changeInput(bindingTypeSelect, 'deployment');
+          expectBindingType(userTask, 'deployment');
+
+          // when
+          await act(() => {
+            commandStack.undo();
+          });
+
+          expectBindingType(userTask, initialBindingType);
+        }));
+
+      });
+
+
+      describe('version tag', function () {
+
+        it('should display', inject(async function (elementRegistry, selection) {
+
+          // given
+          const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED_VERSION_TAG');
+
+          // when
+          await act(() => {
+            selection.select(userTask);
+          });
+
+          const versionTagInput = getVersionTagInput(container);
+
+          // then
+          expect(versionTagInput).to.exist;
+        }));
+
+
+        it('should update', inject(async function (elementRegistry, selection) {
+
+          // given
+          const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED_VERSION_TAG');
+
+          await act(() => {
+            selection.select(userTask);
+          });
+
+          const versionTagInput = getVersionTagInput(container);
+
+          // when
+          changeInput(versionTagInput, 'v2.0.0');
+
+          // then
+          expectVersionTag(userTask, 'v2.0.0');
+        }));
+
+
+        it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+          // given
+          const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED_VERSION_TAG');
+
+          await act(() => {
+            selection.select(userTask);
+          });
+
+          const versionTagInput = getVersionTagInput(container);
+          const initialVersionTag = versionTagInput.value;
+
+          changeInput(versionTagInput, 'v2.0.0');
+          expectVersionTag(userTask, 'v2.0.0');
+
+          // when
+          await act(() => {
+            commandStack.undo();
+          });
+
+          expectVersionTag(userTask, initialVersionTag);
+        }));
+
+      });
+
+    });
+
+
+    describe('custom form', function () {
+
+      it('should display', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const customFormKeyInput = getCustomFormKeyInput(container);
+
+        // then
+        expect(customFormKeyInput).to.exist;
+      }));
+
+
+      it('should NOT display', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const customFormKeyInput = getCustomFormKeyInput(container);
+
+        // then
+        expect(customFormKeyInput).not.to.exist;
+      }));
+
+
+      it('should update', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const customFormKeyInput = getCustomFormKeyInput(container);
+
+        // when
+        changeInput(customFormKeyInput, 'foo');
+
+        // then
+        expectFormKey(userTask, 'foo');
+      }));
+
+
+      it('should not delete if empty', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const customFormKeyInput = getCustomFormKeyInput(container);
+
+        // when
+        changeInput(customFormKeyInput, '');
+
+        // then
+        expectFormKey(userTask, '');
+      }));
+
+
+      it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const customFormKeyInput = getCustomFormKeyInput(container);
+        const initialFormKey = customFormKeyInput.value;
+
+        changeInput(customFormKeyInput, 'bar');
+        expectFormKey(userTask, 'bar');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        expectFormKey(userTask, initialFormKey);
+      }));
+    });
+
+
+    describe('external reference', function () {
+
+      it('should display', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const externalReferenceInput = getExternalReferenceInput(container);
+
+        // then
+        expect(externalReferenceInput).to.exist;
+      }));
+
+
+      it('should NOT display', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const externalReferenceInput = getExternalReferenceInput(container);
+
+        // then
+        expect(externalReferenceInput).not.to.exist;
+      }));
+
+
+      it('should update', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const externalReferenceInput = getExternalReferenceInput(container);
+
+        // when
+        changeInput(externalReferenceInput, 'foo');
+
+        // then
+        expectExternalReference(userTask, 'foo');
+      }));
+
+
+      it('should not delete if empty', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const externalReferenceInput = getExternalReferenceInput(container);
+
+        // when
+        changeInput(externalReferenceInput, '');
+
+        // then
+        expectExternalReference(userTask, '');
+      }));
+
+
+      it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const externalReferenceInput = getExternalReferenceInput(container);
+        const initialFormKey = externalReferenceInput.value;
+
+        changeInput(externalReferenceInput, 'bar');
+        expectExternalReference(userTask, 'bar');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        expectExternalReference(userTask, initialFormKey);
+      }));
+    });
+
   });
-
-
-  describe('custom form', function() {
-
-    it('should display', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CUSTOM_FORM');
-
-      // when
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const customFormKeyInput = getCustomFormKeyInput(container);
-
-      // then
-      expect(customFormKeyInput).to.exist;
-    }));
-
-
-    it('should NOT display', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
-
-      // when
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const customFormKeyInput = getCustomFormKeyInput(container);
-
-      // then
-      expect(customFormKeyInput).not.to.exist;
-    }));
-
-
-    it('should update', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CUSTOM_FORM');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const customFormKeyInput = getCustomFormKeyInput(container);
-
-      // when
-      changeInput(customFormKeyInput, 'foo');
-
-      // then
-      expectFormKey(userTask, 'foo');
-    }));
-
-
-    it('should not delete if empty', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CUSTOM_FORM');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const customFormKeyInput = getCustomFormKeyInput(container);
-
-      // when
-      changeInput(customFormKeyInput, '');
-
-      // then
-      expectFormKey(userTask, '');
-    }));
-
-
-    it('should update on external change', inject(async function(commandStack, elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CUSTOM_FORM');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const customFormKeyInput = getCustomFormKeyInput(container);
-      const initialFormKey = customFormKeyInput.value;
-
-      changeInput(customFormKeyInput, 'bar');
-      expectFormKey(userTask, 'bar');
-
-      // when
-      await act(() => {
-        commandStack.undo();
-      });
-
-      expectFormKey(userTask, initialFormKey);
-    }));
-  });
-
-
-  describe('external reference', function() {
-
-    it('should display', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
-
-      // when
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const externalReferenceInput = getExternalReferenceInput(container);
-
-      // then
-      expect(externalReferenceInput).to.exist;
-    }));
-
-
-    it('should NOT display', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CUSTOM_FORM');
-
-      // when
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const externalReferenceInput = getExternalReferenceInput(container);
-
-      // then
-      expect(externalReferenceInput).not.to.exist;
-    }));
-
-
-    it('should update', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const externalReferenceInput = getExternalReferenceInput(container);
-
-      // when
-      changeInput(externalReferenceInput, 'foo');
-
-      // then
-      expectExternalReference(userTask, 'foo');
-    }));
-
-
-    it('should not delete if empty', inject(async function(elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const externalReferenceInput = getExternalReferenceInput(container);
-
-      // when
-      changeInput(externalReferenceInput, '');
-
-      // then
-      expectExternalReference(userTask, '');
-    }));
-
-
-    it('should update on external change', inject(async function(commandStack, elementRegistry, selection) {
-
-      // given
-      const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
-
-      await act(() => {
-        selection.select(userTask);
-      });
-
-      const externalReferenceInput = getExternalReferenceInput(container);
-      const initialFormKey = externalReferenceInput.value;
-
-      changeInput(externalReferenceInput, 'bar');
-      expectExternalReference(userTask, 'bar');
-
-      // when
-      await act(() => {
-        commandStack.undo();
-      });
-
-      expectExternalReference(userTask, initialFormKey);
-    }));
-  });
-
 });
-
 
 // helpers //////////
 

--- a/test/spec/provider/zeebe/Forms.spec.js
+++ b/test/spec/provider/zeebe/Forms.spec.js
@@ -1714,7 +1714,8 @@ describe('provider/zeebe - Forms', function() {
 
         const rootElement = getRootElement(startEvent);
         const userTaskForms = getExtensionElementsList(rootElement, 'zeebe:UserTaskForm');
-        expect(userTaskForms).to.have.lengthOf(1); // UserTaskForm_1 should still exist
+        const remainingFormIds = userTaskForms.map(form => form.id);
+        expect(remainingFormIds).to.not.include('UserTaskForm_2');
       }));
 
 

--- a/test/spec/provider/zeebe/Forms.spec.js
+++ b/test/spec/provider/zeebe/Forms.spec.js
@@ -1676,6 +1676,23 @@ describe('provider/zeebe - Forms', function() {
       }));
 
 
+      it('should not display - subprocess start event', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_SUB_PROCESS');
+
+        // when
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // then
+        expect(formTypeSelect).to.not.exist;
+      }));
+
+
       it('should update - empty', inject(async function (elementRegistry, selection) {
 
         // given

--- a/test/spec/provider/zeebe/Forms.spec.js
+++ b/test/spec/provider/zeebe/Forms.spec.js
@@ -184,8 +184,9 @@ describe('provider/zeebe - Forms', function() {
 
         const rootElement = getRootElement(userTask);
         const userTaskForms = getExtensionElementsList(rootElement, 'zeebe:UserTaskForm');
-        expect(userTaskForms).to.have.lengthOf(0);
-    }));
+        const userTaskForm1 = userTaskForms.find(form => form.get('id') === 'UserTaskForm_1');
+        expect(userTaskForm1).to.not.exist;
+      }));
 
 
       it('should update - embedded form', inject(async function (elementRegistry, selection) {
@@ -829,7 +830,1217 @@ describe('provider/zeebe - Forms', function() {
     });
 
   });
+
+  describe('user tasks', function () {
+    describe('form type', function () {
+      it('should display - embedded form', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // then
+        expect(formTypeSelect).to.exist;
+
+        expect(formTypeSelect.value).to.equal(FORM_TYPES.CAMUNDA_FORM_EMBEDDED);
+      }));
+
+
+      it('should display - linked form', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // then
+        expect(formTypeSelect).to.exist;
+
+        expect(formTypeSelect.value).to.equal(FORM_TYPES.CAMUNDA_FORM_LINKED);
+      }));
+
+
+      it('should display - custom form', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // then
+        expect(formTypeSelect).to.exist;
+
+        expect(formTypeSelect.value).to.equal(FORM_TYPES.CUSTOM_FORM);
+      }));
+
+
+      it('should display - external reference', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // then
+        expect(formTypeSelect).to.exist;
+
+        expect(formTypeSelect.value).to.equal(FORM_TYPES.EXTERNAL_REFERENCE);
+      }));
+
+
+      it('should display - empty', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('NO_FORM');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // then
+        expect(formTypeSelect).to.exist;
+
+        expect(formTypeSelect.value).to.equal('none');
+      }));
+
+
+      it('should update - empty', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // when
+        changeInput(formTypeSelect, '');
+
+        // then
+
+        const formDefinition = getFormDefinition(userTask);
+        expect(formDefinition).to.not.exist;
+
+        const rootElement = getRootElement(userTask);
+        const userTaskForms = getExtensionElementsList(rootElement, 'zeebe:UserTaskForm');
+        const userTaskForm1 = userTaskForms.find(form => form.get('id') === 'UserTaskForm_1');
+        expect(userTaskForm1).to.not.exist;
+      }));
+
+
+      it('should update - embedded form', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('NO_FORM');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // when
+        changeInput(formTypeSelect, FORM_TYPES.CAMUNDA_FORM_EMBEDDED);
+
+        // then
+        expectUserTaskForm(userTask, '');
+      }));
+
+
+      it('should update - linked form', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('NO_FORM');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // when
+        changeInput(formTypeSelect, FORM_TYPES.CAMUNDA_FORM_LINKED);
+
+        // then
+        expectFormId(userTask, '');
+      }));
+
+
+      it('should update - custom form', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('NO_FORM');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // when
+        changeInput(formTypeSelect, FORM_TYPES.CUSTOM_FORM);
+
+        // then
+        expectFormKey(userTask, '');
+      }));
+
+
+      it('should update - external reference', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('NO_FORM_ZEEBE_USER_TASK');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // when
+        changeInput(formTypeSelect, FORM_TYPES.EXTERNAL_REFERENCE);
+
+        // then
+        expectExternalReference(userTask, '');
+      }));
+
+
+      it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('NO_FORM');
+        const rootElement = getRootElement(userTask);
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+        const initialTaskForms = getExtensionElementsList(rootElement, 'zeebe:UserTaskForm').length;
+
+        changeInput(formTypeSelect, FORM_TYPES.CAMUNDA_FORM_EMBEDDED);
+        expectUserTaskForm(userTask, '');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // expect user task form not to exist
+        const formDefinition = getFormDefinition(userTask);
+        expect(formDefinition).to.not.exist;
+
+        const forms = getExtensionElementsList(rootElement, 'zeebe:UserTaskForm');
+        expect(forms).to.have.lengthOf(initialTaskForms);
+      }));
+
+    });
+
+
+    describe('embedded form', function () {
+
+      it('should display', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formConfigurationTextarea = getFormConfigurationTextarea(container);
+
+        // then
+        expect(formConfigurationTextarea).to.exist;
+      }));
+
+
+      it('should update', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formConfigurationTextarea = getFormConfigurationTextarea(container);
+
+        // when
+        changeInput(formConfigurationTextarea, '{ "a": 1 }');
+
+        // then
+        expectUserTaskForm(userTask, '{ "a": 1 }');
+      }));
+
+
+      it('should not delete if empty', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formConfigurationTextarea = getFormConfigurationTextarea(container);
+
+        // when
+        changeInput(formConfigurationTextarea, '');
+
+        // then
+        expectUserTaskForm(userTask, '');
+      }));
+
+
+      it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_EMBEDDED');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formConfigurationTextarea = getFormConfigurationTextarea(container);
+        const initialConfig = formConfigurationTextarea.value;
+
+        changeInput(formConfigurationTextarea, '{ "a": 1 }');
+        expectUserTaskForm(userTask, '{ "a": 1 }');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        expectUserTaskForm(userTask, initialConfig);
+      }));
+
+    });
+
+
+    describe('linked form', function () {
+
+      it('should display', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formIdInput = getFormIdInput(container);
+
+        // then
+        expect(formIdInput).to.exist;
+      }));
+
+
+      it('should display - Zeebe User Task', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED_ZEEBE_USER_TASK');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formIdInput = getFormIdInput(container);
+
+        // then
+        expect(formIdInput).to.exist;
+      }));
+
+
+      it('should update', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formIdInput = getFormIdInput(container);
+
+        // when
+        changeInput(formIdInput, 'bar');
+
+        // then
+        expectFormId(userTask, 'bar');
+      }));
+
+
+      it('should not delete if empty', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formIdInput = getFormIdInput(container);
+
+        // when
+        changeInput(formIdInput, '');
+
+        // then
+        expectFormId(userTask, '');
+      }));
+
+
+      it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const formIdInput = getFormIdInput(container);
+        const initialFormId = formIdInput.value;
+
+        changeInput(formIdInput, 'bar');
+        expectFormId(userTask, 'bar');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        expectFormId(userTask, initialFormId);
+      }));
+
+
+      it('should update Form ID field with FEEL expression', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        // when
+        let formIdInput = getFormIdInput(container);
+
+        // clear existing value
+        changeInput(formIdInput, '=');
+
+        // update value in FEEL editor
+        const formIdEditor = domQuery('[name=formId] [role=textbox]', container);
+        await setEditorValue(formIdEditor, 'newFormId');
+
+        // then
+        expect(getFormDefinition(userTask).get('formId')).to.equal('=newFormId');
+      }));
+
+
+      describe('binding type', function () {
+
+        it('should display', inject(async function (elementRegistry, selection) {
+
+          // given
+          const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+          // when
+          await act(() => {
+            selection.select(userTask);
+          });
+
+          const bindingTypeSelect = getBindingTypeSelect(container);
+
+          // then
+          expect(bindingTypeSelect).to.exist;
+        }));
+
+
+        it('should update', inject(async function (elementRegistry, selection) {
+
+          // given
+          const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+          await act(() => {
+            selection.select(userTask);
+          });
+
+          const bindingTypeSelect = getBindingTypeSelect(container);
+
+          // when
+          changeInput(bindingTypeSelect, 'deployment');
+
+          // then
+          expectBindingType(userTask, 'deployment');
+        }));
+
+
+        it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+          // given
+          const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED');
+
+          await act(() => {
+            selection.select(userTask);
+          });
+
+          const bindingTypeSelect = getBindingTypeSelect(container);
+          const initialBindingType = bindingTypeSelect.value;
+
+          changeInput(bindingTypeSelect, 'deployment');
+          expectBindingType(userTask, 'deployment');
+
+          // when
+          await act(() => {
+            commandStack.undo();
+          });
+
+          expectBindingType(userTask, initialBindingType);
+        }));
+
+      });
+
+
+      describe('version tag', function () {
+
+        it('should display', inject(async function (elementRegistry, selection) {
+
+          // given
+          const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED_VERSION_TAG');
+
+          // when
+          await act(() => {
+            selection.select(userTask);
+          });
+
+          const versionTagInput = getVersionTagInput(container);
+
+          // then
+          expect(versionTagInput).to.exist;
+        }));
+
+
+        it('should update', inject(async function (elementRegistry, selection) {
+
+          // given
+          const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED_VERSION_TAG');
+
+          await act(() => {
+            selection.select(userTask);
+          });
+
+          const versionTagInput = getVersionTagInput(container);
+
+          // when
+          changeInput(versionTagInput, 'v2.0.0');
+
+          // then
+          expectVersionTag(userTask, 'v2.0.0');
+        }));
+
+
+        it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+          // given
+          const userTask = elementRegistry.get('CAMUNDA_FORM_LINKED_VERSION_TAG');
+
+          await act(() => {
+            selection.select(userTask);
+          });
+
+          const versionTagInput = getVersionTagInput(container);
+          const initialVersionTag = versionTagInput.value;
+
+          changeInput(versionTagInput, 'v2.0.0');
+          expectVersionTag(userTask, 'v2.0.0');
+
+          // when
+          await act(() => {
+            commandStack.undo();
+          });
+
+          expectVersionTag(userTask, initialVersionTag);
+        }));
+
+      });
+
+    });
+
+
+    describe('custom form', function () {
+
+      it('should display', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const customFormKeyInput = getCustomFormKeyInput(container);
+
+        // then
+        expect(customFormKeyInput).to.exist;
+      }));
+
+
+      it('should NOT display', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const customFormKeyInput = getCustomFormKeyInput(container);
+
+        // then
+        expect(customFormKeyInput).not.to.exist;
+      }));
+
+
+      it('should update', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const customFormKeyInput = getCustomFormKeyInput(container);
+
+        // when
+        changeInput(customFormKeyInput, 'foo');
+
+        // then
+        expectFormKey(userTask, 'foo');
+      }));
+
+
+      it('should not delete if empty', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const customFormKeyInput = getCustomFormKeyInput(container);
+
+        // when
+        changeInput(customFormKeyInput, '');
+
+        // then
+        expectFormKey(userTask, '');
+      }));
+
+
+      it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const customFormKeyInput = getCustomFormKeyInput(container);
+        const initialFormKey = customFormKeyInput.value;
+
+        changeInput(customFormKeyInput, 'bar');
+        expectFormKey(userTask, 'bar');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        expectFormKey(userTask, initialFormKey);
+      }));
+    });
+
+
+    describe('external reference', function () {
+
+      it('should display', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const externalReferenceInput = getExternalReferenceInput(container);
+
+        // then
+        expect(externalReferenceInput).to.exist;
+      }));
+
+
+      it('should NOT display', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM');
+
+        // when
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const externalReferenceInput = getExternalReferenceInput(container);
+
+        // then
+        expect(externalReferenceInput).not.to.exist;
+      }));
+
+
+      it('should update', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const externalReferenceInput = getExternalReferenceInput(container);
+
+        // when
+        changeInput(externalReferenceInput, 'foo');
+
+        // then
+        expectExternalReference(userTask, 'foo');
+      }));
+
+
+      it('should not delete if empty', inject(async function (elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const externalReferenceInput = getExternalReferenceInput(container);
+
+        // when
+        changeInput(externalReferenceInput, '');
+
+        // then
+        expectExternalReference(userTask, '');
+      }));
+
+
+      it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+        // given
+        const userTask = elementRegistry.get('CUSTOM_FORM_ZEEBE_USER_TASK');
+
+        await act(() => {
+          selection.select(userTask);
+        });
+
+        const externalReferenceInput = getExternalReferenceInput(container);
+        const initialFormKey = externalReferenceInput.value;
+
+        changeInput(externalReferenceInput, 'bar');
+        expectExternalReference(userTask, 'bar');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        expectExternalReference(userTask, initialFormKey);
+      }));
+    });
+
+  });
+
+
+
+
+  describe('start events', function () {
+    describe('form type', function () {
+      it('should display - embedded form', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_FORM_EMBEDDED');
+        // when
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // then
+        expect(formTypeSelect).to.exist;
+
+        expect(formTypeSelect.value).to.equal(FORM_TYPES.CAMUNDA_FORM_EMBEDDED);
+      }));
+
+
+      it('should display - linked form', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_FORM_LINKED');
+
+        // when
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // then
+        expect(formTypeSelect).to.exist;
+
+        expect(formTypeSelect.value).to.equal(FORM_TYPES.CAMUNDA_FORM_LINKED);
+      }));
+
+
+      it('should display - custom form', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_CUSTOM_FORM');
+
+        // when
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // then
+        expect(formTypeSelect).to.exist;
+
+        expect(formTypeSelect.value).to.equal(FORM_TYPES.CUSTOM_FORM);
+      }));
+
+
+      it('should display - empty', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_NO_FORM');
+
+        // when
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // then
+        expect(formTypeSelect).to.exist;
+
+        expect(formTypeSelect.value).to.equal('none');
+      }));
+
+
+      it('should update - empty', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_FORM_EMBEDDED');
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // when
+        changeInput(formTypeSelect, '');
+
+        // then
+
+        const formDefinition = getFormDefinition(startEvent);
+        expect(formDefinition).to.not.exist;
+
+        const rootElement = getRootElement(startEvent);
+        const userTaskForms = getExtensionElementsList(rootElement, 'zeebe:UserTaskForm');
+        expect(userTaskForms).to.have.lengthOf(1); // UserTaskForm_1 should still exist
+      }));
+
+
+      it('should update - embedded form', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_NO_FORM');
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // when
+        changeInput(formTypeSelect, FORM_TYPES.CAMUNDA_FORM_EMBEDDED);
+
+        // then
+        expectUserTaskForm(startEvent, '');
+      }));
+
+
+      it('should update - linked form', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_NO_FORM');
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // when
+        changeInput(formTypeSelect, FORM_TYPES.CAMUNDA_FORM_LINKED);
+
+        // then
+        expectFormId(startEvent, '');
+      }));
+
+
+      it('should update - custom form', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_NO_FORM');
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+
+        // when
+        changeInput(formTypeSelect, FORM_TYPES.CUSTOM_FORM);
+
+        // then
+        expectFormKey(startEvent, '');
+      }));
+
+
+      it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_NO_FORM');
+        const rootElement = getRootElement(startEvent);
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formTypeSelect = getFormTypeSelect(container);
+        const initialTaskForms = getExtensionElementsList(rootElement, 'zeebe:UserTaskForm').length;
+
+        changeInput(formTypeSelect, FORM_TYPES.CAMUNDA_FORM_EMBEDDED);
+        expectUserTaskForm(startEvent, '');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // expect user task form not to exist
+        const formDefinition = getFormDefinition(startEvent);
+        expect(formDefinition).to.not.exist;
+
+        const forms = getExtensionElementsList(rootElement, 'zeebe:UserTaskForm');
+        expect(forms).to.have.lengthOf(initialTaskForms);
+      }));
+
+    });
+
+
+    describe('embedded form', function () {
+
+      it('should display', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_FORM_EMBEDDED');
+
+        // when
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formConfigurationTextarea = getFormConfigurationTextarea(container);
+
+        // then
+        expect(formConfigurationTextarea).to.exist;
+      }));
+
+
+      it('should update', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_FORM_EMBEDDED');
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formConfigurationTextarea = getFormConfigurationTextarea(container);
+
+        // when
+        changeInput(formConfigurationTextarea, '{ "a": 1 }');
+
+        // then
+        expectUserTaskForm(startEvent, '{ "a": 1 }');
+      }));
+
+
+      it('should not delete if empty', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_FORM_EMBEDDED');
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formConfigurationTextarea = getFormConfigurationTextarea(container);
+
+        // when
+        changeInput(formConfigurationTextarea, '');
+
+        // then
+        expectUserTaskForm(startEvent, '');
+      }));
+
+
+      it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_FORM_EMBEDDED');
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formConfigurationTextarea = getFormConfigurationTextarea(container);
+        const initialBody = formConfigurationTextarea.value;
+
+        changeInput(formConfigurationTextarea, '{ "a": 1 }');
+        expectUserTaskForm(startEvent, '{ "a": 1 }');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        expectUserTaskForm(startEvent, initialBody);
+      }));
+    });
+
+
+    describe('linked form', function () {
+
+      it('should display', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_FORM_LINKED');
+
+        // when
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formIdInput = getFormIdInput(container);
+
+        // then
+        expect(formIdInput).to.exist;
+        expect(formIdInput.value).to.equal('foo');
+      }));
+
+
+      it('should update', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_FORM_LINKED');
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formIdInput = getFormIdInput(container);
+
+        // when
+        changeInput(formIdInput, 'bar');
+
+        // then
+        expectFormId(startEvent, 'bar');
+      }));
+
+
+      it('should not delete if empty', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_FORM_LINKED');
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formIdInput = getFormIdInput(container);
+
+        // when
+        changeInput(formIdInput, '');
+
+        // then
+        expectFormId(startEvent, '');
+      }));
+
+
+      it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_FORM_LINKED');
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const formIdInput = getFormIdInput(container);
+        const initialFormId = formIdInput.value;
+
+        changeInput(formIdInput, 'bar');
+        expectFormId(startEvent, 'bar');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        expectFormId(startEvent, initialFormId);
+      }));
+    });
+
+
+    describe('custom form', function () {
+
+      it('should display', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_CUSTOM_FORM');
+
+        // when
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const customFormKeyInput = getCustomFormKeyInput(container);
+
+        // then
+        expect(customFormKeyInput).to.exist;
+        expect(customFormKeyInput.value).to.equal('foo');
+      }));
+
+
+      it('should update', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_CUSTOM_FORM');
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const customFormKeyInput = getCustomFormKeyInput(container);
+
+        // when
+        changeInput(customFormKeyInput, 'bar');
+
+        // then
+        expectFormKey(startEvent, 'bar');
+      }));
+
+
+      it('should not delete if empty', inject(async function (elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_CUSTOM_FORM');
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const customFormKeyInput = getCustomFormKeyInput(container);
+
+        // when
+        changeInput(customFormKeyInput, '');
+
+        // then
+        expectFormKey(startEvent, '');
+      }));
+
+
+      it('should update on external change', inject(async function (commandStack, elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_CUSTOM_FORM');
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const customFormKeyInput = getCustomFormKeyInput(container);
+        const initialFormKey = customFormKeyInput.value;
+
+        changeInput(customFormKeyInput, 'bar');
+        expectFormKey(startEvent, 'bar');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        expectFormKey(startEvent, initialFormKey);
+      }));
+    });
+
+  });
+
 });
+
 
 // helpers //////////
 


### PR DESCRIPTION
### Proposed Changes
Closes #1196 by enabling the "Form" group property in case the element is either a user task, or a start event (but not if the start event is part of a sub process)

This is in line with the cloud/platform providers in this repository.

Screenshot in desktop modeler:
<img width="1471" height="814" alt="image" src="https://github.com/user-attachments/assets/79998296-4dcf-4316-a47a-74d63be9f0f1" />

Screenshot from this repo's `npm run start`:
<img width="1511" height="797" alt="image" src="https://github.com/user-attachments/assets/bb9a6a12-aeea-42da-90e1-6045102ee927" />



To try out:

1. Run `npm run start`
2. Click on a start event
3. See that there is now a section where you can specify the form to use upon starting a form

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)