### PR TITLE
feat: add support of start event forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: add support for start event forms ([#1219](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1219))
+
 ## 5.56.0
 
 * `FEAT`: support `cancel` event type for execution listeners on the process element

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: add support for start event forms ([#1219](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1219))
+* `DEPS`: update to `camunda-bpmn-js-behaviors@1.16.1`
+* `DEPS`: update to `zeebe-bpmn-moddle@1.14.0`
 
 ## 5.56.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "bpmn-js": "^18.14.0",
         "bpmn-js-create-append-anything": "^1.2.0",
         "bpmn-moddle": "^10.0.0",
-        "camunda-bpmn-js-behaviors": "^1.16.0",
+        "camunda-bpmn-js-behaviors": "^1.16.1",
         "camunda-bpmn-moddle": "^7.0.1",
         "chai": "^6.0.0",
         "cross-env": "^10.1.0",
@@ -3233,9 +3233,9 @@
       }
     },
     "node_modules/camunda-bpmn-js-behaviors": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.16.0.tgz",
-      "integrity": "sha512-GARp6QISrX63YiwX+G6JwU6hJmioLDhfbotbOVesL8MTXBbrCrWMTI0AKaU0ZLD8Yv/TwqNBKoy5QdBtzCpIuQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.16.1.tgz",
+      "integrity": "sha512-0RL1Wei37Rl4wTQqrxtsSipBRubbthx2wIsJRKVEtxXEYIQoTfZREVcQrG3LJywMpjElVIBgG1qQjrqEMfYC9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "bpmn-js": "^18.14.0",
         "bpmn-js-create-append-anything": "^1.2.0",
         "bpmn-moddle": "^10.0.0",
-        "camunda-bpmn-js-behaviors": "^1.15.0",
+        "camunda-bpmn-js-behaviors": "^1.16.0",
         "camunda-bpmn-moddle": "^7.0.1",
         "chai": "^6.0.0",
         "cross-env": "^10.1.0",
@@ -63,7 +63,7 @@
         "sinon": "^22.0.0",
         "sinon-chai": "^4.0.0",
         "webpack": "^5.106.2",
-        "zeebe-bpmn-moddle": "^1.13.0"
+        "zeebe-bpmn-moddle": "^1.14.0"
       },
       "engines": {
         "node": "*"
@@ -3233,9 +3233,9 @@
       }
     },
     "node_modules/camunda-bpmn-js-behaviors": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.15.0.tgz",
-      "integrity": "sha512-3HVWJsDn2/XqOiwmi8TKsYlNxbV003YqPpAsLWSxu0RPezWa9FoDyymRlfW98qhU4uw/5iBaFQUc7RZEe5ygfw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.16.0.tgz",
+      "integrity": "sha512-GARp6QISrX63YiwX+G6JwU6hJmioLDhfbotbOVesL8MTXBbrCrWMTI0AKaU0ZLD8Yv/TwqNBKoy5QdBtzCpIuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10518,9 +10518,9 @@
       }
     },
     "node_modules/zeebe-bpmn-moddle": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.13.0.tgz",
-      "integrity": "sha512-F5IGMleZo48OG3Q20TTBdQmIcnVZSzBjizUq3WyNm0WwNzaKyeTXu3LBheOFuVtm//inEBArv/t7FGQD16yXdg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.14.0.tgz",
+      "integrity": "sha512-jhEr/UOaWcT4peXxkUqXd7tscjYf2evbm/ElofmZ8TFPqs8MhxTVolFQBtKza6n9cwIVDyc6L7ChQHSzicG7QA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "bpmn-js": "^18.14.0",
     "bpmn-js-create-append-anything": "^1.2.0",
     "bpmn-moddle": "^10.0.0",
-    "camunda-bpmn-js-behaviors": "^1.16.0",
+    "camunda-bpmn-js-behaviors": "^1.16.1",
     "camunda-bpmn-moddle": "^7.0.1",
     "chai": "^6.0.0",
     "cross-env": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "bpmn-js": "^18.14.0",
     "bpmn-js-create-append-anything": "^1.2.0",
     "bpmn-moddle": "^10.0.0",
-    "camunda-bpmn-js-behaviors": "^1.15.0",
+    "camunda-bpmn-js-behaviors": "^1.16.0",
     "camunda-bpmn-moddle": "^7.0.1",
     "chai": "^6.0.0",
     "cross-env": "^10.1.0",
@@ -104,7 +104,7 @@
     "sinon": "^22.0.0",
     "sinon-chai": "^4.0.0",
     "webpack": "^5.106.2",
-    "zeebe-bpmn-moddle": "^1.13.0"
+    "zeebe-bpmn-moddle": "^1.14.0"
   },
   "peerDependencies": {
     "@bpmn-io/properties-panel": ">= 3.40.6",

--- a/src/contextProvider/zeebe/TooltipProvider.js
+++ b/src/contextProvider/zeebe/TooltipProvider.js
@@ -83,6 +83,17 @@ const TooltipProvider = {
   'group-form': (element) => {
     const translate = useService('translate');
 
+    if (is(element, 'bpmn:StartEvent')) {
+      return (
+        <div>
+          { translate('Link a form created with the Camunda Forms editor. Submitting this form will start a new process instance. ')}
+          <a href="https://docs.camunda.io/docs/components/modeler/forms/utilizing-forms/#connect-your-form-to-a-bpmn-diagram" target="_blank" rel="noopener noreferrer" title={ translate('Start event form documentation') }>
+            { translate('Learn more.') }
+          </a>
+        </div>
+      );
+    }
+
     if (isZeebeUserTask(element)) {
       return (
         <div>

--- a/src/provider/zeebe/properties/FormProps.js
+++ b/src/provider/zeebe/properties/FormProps.js
@@ -34,6 +34,7 @@ import {
   getFormType,
   getRootElement,
   getUserTaskForm,
+  isFormSupported,
   isZeebeUserTask,
   userTaskFormIdToFormKey
 } from '../utils/FormUtil';
@@ -51,17 +52,18 @@ const NONE_VALUE = 'none';
 export function FormProps(props) {
   const { element } = props;
 
-  if (!is(element, 'bpmn:UserTask')) {
+  if (!isFormSupported(element)) {
     return [];
   }
+
+  const isStartEvent = is(element, 'bpmn:StartEvent');
+  const formType = getFormType(element);
 
   const entries = [ {
     id: 'formType',
     component: FormType,
     isEdited: node => node.value !== NONE_VALUE
   } ];
-
-  const formType = getFormType(element);
 
   if (formType === FORM_TYPES.CAMUNDA_FORM_EMBEDDED) {
     entries.push({
@@ -89,7 +91,8 @@ export function FormProps(props) {
     });
   }
 
-  if (formType === FORM_TYPES.CAMUNDA_FORM_LINKED) {
+  // Binding and version tag are not supported for start events
+  if (!isStartEvent && formType === FORM_TYPES.CAMUNDA_FORM_LINKED) {
     entries.push({
       id: 'bindingType',
       component: FormDefinitionBinding,
@@ -157,6 +160,14 @@ function getFormTypeOptions(translate, element) {
       { value: NONE_VALUE, label: translate('<none>') },
       { value: FORM_TYPES.CAMUNDA_FORM_LINKED, label: translate('Camunda Form') },
       { value: FORM_TYPES.EXTERNAL_REFERENCE, label: translate('External form reference') }
+    ];
+  }
+
+  if (is(element, 'bpmn:StartEvent')) {
+    return [
+      { value: NONE_VALUE, label: translate('<none>') },
+      { value: FORM_TYPES.CAMUNDA_FORM_LINKED, label: translate('Camunda Form (linked)') },
+      { value: FORM_TYPES.CAMUNDA_FORM_EMBEDDED, label: translate('Camunda Form (embedded)') }
     ];
   }
 

--- a/src/provider/zeebe/utils/FormUtil.js
+++ b/src/provider/zeebe/utils/FormUtil.js
@@ -21,6 +21,31 @@ export const FORM_TYPES = {
 
 export const DEFAULT_FORM_TYPE = FORM_TYPES.CAMUNDA_FORM_LINKED;
 
+export function isFormSupported(element) {
+  if (is(element, 'bpmn:UserTask')) {
+    return true;
+  }
+
+  if (is(element, 'bpmn:StartEvent')) {
+    const bo = getBusinessObject(element);
+
+    // Only "none" start events (no event definitions)
+    if (bo.eventDefinitions && bo.eventDefinitions.length > 0) {
+      return false;
+    }
+
+    // Only top-level (parent is Process, not SubProcess)
+    const parent = bo.$parent;
+    if (!is(parent, 'bpmn:Process')) {
+      return false;
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
 export function getFormDefinition(element) {
   const businessObject = getBusinessObject(element);
 

--- a/test/spec/provider/zeebe/StartEventForms.bpmn
+++ b/test/spec/provider/zeebe/StartEventForms.bpmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:userTaskForm id="UserTaskForm_1">{}</zeebe:userTaskForm>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="START_EVENT_NO_FORM" name="No form" />
+    <bpmn:startEvent id="START_EVENT_LINKED" name="Linked form">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="myFormId" />
+      </bpmn:extensionElements>
+    </bpmn:startEvent>
+    <bpmn:startEvent id="START_EVENT_EMBEDDED" name="Embedded form">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="camunda-forms:bpmn:UserTaskForm_1" />
+      </bpmn:extensionElements>
+    </bpmn:startEvent>
+    <bpmn:startEvent id="START_EVENT_MESSAGE" name="Message start">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1" />
+    </bpmn:startEvent>
+    <bpmn:startEvent id="START_EVENT_TIMER" name="Timer start">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1" />
+    </bpmn:startEvent>
+    <bpmn:subProcess id="SubProcess_1">
+      <bpmn:startEvent id="START_EVENT_IN_SUBPROCESS" name="Sub start" />
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="START_EVENT_NO_FORM_di" bpmnElement="START_EVENT_NO_FORM">
+        <dc:Bounds x="160" y="80" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="START_EVENT_LINKED_di" bpmnElement="START_EVENT_LINKED">
+        <dc:Bounds x="220" y="80" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="START_EVENT_EMBEDDED_di" bpmnElement="START_EVENT_EMBEDDED">
+        <dc:Bounds x="280" y="80" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="START_EVENT_MESSAGE_di" bpmnElement="START_EVENT_MESSAGE">
+        <dc:Bounds x="340" y="80" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="START_EVENT_TIMER_di" bpmnElement="START_EVENT_TIMER">
+        <dc:Bounds x="400" y="80" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_1_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="160" y="200" width="200" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="START_EVENT_IN_SUBPROCESS_di" bpmnElement="START_EVENT_IN_SUBPROCESS">
+        <dc:Bounds x="200" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/zeebe/StartEventForms.spec.js
+++ b/test/spec/provider/zeebe/StartEventForms.spec.js
@@ -1,0 +1,352 @@
+import { expect } from 'chai';
+import TestContainer from 'mocha-test-container-support';
+
+import * as sinon from 'sinon';
+
+import {
+  act
+} from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  changeInput,
+  inject,
+  mouseEnter,
+  TOOLTIP_OPEN_DELAY
+} from 'test/TestHelper';
+
+import {
+  query as domQuery,
+} from 'min-dom';
+
+import {
+  getExtensionElementsList
+} from 'src/utils/ExtensionElementsUtil.js';
+
+import {
+  FORM_TYPES,
+  getFormDefinition,
+  getRootElement,
+  getUserTaskForm
+} from 'src/provider/zeebe/utils/FormUtil.js';
+
+import BpmnPropertiesPanel from 'src/render';
+import CoreModule from 'bpmn-js/lib/core';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ZeebePropertiesProvider from 'src/provider/zeebe';
+
+import BehaviorsModule from 'camunda-bpmn-js-behaviors/lib/camunda-cloud';
+
+import TooltipProvider from 'src/contextProvider/zeebe/TooltipProvider';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import diagramXML from './StartEventForms.bpmn';
+
+
+describe('provider/zeebe - StartEventForms', function() {
+
+  const testModules = [
+    BpmnPropertiesPanel,
+    CoreModule,
+    ModelingModule,
+    SelectionModule,
+    ZeebePropertiesProvider,
+    BehaviorsModule
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container, clock;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(function() {
+    clock.restore();
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    modules: testModules,
+    moddleExtensions,
+    propertiesPanel: {
+      tooltip: TooltipProvider
+    },
+    debounceInput: false
+  }));
+
+
+  describe('form group visibility', function() {
+
+    it('should show for none start event at process level', inject(
+      async function(elementRegistry, selection) {
+
+        // when
+        await act(() => selection.select(elementRegistry.get('START_EVENT_NO_FORM')));
+
+        // then
+        expect(getFormTypeSelect(container)).to.exist;
+      }
+    ));
+
+
+    [
+      [ 'message start event', 'START_EVENT_MESSAGE' ],
+      [ 'timer start event', 'START_EVENT_TIMER' ],
+      [ 'start event in subprocess', 'START_EVENT_IN_SUBPROCESS' ]
+    ].forEach(([ title, id ]) => {
+
+      it(`should NOT show for ${ title }`, inject(
+        async function(elementRegistry, selection) {
+
+          // when
+          await act(() => selection.select(elementRegistry.get(id)));
+
+          // then
+          expect(getFormTypeSelect(container)).to.not.exist;
+        }
+      ));
+
+    });
+
+  });
+
+  describe('form type options', function() {
+
+    it('should offer <none>, linked and embedded', inject(
+      async function(elementRegistry, selection) {
+
+        // when
+        await act(() => selection.select(elementRegistry.get('START_EVENT_NO_FORM')));
+
+        // then
+        const values = Array.from(getFormTypeSelect(container).options).map(o => o.value);
+
+        expect(values).to.have.lengthOf(3);
+        expect(values).to.eql([ 'none', FORM_TYPES.CAMUNDA_FORM_LINKED, FORM_TYPES.CAMUNDA_FORM_EMBEDDED ]);
+      }
+    ));
+
+  });
+
+
+  describe('select linked form', function() {
+
+    it('should show form id input and set formId in XML', inject(
+      async function(elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_NO_FORM');
+        await act(() => selection.select(startEvent));
+
+        // when
+        changeInput(getFormTypeSelect(container), FORM_TYPES.CAMUNDA_FORM_LINKED);
+
+        // then
+        const formIdInput = getFormIdInput(container);
+        expect(formIdInput).to.exist;
+
+        const formDefinition = getFormDefinition(startEvent);
+        expect(formDefinition).to.exist;
+        expect(formDefinition.get('formId')).to.equal('');
+      }
+    ));
+
+
+    it('should update form id', inject(
+      async function(elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_LINKED');
+        await act(() => selection.select(startEvent));
+
+        // when
+        changeInput(getFormIdInput(container), 'newFormId');
+
+        // then
+        expect(getFormDefinition(startEvent).get('formId')).to.equal('newFormId');
+      }
+    ));
+
+
+    it('should NOT show binding type or version tag', inject(
+      async function(elementRegistry, selection) {
+
+        // when
+        await act(() => selection.select(elementRegistry.get('START_EVENT_LINKED')));
+
+        // then
+        expect(getBindingTypeSelect(container)).to.not.exist;
+        expect(getVersionTagInput(container)).to.not.exist;
+      }
+    ));
+
+
+    it('should undo', inject(
+      async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_NO_FORM');
+        await act(() => selection.select(startEvent));
+        changeInput(getFormTypeSelect(container), FORM_TYPES.CAMUNDA_FORM_LINKED);
+
+        // when
+        await act(() => commandStack.undo());
+
+        // then
+        expect(getFormDefinition(startEvent)).to.not.exist;
+      }
+    ));
+
+  });
+
+
+  describe('select embedded form', function() {
+
+    it('should show form configuration and create user task form in XML', inject(
+      async function(elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_NO_FORM');
+        await act(() => selection.select(startEvent));
+
+        // when
+        changeInput(getFormTypeSelect(container), FORM_TYPES.CAMUNDA_FORM_EMBEDDED);
+
+        // then
+        const formConfigTextarea = getFormConfigurationTextarea(container);
+        expect(formConfigTextarea).to.exist;
+
+        const userTaskForm = getUserTaskForm(startEvent);
+        expect(userTaskForm).to.exist;
+      }
+    ));
+
+  });
+
+
+  describe('migrate from embedded to linked', function() {
+
+    it('should switch to linked form and clean up embedded form', inject(
+      async function(elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_EMBEDDED');
+        await act(() => selection.select(startEvent));
+
+        // when
+        changeInput(getFormTypeSelect(container), FORM_TYPES.CAMUNDA_FORM_LINKED);
+
+        // then
+        const formDefinition = getFormDefinition(startEvent);
+        expect(formDefinition.get('formId')).to.equal('');
+        expect(formDefinition.get('formKey')).to.not.exist;
+
+        const userTaskForms = getExtensionElementsList(getRootElement(startEvent), 'zeebe:UserTaskForm');
+        expect(userTaskForms).to.have.lengthOf(0);
+      }
+    ));
+
+
+    it('should undo', inject(
+      async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_EMBEDDED');
+        await act(() => selection.select(startEvent));
+        changeInput(getFormTypeSelect(container), FORM_TYPES.CAMUNDA_FORM_LINKED);
+
+        // when
+        await act(() => commandStack.undo());
+
+        // then
+        expect(getFormDefinition(startEvent).get('formKey')).to.exist;
+        expect(getUserTaskForm(startEvent)).to.exist;
+      }
+    ));
+
+  });
+
+
+  describe('remove form', function() {
+
+    it('should remove form definition when set to none', inject(
+      async function(elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_LINKED');
+        await act(() => selection.select(startEvent));
+
+        // when
+        changeInput(getFormTypeSelect(container), 'none');
+
+        // then
+        expect(getFormDefinition(startEvent)).to.not.exist;
+      }
+    ));
+
+  });
+
+
+  describe('tooltip', function() {
+
+    function openTooltip() {
+      return act(() => {
+        const wrapper = domQuery('.bio-properties-panel-tooltip-wrapper', container);
+        mouseEnter(wrapper);
+        clock.tick(TOOLTIP_OPEN_DELAY);
+      });
+    }
+
+    it('should display correct documentation', inject(
+      async function(elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('START_EVENT_NO_FORM');
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        // when
+        await openTooltip();
+
+        const documentationLinkGroup = domQuery('.bio-properties-panel-tooltip-content a', container);
+
+        // then
+        expect(documentationLinkGroup).to.exist;
+        expect(documentationLinkGroup.title).to.equal('Start event form documentation');
+      }
+    ));
+
+  });
+
+});
+
+
+// helpers //////////
+
+function getFormTypeSelect(container) {
+  return domQuery('select[name=formType]', container);
+}
+
+function getFormIdInput(container) {
+  return domQuery('input[name=formId]', container);
+}
+
+function getFormConfigurationTextarea(container) {
+  return domQuery('textarea[name=formConfiguration]', container);
+}
+
+function getBindingTypeSelect(container) {
+  return domQuery('select[name=bindingType]', container);
+}
+
+function getVersionTagInput(container) {
+  return domQuery('input[name=versionTag]', container);
+}


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4672

### Proposed Changes

Add support of form for none start event with only 2 form types allowed: 'Linked' and 'Embedded'. Also integrated https://github.com/camunda/camunda-bpmn-js-behaviors/pull/127 behaviors that ensure form is deleted when element is changed from none start event(e.g. Message start event) or placed not in the process root.


https://github.com/user-attachments/assets/02962425-a386-4ffa-a298-73def3e72892



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
