### PR TITLE
Allow custom panel header provider

### DIFF
--- a/src/render/BpmnPropertiesPanel.js
+++ b/src/render/BpmnPropertiesPanel.js
@@ -34,6 +34,7 @@ const DEFAULT_FEEL_LANGUAGE_CONTEXT = {
  * @param {Object} props.layoutConfig
  * @param {Object} props.descriptionConfig
  * @param {Object} props.tooltipConfig
+ * @param {Object} props.headerProvider
  * @param {HTMLElement} props.feelPopupContainer
  * @param {Function} props.getFeelPopupLinks
  */
@@ -45,6 +46,7 @@ export default function BpmnPropertiesPanel(props) {
     layoutConfig: initialLayoutConfig,
     descriptionConfig,
     tooltipConfig,
+    headerProvider: customHeaderProvider,
     feelPopupContainer,
     getFeelPopupLinks
   } = props;
@@ -239,7 +241,7 @@ export default function BpmnPropertiesPanel(props) {
       <FeelLanguageContext.Provider value={ DEFAULT_FEEL_LANGUAGE_CONTEXT }>
         <PropertiesPanel
           element={ selectedElement }
-          headerProvider={ PanelHeaderProvider(translate) }
+          headerProvider={ customHeaderProvider || PanelHeaderProvider(translate) }
           placeholderProvider={ PanelPlaceholderProvider(translate) }
           groups={ groups }
           layoutConfig={ layoutConfig }

--- a/src/render/BpmnPropertiesPanelRenderer.js
+++ b/src/render/BpmnPropertiesPanelRenderer.js
@@ -33,6 +33,7 @@ export default class BpmnPropertiesPanelRenderer {
       layout: layoutConfig,
       description: descriptionConfig,
       tooltip: tooltipConfig,
+      headerProvider,
       feelPopupContainer,
       getFeelPopupLinks
     } = config || {};
@@ -42,6 +43,7 @@ export default class BpmnPropertiesPanelRenderer {
     this._layoutConfig = layoutConfig;
     this._descriptionConfig = descriptionConfig;
     this._tooltipConfig = tooltipConfig;
+    this._headerProvider = headerProvider || injector.get('propertiesPanelHeaderProvider', false);
     this._feelPopupContainer = feelPopupContainer;
     this._getFeelPopupLinks = getFeelPopupLinks;
 
@@ -179,6 +181,7 @@ export default class BpmnPropertiesPanelRenderer {
         layoutConfig={ this._layoutConfig }
         descriptionConfig={ this._descriptionConfig }
         tooltipConfig={ this._tooltipConfig }
+        headerProvider={ this._headerProvider }
         feelPopupContainer={ this._feelPopupContainer }
         getFeelPopupLinks={ this._getFeelPopupLinks }
       />,

--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -337,6 +337,45 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
   });
 
 
+  it('should allow providing custom panel header provider', async function() {
+
+    // given
+    const diagramXml = require('test/fixtures/simple.bpmn').default;
+
+    const customHeaderProvider = {
+      getElementLabel(element) {
+        return `custom:${ element.id }`;
+      },
+      getElementIcon() {
+        return null;
+      },
+      getTypeLabel() {
+        return 'Custom Type';
+      }
+    };
+
+    const CustomHeaderProviderModule = {
+      propertiesPanelHeaderProvider: [ 'value', customHeaderProvider ]
+    };
+
+    const modules = [
+      ZeebeBehaviorsModule,
+      BpmnPropertiesPanel,
+      BpmnPropertiesProvider,
+      ZeebePropertiesProvider,
+      CustomHeaderProviderModule
+    ];
+
+    // when
+    await createModeler(diagramXml, {
+      additionalModules: modules
+    });
+
+    // then
+    expect(getHeaderName(propertiesContainer)).to.eql('custom:Process_1');
+  });
+
+
   it('should ignore implicit root', async function() {
 
     // given


### PR DESCRIPTION
## Summary

This adds support for providing a custom properties panel header provider through either:

- `config.propertiesPanel.headerProvider`
- an optional `propertiesPanelHeaderProvider` service

The default BPMN header provider remains unchanged when no custom provider is configured.

Closes #1123

## Validation

- `npm run lint`
- `npm test -- --single-run`