### PR TITLE
feat: add multi-instance specific event types for execution listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: add multi-instance specific event types for execution listeners ([#1215](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1215))
+
 ## 5.54.0
 
 * `FEAT`: add execution listener headers configuration ([#1211](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1211))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: add multi-instance specific event types for execution listeners ([#1215](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1215))
+* `DEPS`: update to `camunda-bpmn-js-behaviors@1.15.0`
 
 ## 5.54.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "bpmn-js": "^18.14.0",
         "bpmn-js-create-append-anything": "^1.2.0",
         "bpmn-moddle": "^10.0.0",
-        "camunda-bpmn-js-behaviors": "^1.14.1",
+        "camunda-bpmn-js-behaviors": "^1.15.0",
         "camunda-bpmn-moddle": "^7.0.1",
         "chai": "^4.5.0",
         "cross-env": "^10.1.0",
@@ -3310,9 +3310,9 @@
       }
     },
     "node_modules/camunda-bpmn-js-behaviors": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.14.1.tgz",
-      "integrity": "sha512-M+awrL4PuKFi8kemtjLV8A32zODVQ2/cLuaHl2lZt5EKmMjxGb41BL3ulDRaK1Je712/zFTliYKNDX3IsLAvpQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.15.0.tgz",
+      "integrity": "sha512-3HVWJsDn2/XqOiwmi8TKsYlNxbV003YqPpAsLWSxu0RPezWa9FoDyymRlfW98qhU4uw/5iBaFQUc7RZEe5ygfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "bpmn-js": "^18.14.0",
     "bpmn-js-create-append-anything": "^1.2.0",
     "bpmn-moddle": "^10.0.0",
-    "camunda-bpmn-js-behaviors": "^1.14.1",
+    "camunda-bpmn-js-behaviors": "^1.15.0",
     "camunda-bpmn-moddle": "^7.0.1",
     "chai": "^4.5.0",
     "cross-env": "^10.1.0",

--- a/src/provider/zeebe/properties/ExecutionListener.js
+++ b/src/provider/zeebe/properties/ExecutionListener.js
@@ -1,6 +1,7 @@
 import { SelectEntry } from '@bpmn-io/properties-panel';
 
 import {
+  getBusinessObject,
   is,
   isAny
 } from 'bpmn-js/lib/util/ModelUtil';
@@ -22,6 +23,18 @@ export const EVENT_TO_LABEL = {
   'start': 'Start',
   'end': 'End'
 };
+
+// Specific event label for Multi instance elements: `beforeAll` runs once before MI init; `start` / `end` run per iteration.
+export const MI_EVENT_TO_LABEL = {
+  'beforeAll': 'Before all',
+  'start': 'Before each',
+  'end': 'After each'
+};
+
+export function getEventLabel(element, eventType) {
+  const labels = isMultiInstance(element) ? MI_EVENT_TO_LABEL : EVENT_TO_LABEL;
+  return labels[eventType];
+}
 
 export function ExecutionListenerEntries(props) {
 
@@ -78,7 +91,7 @@ function EventType(props) {
   const getOptions = () => {
     return eventTypes.map(eventType => ({
       value: eventType,
-      label: translate(EVENT_TO_LABEL[eventType])
+      label: translate(getEventLabel(element, eventType))
     }));
   };
 
@@ -115,5 +128,14 @@ export function getEventTypes(element) {
     return [ 'start' ];
   }
 
+  if (isMultiInstance(element)) {
+    return [ 'beforeAll', 'start', 'end' ];
+  }
+
   return [ 'start', 'end' ];
+}
+
+function isMultiInstance(element) {
+  const loopCharacteristics = getBusinessObject(element).get('loopCharacteristics');
+  return !!loopCharacteristics && is(loopCharacteristics, 'bpmn:MultiInstanceLoopCharacteristics');
 }

--- a/src/provider/zeebe/properties/ExecutionListenersProps.js
+++ b/src/provider/zeebe/properties/ExecutionListenersProps.js
@@ -6,7 +6,7 @@ import {
 
 import { without } from 'min-dash';
 
-import { ExecutionListenerEntries, getEventTypes, EVENT_TO_LABEL } from './ExecutionListener';
+import { ExecutionListenerEntries, getEventTypes, getEventLabel } from './ExecutionListener';
 
 import {
   createElement
@@ -49,7 +49,7 @@ export function ExecutionListenersProps({ element, injector }) {
 
     return {
       id,
-      label: translate(`${EVENT_TO_LABEL[listener.get('eventType')]}: {type}`, { type }),
+      label: translate(`${getEventLabel(element, listener.get('eventType'))}: {type}`, { type }),
       entries: ExecutionListenerEntries({
         idPrefix: id,
         element,

--- a/test/spec/provider/zeebe/ExecutionListenerProps.bpmn
+++ b/test/spec/provider/zeebe/ExecutionListenerProps.bpmn
@@ -128,6 +128,19 @@
         </zeebe:executionListeners>
       </bpmn:extensionElements>
     </bpmn:task>
+    <bpmn:serviceTask id="MultiInstanceTask">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="beforeAll" retries="3" type="mi-body-init" />
+          <zeebe:executionListener eventType="start" retries="3" type="mi-entry-start" />
+          <zeebe:executionListener eventType="end" retries="3" type="mi-entry-end" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:multiInstanceLoopCharacteristics />
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="MultiInstanceTask_NoListeners">
+      <bpmn:multiInstanceLoopCharacteristics />
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
@@ -181,6 +194,15 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_SingleHeader_di" bpmnElement="Task_SingleHeader">
         <dc:Bounds x="440" y="750" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="MultiInstanceTask_di" bpmnElement="MultiInstanceTask">
+        <dc:Bounds x="580" y="750" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="MultiInstanceTask_NoListeners_di" bpmnElement="MultiInstanceTask_NoListeners">
+        <dc:Bounds x="720" y="750" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="MultiInstanceSubProcess_di" bpmnElement="MultiInstanceSubProcess" isExpanded="true">
+        <dc:Bounds x="860" y="750" width="200" height="120" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/zeebe/ExecutionListenerProps.spec.js
+++ b/test/spec/provider/zeebe/ExecutionListenerProps.spec.js
@@ -739,8 +739,141 @@ describe('provider/zeebe - ExecutionListenerProps', function() {
         expect(getListenerHeaders(element, 0)).to.have.length(originalHeaders.length);
       })
     );
+  });
+
+
+  describe('multi-instance', function() {
+
+    it('should have "beforeAll" / "start" / "end" as event types on MI element',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('MultiInstanceTask');
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        // when
+        const group = getExecutionListenersGroup(container);
+        const eventType = getEventType(group);
+        const options = domQueryAll('option', eventType);
+
+        // then
+        expect(options).to.have.length(3);
+        expect(options[0]).to.have.property('value', 'beforeAll');
+        expect(options[1]).to.have.property('value', 'start');
+        expect(options[2]).to.have.property('value', 'end');
+      })
+    );
+
+
+    it('should render MI-specific labels in event type dropdown',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('MultiInstanceTask');
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        // when
+        const group = getExecutionListenersGroup(container);
+        const eventType = getEventType(group);
+        const options = domQueryAll('option', eventType);
+
+        // then
+        expect(options[0]).to.have.property('textContent', 'Before all');
+        expect(options[1]).to.have.property('textContent', 'Before each');
+        expect(options[2]).to.have.property('textContent', 'After each');
+      })
+    );
+
+    it('should write eventType="beforeAll" when user selects Before all',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('MultiInstanceTask_NoListeners');
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        const group = getExecutionListenersGroup(container);
+        const addEntry = domQuery('.bio-properties-panel-add-entry', group);
+
+        await act(() => {
+          addEntry.click();
+        });
+
+        const eventType = getEventType(group);
+        const input = domQuery('select', eventType);
+
+        // when
+        changeInput(input, 'beforeAll');
+
+        // then
+        const listeners = getListeners(element);
+        expect(listeners[0]).to.have.property('eventType', 'beforeAll');
+      })
+    );
+
+    it('should write plain start/end event types to XML on MI task ("Before each"/"After each" labels are UI-only)',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('MultiInstanceTask');
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        const group = getExecutionListenersGroup(container);
+        const input = domQuery('select', getEventType(group));
+
+        // when
+        changeInput(input, 'start');
+
+        // then
+        expect(getListeners(element)[0]).to.have.property('eventType', 'start');
+
+        // when
+        changeInput(input, 'end');
+
+        // then
+        expect(getListeners(element)[0]).to.have.property('eventType', 'end');
+      })
+    );
+
+
+    it('should drop `beforeAll` listener when multi-instance is removed',
+      inject(async function(elementRegistry, selection, modeling) {
+
+        // given
+        const element = elementRegistry.get('MultiInstanceTask');
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        // assume
+        expect(getListeners(element)).to.have.lengthOf(3);
+
+        // when
+        await act(() => {
+          modeling.updateProperties(element, { loopCharacteristics: undefined });
+        });
+
+        // then
+        const listeners = getListeners(element);
+        expect(listeners).to.have.lengthOf(2);
+        expect(listeners.map(l => l.get('eventType'))).to.eql([ 'start', 'end' ]);
+      })
+    );
 
   });
+
 
 });
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5869

### Proposed Changes

Add multi-instance specific event types for execution listeners:
 - **Before All**: New type; applied to the XML as `beforeAll`.
 - **Before Each**: Renamed from 'Start'; applied to the XML as `start` (as before).
 - **After Each**: Renamed from 'End'; applied to the XML as `end` (as before).
 
The cleanup of the 'Before All' event when multi-instance is removed is done by this pr - https://github.com/camunda/camunda-bpmn-js-behaviors/pull/126 which is also incorporated here.
 
https://github.com/user-attachments/assets/f113e195-85f8-437c-8da7-dcb5e09bd786



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
