### PR TITLE
feat: make called decision version tag feel-optional

### DIFF
--- a/src/provider/zeebe/properties/CalledDecisionProps.js
+++ b/src/provider/zeebe/properties/CalledDecisionProps.js
@@ -28,7 +28,7 @@ import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
 import { withProps } from '../../HOCs/withProps.js';
 
 const CalledDecisionBinding = withProps(Binding, { type: 'zeebe:CalledDecision' }),
-      CalledDecisionVersionTag = withProps(VersionTag, { type: 'zeebe:CalledDecision' });
+      CalledDecisionVersionTag = withProps(VersionTag, { type: 'zeebe:CalledDecision', feel: 'optional' });
 
 
 export function CalledDecisionProps(props) {
@@ -57,7 +57,7 @@ export function CalledDecisionProps(props) {
     entries.push({
       id: 'versionTag',
       component: CalledDecisionVersionTag,
-      isEdited: isTextFieldEntryEdited
+      isEdited: isFeelEntryEdited
     });
   }
 

--- a/src/provider/zeebe/properties/shared/VersionTag.js
+++ b/src/provider/zeebe/properties/shared/VersionTag.js
@@ -8,9 +8,12 @@ import { useService } from '../../../../hooks';
 
 import { getExtensionElementsList } from '../../../../utils/ExtensionElementsUtil';
 
+import { BpmnFeelEntry } from '../../../../entries/BpmnFeelEntry';
+
 export default function VersionTag(props) {
   const {
     element,
+    feel,
     type
   } = props;
 
@@ -86,6 +89,18 @@ export default function VersionTag(props) {
     // (4) Execute the commands
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
+
+  if (feel) {
+    return BpmnFeelEntry({
+      element,
+      id: 'versionTag',
+      label: translate('Version tag'),
+      feel,
+      getValue,
+      setValue,
+      debounce
+    });
+  }
 
   return TextFieldEntry({
     element,


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5946

### Proposed Changes

Version tag for a called decision can be a FEEL expression:

<img width="301" height="560" alt="image" src="https://github.com/user-attachments/assets/bcd6a937-439b-499e-a88c-8fdeecb4538b" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
