### PR TITLE
feat: support cancel event type for execution listeners on the process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+## 5.56.0
+
+* `FEAT`: support `cancel` event type for execution listeners on the process element
+
 ## 5.55.0
 
 * `FEAT`: add multi-instance specific event types for execution listeners ([#1215](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1215))

--- a/src/provider/zeebe/properties/ExecutionListener.js
+++ b/src/provider/zeebe/properties/ExecutionListener.js
@@ -21,7 +21,8 @@ import ExecutionListenerHeaders from './ExecutionListenerHeaderProps';
 
 export const EVENT_TO_LABEL = {
   'start': 'Start',
-  'end': 'End'
+  'end': 'End',
+  'cancel': 'Cancel'
 };
 
 // Specific event label for Multi instance elements: `beforeAll` runs once before MI init; `start` / `end` run per iteration.
@@ -130,6 +131,10 @@ export function getEventTypes(element) {
 
   if (isMultiInstance(element)) {
     return [ 'beforeAll', 'start', 'end' ];
+  }
+
+  if (isAny(element, [ 'bpmn:Process', 'bpmn:Participant' ])) {
+    return [ 'start', 'end', 'cancel' ];
   }
 
   return [ 'start', 'end' ];

--- a/test/spec/provider/zeebe/ExecutionListenerProps.spec.js
+++ b/test/spec/provider/zeebe/ExecutionListenerProps.spec.js
@@ -321,6 +321,46 @@ describe('provider/zeebe - ExecutionListenerProps', function() {
     }
 
 
+    it('should offer cancel for Process', inject(async function(elementRegistry, selection) {
+
+      // given
+      const element = elementRegistry.get('Process');
+
+      await act(() => {
+        selection.select(element);
+      });
+
+      // when
+      const group = getExecutionListenersGroup(container);
+      const eventType = getEventType(group);
+      const options = domQuery('select', eventType).querySelectorAll('option');
+
+      // then
+      expect(Array.from(options).map(o => o.value)).to.eql([ 'start', 'end', 'cancel' ]);
+    }));
+
+
+    it('should NOT offer cancel for non-process elements', inject(
+      async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('Task');
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        // when
+        const group = getExecutionListenersGroup(container);
+        const eventType = getEventType(group);
+        const options = domQuery('select', eventType).querySelectorAll('option');
+
+        // then
+        expect(Array.from(options).map(o => o.value)).to.eql([ 'start', 'end' ]);
+      }
+    ));
+
+
     it('should use a supported event type for a new listener', inject(
       async function(elementRegistry, selection) {
 


### PR DESCRIPTION
Adds the `cancel` event type to the property panel for `bpmn:Process` and `bpmn:Participant` elements. Other elements continue to expose `start` and `end` only.

Related to camunda/camunda-modeler#5929

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
