### PR TITLE
feat: add `core` and `header` modules 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@babel/core": "^7.29.0",
         "@babel/plugin-transform-react-jsx": "^7.28.6",
         "@bpmn-io/element-template-chooser": "^2.1.0",
-        "@bpmn-io/properties-panel": "^3.40.6",
+        "@bpmn-io/properties-panel": "^3.42.0",
         "@bpmn-io/variable-resolver": "^3.0.0",
         "@rollup/plugin-alias": "^6.0.0",
         "@rollup/plugin-babel": "^7.0.0",
@@ -605,14 +605,20 @@
       }
     },
     "node_modules/@bpmn-io/properties-panel": {
-      "version": "3.40.6",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.40.6.tgz",
-      "integrity": "sha512-lviXOp3z99BmdOoTazW13M6s4CyuCveygHL4g8v1z6Tp6rar4irBS//DggNLWha26Ae6vUfvHPnwcNjuHsNDjg==",
+      "version": "3.42.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.42.0.tgz",
+      "integrity": "sha512-ovvOHHR3dcWJi4BX2Fg2vNpAAkU/exo3lGtRC7caNcmrqlVEr74MN0lfo9U8F+dxI7aZsbHfFxBSRlcUAEIVvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/feel-editor": "^2.5.2",
         "@carbon/icons": "^11.69.0",
+        "@codemirror/autocomplete": "^6.18.6",
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/lang-json": "^6.0.2",
+        "@codemirror/language": "^6.11.0",
+        "@codemirror/lint": "^6.9.5",
+        "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.28.1",
         "classnames": "^2.5.1",
         "feelers": "^1.5.1",
@@ -674,16 +680,27 @@
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.2.tgz",
-      "integrity": "sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.4.0",
+        "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.27.0",
         "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
       }
     },
     "node_modules/@codemirror/language": {
@@ -702,21 +719,21 @@
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.4.tgz",
-      "integrity": "sha512-ABc9vJ8DEmvOWuH26P3i8FpMWPQkduD9Rvba5iwb6O3hxASgclm3T3krGo8NASXkHCidz6b++LWlzWIUfEPSWw==",
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.6.tgz",
+      "integrity": "sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.35.0",
+        "@codemirror/view": "^6.42.0",
         "crelt": "^1.0.5"
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
-      "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -724,13 +741,13 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.39.13",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.13.tgz",
-      "integrity": "sha512-QBO8ZsgJLCbI28KdY0/oDy5NQLqOQVZCozBknxc2/7L98V+TVYFHnfaCsnGh1U+alpd2LOkStVwYY7nW2R1xbw==",
+      "version": "6.42.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.42.1.tgz",
+      "integrity": "sha512-ToN3oFc0nsxNUYVF5P0ztLgbC4UPPjPtA9aKYhkOKQaZASpOUo6ISXyQLP66ctVwlDc+j6Jv0uK5IFALkiXztg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@codemirror/state": "^6.5.0",
+        "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
@@ -1198,6 +1215,18 @@
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@lezer/lr": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "start:cloud": "cross-env SINGLE_START=cloud npm run dev",
     "start:platform": "cross-env SINGLE_START=platform npm run dev",
     "start:bpmn": "cross-env SINGLE_START=bpmn npm run dev",
+    "start:core": "cross-env SINGLE_START=core npm run dev",
+    "start:header": "cross-env SINGLE_START=header npm run dev",
     "prepare": "run-s build"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@babel/core": "^7.29.0",
     "@babel/plugin-transform-react-jsx": "^7.28.6",
     "@bpmn-io/element-template-chooser": "^2.1.0",
-    "@bpmn-io/properties-panel": "^3.40.6",
+    "@bpmn-io/properties-panel": "^3.42.0",
     "@bpmn-io/variable-resolver": "^3.0.0",
     "@rollup/plugin-alias": "^6.0.0",
     "@rollup/plugin-babel": "^7.0.0",

--- a/src/contextProvider/camunda-platform/TooltipProvider.js
+++ b/src/contextProvider/camunda-platform/TooltipProvider.js
@@ -1,5 +1,3 @@
-/* eslint-disable react-hooks/rules-of-hooks */
-
 import {
   useService
 } from '../../hooks';

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,11 @@
 export { default as BpmnPropertiesPanelModule } from './render';
+export { default as BpmnPropertiesPanelCoreModule } from './render/core';
+export { default as BpmnPropertiesPanelHeaderModule } from './render/header';
+
 export { default as BpmnPropertiesProviderModule } from './provider/bpmn';
 export { default as ZeebePropertiesProviderModule } from './provider/zeebe';
 export { default as CamundaPlatformPropertiesProviderModule } from './provider/camunda-platform';
+
 export { TooltipProvider as ZeebeTooltipProvider } from './contextProvider/zeebe';
 export { TooltipProvider as CamundaPlatformTooltipProvider } from './contextProvider/camunda-platform';
 

--- a/src/render/BpmnPropertiesPanel.js
+++ b/src/render/BpmnPropertiesPanel.js
@@ -17,7 +17,6 @@ import {
   BpmnPropertiesPanelContext
 } from '../context';
 
-import { PanelHeaderProvider } from './PanelHeaderProvider';
 import { PanelPlaceholderProvider } from './PanelPlaceholderProvider';
 
 { /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
@@ -46,7 +45,8 @@ export default function BpmnPropertiesPanel(props) {
     descriptionConfig,
     tooltipConfig,
     feelPopupContainer,
-    getFeelPopupLinks
+    getFeelPopupLinks,
+    headerProvider
   } = props;
 
   const canvas = injector.get('canvas');
@@ -239,7 +239,7 @@ export default function BpmnPropertiesPanel(props) {
       <FeelLanguageContext.Provider value={ DEFAULT_FEEL_LANGUAGE_CONTEXT }>
         <PropertiesPanel
           element={ selectedElement }
-          headerProvider={ PanelHeaderProvider(translate) }
+          headerProvider={ headerProvider }
           placeholderProvider={ PanelPlaceholderProvider(translate) }
           groups={ groups }
           layoutConfig={ layoutConfig }

--- a/src/render/BpmnPropertiesPanelHeader.js
+++ b/src/render/BpmnPropertiesPanelHeader.js
@@ -1,0 +1,35 @@
+import {
+  useMemo
+} from '@bpmn-io/properties-panel/preact/hooks';
+
+import { Header } from '@bpmn-io/properties-panel';
+
+import {
+  BpmnPropertiesPanelContext
+} from '../context';
+
+import { PanelHeaderProvider } from './PanelHeaderProvider';
+
+{ /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
+
+export default function BpmnPropertiesPanelHeader({ injector, element }) {
+  const translate = injector.get('translate');
+
+  const headerProvider = useMemo(() => PanelHeaderProvider(translate), [ translate ]);
+
+  const context = useMemo(() => ({
+    selectedElement: element,
+    injector,
+    getService: (type, strict) => injector.get(type, strict)
+  }), [ injector, element ]);
+
+  if (!element || Array.isArray(element)) {
+    return null;
+  }
+
+  return (
+    <BpmnPropertiesPanelContext.Provider value={ context }>
+      <Header element={ element } headerProvider={ headerProvider } />
+    </BpmnPropertiesPanelContext.Provider>
+  );
+}

--- a/src/render/BpmnPropertiesPanelHeaderRenderer.js
+++ b/src/render/BpmnPropertiesPanelHeaderRenderer.js
@@ -1,0 +1,139 @@
+import { h, render } from '@bpmn-io/properties-panel/preact';
+
+import {
+  domify,
+  query as domQuery
+} from 'min-dom';
+
+import BpmnPropertiesPanelHeader from './BpmnPropertiesPanelHeader';
+
+{ /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
+
+export default class BpmnPropertiesPanelHeaderRenderer {
+
+  constructor(config, injector, eventBus) {
+    const { parent } = config || {};
+
+    this._eventBus = eventBus;
+    this._injector = injector;
+    this._element = null;
+
+    this._container = domify(
+      '<div class="bio-properties-panel"></div>'
+    );
+
+    eventBus.on('diagram.init', () => {
+      if (parent) {
+        this.attachTo(parent);
+      }
+    });
+
+    eventBus.on('root.added', (event) => {
+      if (event.element && event.element.isImplicit) {
+        return;
+      }
+
+      this._renderElement(event.element);
+    });
+
+    eventBus.on('selection.changed', (e) => {
+      const { newSelection = [] } = e;
+      const canvas = injector.get('canvas', false);
+      if (!canvas) {
+        return;
+      }
+
+      const rootElement = canvas.getRootElement();
+      if (rootElement && rootElement.isImplicit) {
+        return;
+      }
+
+      const element = newSelection.length > 1
+        ? newSelection
+        : newSelection[0] || rootElement;
+
+      this._renderElement(element);
+    });
+
+    eventBus.on('elements.changed', (e) => {
+      if (!this._element) {
+        return;
+      }
+
+      const current = Array.isArray(this._element) ? this._element : [ this._element ];
+      if (e.elements.some(el => current.includes(el))) {
+        this._renderElement(this._element);
+      }
+    });
+
+    eventBus.on('import.done', () => {
+      const canvas = injector.get('canvas', false);
+      if (!canvas) {
+        return;
+      }
+
+      const rootElement = canvas.getRootElement();
+      if (rootElement && !rootElement.isImplicit) {
+        this._renderElement(rootElement);
+      }
+    });
+
+    eventBus.on('diagram.destroy', () => {
+      this.detach();
+      render(null, this._container);
+    });
+  }
+
+  /**
+   * Attach the header to a parent node.
+   *
+   * @param {HTMLElement|string} container
+   */
+  attachTo(container) {
+    if (!container) {
+      throw new Error('container required');
+    }
+
+    if (container.get && container.constructor.prototype.jquery) {
+      container = container.get(0);
+    }
+
+    if (typeof container === 'string') {
+      container = domQuery(container);
+    }
+
+    this.detach();
+
+    container.appendChild(this._container);
+
+    this._eventBus.fire('propertiesPanelHeader.attach');
+  }
+
+  /**
+   * Detach the header from its parent node.
+   */
+  detach() {
+    const parentNode = this._container.parentNode;
+
+    if (parentNode) {
+      parentNode.removeChild(this._container);
+
+      this._eventBus.fire('propertiesPanelHeader.detach');
+    }
+  }
+
+  _renderElement(element) {
+    this._element = element;
+
+    render(
+      h(BpmnPropertiesPanelHeader, { injector: this._injector, element }),
+      this._container
+    );
+  }
+}
+
+BpmnPropertiesPanelHeaderRenderer.$inject = [
+  'config.propertiesPanelHeader',
+  'injector',
+  'eventBus'
+];

--- a/src/render/BpmnPropertiesPanelHeaderRenderer.js
+++ b/src/render/BpmnPropertiesPanelHeaderRenderer.js
@@ -19,8 +19,14 @@ export default class BpmnPropertiesPanelHeaderRenderer {
     this._element = null;
 
     this._container = domify(
+      '<div class="bio-properties-panel-container"></div>'
+    );
+
+    this._innerContainer = domify(
       '<div class="bio-properties-panel"></div>'
     );
+
+    this._container.appendChild(this._innerContainer);
 
     eventBus.on('diagram.init', () => {
       if (parent) {
@@ -80,7 +86,7 @@ export default class BpmnPropertiesPanelHeaderRenderer {
 
     eventBus.on('diagram.destroy', () => {
       this.detach();
-      render(null, this._container);
+      render(null, this._innerContainer);
     });
   }
 
@@ -127,7 +133,7 @@ export default class BpmnPropertiesPanelHeaderRenderer {
 
     render(
       h(BpmnPropertiesPanelHeader, { injector: this._injector, element }),
-      this._container
+      this._innerContainer
     );
   }
 }

--- a/src/render/BpmnPropertiesPanelRenderer.js
+++ b/src/render/BpmnPropertiesPanelRenderer.js
@@ -160,6 +160,10 @@ export default class BpmnPropertiesPanelRenderer {
     return event.providers;
   }
 
+  _getHeaderProvider() {
+    return this._injector.get('propertiesPanelHeaderProvider', false) || null;
+  }
+
   _render(element) {
     const canvas = this._injector.get('canvas');
 
@@ -181,6 +185,7 @@ export default class BpmnPropertiesPanelRenderer {
         tooltipConfig={ this._tooltipConfig }
         feelPopupContainer={ this._feelPopupContainer }
         getFeelPopupLinks={ this._getFeelPopupLinks }
+        headerProvider={ this._getHeaderProvider() }
       />,
       this._container
     );

--- a/src/render/PanelHeaderProvider.js
+++ b/src/render/PanelHeaderProvider.js
@@ -90,7 +90,6 @@ export const PanelHeaderProvider = (translate) => {
     getElementIcon: (element) => {
       const concreteType = getConcreteType(element);
 
-      // eslint-disable-next-line react-hooks/rules-of-hooks
       const config = useService('config.elementTemplateIconRenderer', false);
 
       const { iconProperty = 'zeebe:modelerTemplateIcon' } = config || {};
@@ -183,8 +182,6 @@ function isPlane(element) {
 }
 
 function getTemplatesService() {
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   return useService('elementTemplates', false);
 }
 

--- a/src/render/core.js
+++ b/src/render/core.js
@@ -3,10 +3,6 @@ import BpmnPropertiesPanelRenderer from './BpmnPropertiesPanelRenderer';
 import Commands from '../cmd';
 import { DebounceInputModule, FeelPopupModule } from '@bpmn-io/properties-panel';
 
-import { PanelHeaderProvider } from './PanelHeaderProvider';
-
-PanelHeaderProvider.$inject = [ 'translate' ];
-
 export default {
   __depends__: [
     Commands,
@@ -17,5 +13,5 @@ export default {
     'propertiesPanel'
   ],
   propertiesPanel: [ 'type', BpmnPropertiesPanelRenderer ],
-  propertiesPanelHeaderProvider: [ 'factory', PanelHeaderProvider ]
+  propertiesPanelHeaderProvider: [ 'value', null ]
 };

--- a/src/render/header.js
+++ b/src/render/header.js
@@ -1,0 +1,8 @@
+import BpmnPropertiesPanelHeaderRenderer from './BpmnPropertiesPanelHeaderRenderer';
+
+export default {
+  __init__: [
+    'propertiesPanelHeader'
+  ],
+  propertiesPanelHeader: [ 'type', BpmnPropertiesPanelHeaderRenderer ]
+};

--- a/test/distro/distroSpec.js
+++ b/test/distro/distroSpec.js
@@ -13,6 +13,30 @@ describe('modules', function() {
 
 });
 
+describe('named exports', function() {
+
+  let esmBundle;
+
+  before(function() {
+    esmBundle = fs.readFileSync(path.join(DIST_DIR, 'index.esm.js'), 'utf-8');
+  });
+
+  it('should export BpmnPropertiesPanelModule', function() {
+    expect(esmBundle).to.include('BpmnPropertiesPanelModule');
+  });
+
+
+  it('should export BpmnPropertiesPanelCoreModule', function() {
+    expect(esmBundle).to.include('BpmnPropertiesPanelCoreModule');
+  });
+
+
+  it('should export BpmnPropertiesPanelHeaderModule', function() {
+    expect(esmBundle).to.include('BpmnPropertiesPanelHeaderModule');
+  });
+
+});
+
 function verifyExists(relativePath) {
   return function() {
 

--- a/test/spec/BpmnPropertiesPanelHeader.spec.js
+++ b/test/spec/BpmnPropertiesPanelHeader.spec.js
@@ -1,0 +1,111 @@
+import { expect } from 'chai';
+
+import {
+  cleanup,
+  render
+} from '@testing-library/preact/pure';
+
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import { BpmnModdle } from 'bpmn-moddle';
+
+import {
+  insertCoreStyles
+} from 'test/TestHelper';
+
+import BpmnPropertiesPanelHeader from 'src/render/BpmnPropertiesPanelHeader';
+
+insertCoreStyles();
+
+const moddle = new BpmnModdle();
+
+
+describe('<BpmnPropertiesPanelHeader>', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  afterEach(function() { return cleanup(); });
+
+
+  it('should render nothing without an element', function() {
+
+    // given
+    const injector = createInjector();
+
+    // when
+    render(<BpmnPropertiesPanelHeader injector={ injector } element={ null } />, { container });
+
+    // then
+    expect(domQuery('.bio-properties-panel-header', container)).to.not.exist;
+  });
+
+
+  it('should render element', function() {
+
+    // given
+    const element = createElement('bpmn:Task', { name: 'Task' });
+    const injector = createInjector();
+
+    // when
+    render(<BpmnPropertiesPanelHeader injector={ injector } element={ element } />, { container });
+
+    // then
+    expect(domQuery('.bio-properties-panel-header', container)).to.exist;
+  });
+
+
+  it('should render nothing for multi-select', function() {
+
+    // given
+    const elements = [
+      createElement('bpmn:Task', {}),
+      createElement('bpmn:Task', {})
+    ];
+    const injector = createInjector();
+
+    // when
+    render(<BpmnPropertiesPanelHeader injector={ injector } element={ elements } />, { container });
+
+    // then
+    expect(domQuery('.bio-properties-panel-header', container)).to.not.exist;
+  });
+
+});
+
+
+// helpers //////////////////////////
+
+function createElement(type, attrs) {
+  const businessObject = moddle.create(type, attrs);
+
+  return {
+    type,
+    businessObject
+  };
+}
+
+function createInjector() {
+  const services = {
+    translate: (text) => text
+  };
+
+  return {
+    get(type, strict) {
+      const service = services[type];
+
+      if (!service && strict !== false) {
+        throw new Error(`service ${type} not found`);
+      }
+
+      return service || null;
+    }
+  };
+}

--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -33,6 +33,8 @@ import {
 import Modeler from 'bpmn-js/lib/Modeler';
 
 import BpmnPropertiesPanel from 'src/render';
+import BpmnPropertiesPanelCoreModule from 'src/render/core';
+import BpmnPropertiesPanelHeaderModule from 'src/render/header';
 
 import BpmnPropertiesProvider from 'src/provider/bpmn';
 import CamundaPropertiesProvider from 'src/provider/camunda-platform';
@@ -215,6 +217,61 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
           BpmnPropertiesProvider,
           CreateAppendAnythingModule
         ]
+      }
+    );
+
+    // then
+    expect(result.error).not.to.exist;
+  });
+
+
+  (singleStart === 'core' ? it.only : it)('should import simple process (core - body only, no header)', async function() {
+
+    // given
+    const diagramXml = require('test/fixtures/simple.bpmn').default;
+
+    // when
+    const result = await createModeler(
+      diagramXml,
+      {
+        additionalModules: [
+          ZeebeBehaviorsModule,
+          BpmnPropertiesPanelCoreModule,
+          BpmnPropertiesProvider,
+          ZeebePropertiesProvider,
+          CreateAppendAnythingModule,
+          ZeebeVariableResolverModule
+        ],
+        moddleExtensions: {
+          zeebe: ZeebeModdle
+        }
+      }
+    );
+
+    // then
+    expect(result.error).not.to.exist;
+  });
+
+
+  (singleStart === 'header' ? it.only : it)('should import simple process (standalone header)', async function() {
+
+    // given
+    const diagramXml = require('test/fixtures/simple.bpmn').default;
+
+    // when
+    const result = await createModeler(
+      diagramXml,
+      {
+        additionalModules: [
+          ZeebeBehaviorsModule,
+          BpmnPropertiesPanelHeaderModule
+        ],
+        moddleExtensions: {
+          zeebe: ZeebeModdle
+        },
+        propertiesPanelHeader: {
+          parent: propertiesContainer
+        }
       }
     );
 


### PR DESCRIPTION
Related to https://github.com/bpmn-io/internal-docs/issues/1294

### Proposed Changes

Allow consumers to mount the panel header and body at separate DOM locations.

Two new module exports alongside the unchanged default:

  - `BpmnPropertiesPanelCoreModule` — panel body only, no inline header
  - `BpmnPropertiesPanelHeaderModule` — standalone header with its own configurable parent container

### Implementation notes

#### Keep existing HTML structure

Currently, the default panel is rendered into:

```
#propertiesContainer                       
  └── div.bio-properties-panel-container  
      └── div.bio-properties-panel      
          ├── div.bio-properties-panel-header
          └── div.bio-properties-panel-scroll-container
```

When `core` and `header` modules are both used, we wrap them the same way, to **keep the existing CSS overrides working**.

```
  #propertiesHeaderContainer
  └── div.bio-properties-panel-container
      └── div.bio-properties-panel 
          └── div.bio-properties-panel-header 

  #propertiesContainer 
  └── div.bio-properties-panel-container
      └── div.bio-properties-panel       
          └── div.bio-properties-panel-scroll-container
```

### Steps to try out:

```
# Default (unchanged behavior)
npm run start

# Body only, no header
npm run start:core

# Standalone header only, no body
npm run start:header
```

<img width="778" height="710" alt="image" src="https://github.com/user-attachments/assets/5de983d6-ba1a-4846-8817-baf2297a3bfb" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
