### PR TITLE
feat: display input / output variable names as monospace

### DIFF
--- a/src/provider/camunda-platform/properties/InMappingProps.js
+++ b/src/provider/camunda-platform/properties/InMappingProps.js
@@ -45,7 +45,7 @@ export function InMappingProps({ element, injector }) {
 
     return {
       id,
-      label: mapping.get('target') || '',
+      label: mapping.get('target') ? <code>{ mapping.get('target') }</code> : '',
       entries: InOutMapping({
         idPrefix: id,
         element,

--- a/src/provider/camunda-platform/properties/OutMappingProps.js
+++ b/src/provider/camunda-platform/properties/OutMappingProps.js
@@ -37,7 +37,7 @@ export function OutMappingProps({ element, injector }) {
 
     return {
       id,
-      label: mapping.get('target') || '',
+      label: mapping.get('target') ? <code>{ mapping.get('target') }</code> : '',
       entries: InOutMapping({
         idPrefix: id,
         element,

--- a/src/provider/zeebe/properties/InputProps.js
+++ b/src/provider/zeebe/properties/InputProps.js
@@ -35,7 +35,7 @@ export function InputProps({ element, injector }) {
 
     return {
       id,
-      label: parameter.get('target') || '',
+      label: parameter.get('target') ? <code>{ parameter.get('target') }</code> : '',
       entries: InputOutputParameter({
         idPrefix: id,
         element,

--- a/src/provider/zeebe/properties/OutputProps.js
+++ b/src/provider/zeebe/properties/OutputProps.js
@@ -35,7 +35,7 @@ export function OutputProps({ element, injector }) {
 
     return {
       id,
-      label: parameter.get('target') || '',
+      label: parameter.get('target') ? <code>{ parameter.get('target') }</code> : '',
       entries: InputOutputParameter({
         idPrefix: id,
         element,

--- a/test/spec/provider/zeebe/InputProps.spec.js
+++ b/test/spec/provider/zeebe/InputProps.spec.js
@@ -205,7 +205,7 @@ describe('provider/zeebe - InputProps', function() {
     // then
     const inputItemLabel = getInputItemLabel(container, 0);
 
-    expect(inputItemLabel.innerHTML).to.equal('inputTargetValue1');
+    expect(inputItemLabel.textContent).to.equal('inputTargetValue1');
   }));
 
 
@@ -222,7 +222,7 @@ describe('provider/zeebe - InputProps', function() {
     const inputParameters = getInputParameters(serviceTask);
 
     for (let idx = 0; idx < inputParameters.length; idx++) {
-      const inputItemLabel = getInputItemLabel(container, idx).innerHTML;
+      const inputItemLabel = getInputItemLabel(container, idx).textContent;
 
       expect(inputParameters[idx].target).to.equal(inputItemLabel);
     }

--- a/test/spec/provider/zeebe/OutputProps.spec.js
+++ b/test/spec/provider/zeebe/OutputProps.spec.js
@@ -142,7 +142,7 @@ describe('provider/zeebe - OutputProps', function() {
       // then
       const outputItemLabel = getOutputItemLabel(container, 0);
 
-      expect(outputItemLabel.innerHTML).to.equal('outputTargetValue1');
+      expect(outputItemLabel.textContent).to.equal('outputTargetValue1');
     }));
 
 
@@ -159,7 +159,7 @@ describe('provider/zeebe - OutputProps', function() {
       const outputParameters = getOutputParameters(serviceTask);
 
       for (let idx = 0; idx < outputParameters.length; idx++) {
-        const outputItemLabel = getOutputItemLabel(container, idx).innerHTML;
+        const outputItemLabel = getOutputItemLabel(container, idx).textContent;
 
         expect(outputParameters[idx].target).to.equal(outputItemLabel);
       }


### PR DESCRIPTION
### Proposed Changes

This aims to improve the representation of variables - typically monospace, not clear text.

<img width="780" height="828" alt="image" src="https://github.com/user-attachments/assets/77a1a7da-19d3-49c4-8328-104893c14bfa" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
