### PR TITLE
feat: add job priority properties for zeebe:jobPriorityDefinition

### DIFF
--- a/src/provider/zeebe/ZeebePropertiesProvider.js
+++ b/src/provider/zeebe/ZeebePropertiesProvider.js
@@ -18,6 +18,7 @@ import {
   HeaderProps,
   InputPropagationProps,
   InputProps,
+  JobPriorityDefinitionProps,
   MessageProps,
   MultiInstanceProps,
   OutputCollectionProps,
@@ -59,6 +60,7 @@ const ZEEBE_GROUPS = [
   AdHocSubProcessImplementationGroup,
   UserTaskImplementationGroup,
   TaskDefinitionGroup,
+  JobPriorityDefinitionGroup,
   AssignmentDefinitionGroup,
   ActiveElementsGroup,
   FormGroup,
@@ -167,6 +169,20 @@ function TaskDefinitionGroup(element, injector) {
     label: translate('Task definition'),
     entries: [
       ...TaskDefinitionProps({ element })
+    ],
+    component: Group
+  };
+
+  return group.entries.length ? group : null;
+}
+
+function JobPriorityDefinitionGroup(element, injector) {
+  const translate = injector.get('translate');
+  const group = {
+    id: 'jobPriorityDefinition',
+    label: translate('Job priority'),
+    entries: [
+      ...JobPriorityDefinitionProps({ element })
     ],
     component: Group
   };

--- a/src/provider/zeebe/properties/JobPriorityDefinitionProps.js
+++ b/src/provider/zeebe/properties/JobPriorityDefinitionProps.js
@@ -1,0 +1,190 @@
+import {
+  getBusinessObject,
+  is,
+  isAny
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import { isFeelEntryEdited } from '@bpmn-io/properties-panel';
+
+import {
+  getExtensionElementsList
+} from '../../../utils/ExtensionElementsUtil';
+
+import {
+  createElement
+} from '../../../utils/ElementUtil';
+
+import {
+  useService
+} from '../../../hooks';
+
+import {
+  getTaskDefinition
+} from '../utils/ZeebeServiceTaskUtil';
+
+import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
+
+const OPTIONAL_JOB_WORKER_ELEMENTS = [
+  'bpmn:BusinessRuleTask',
+  'bpmn:ScriptTask'
+];
+
+
+export function JobPriorityDefinitionProps(props) {
+  const {
+    element
+  } = props;
+
+  if (!hasJobPriority(element)) {
+    return [];
+  }
+
+  return [
+    {
+      id: 'jobPriorityDefinitionPriority',
+      component: Priority,
+      isEdited: isFeelEntryEdited
+    }
+  ];
+}
+
+function Priority(props) {
+  const {
+    element,
+    id
+  } = props;
+
+  const commandStack = useService('commandStack');
+  const bpmnFactory = useService('bpmnFactory');
+  const translate = useService('translate');
+  const debounce = useService('debounceInput');
+
+  const getValue = () => {
+    return (getJobPriorityDefinition(element) || {}).priority;
+  };
+
+  const setValue = (value) => {
+    const commands = [];
+
+    const businessObject = getBusinessObject(element);
+
+    let extensionElements = businessObject.get('extensionElements');
+
+    // (1) ensure extension elements
+    if (!extensionElements) {
+      extensionElements = createElement(
+        'bpmn:ExtensionElements',
+        { values: [] },
+        businessObject,
+        bpmnFactory
+      );
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: businessObject,
+          properties: { extensionElements }
+        }
+      });
+    }
+
+    // (2) ensure JobPriorityDefinition
+    let jobPriorityDefinition = getJobPriorityDefinition(element);
+    const isNullValue = value === null || value === '' || value === undefined;
+
+    if (jobPriorityDefinition && isNullValue) {
+
+      // (2a) remove job priority definition if it exists and priority is set to null
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: extensionElements,
+          properties: {
+            values: extensionElements.get('values').filter(v => v !== jobPriorityDefinition)
+          }
+        }
+      });
+
+    } else if (jobPriorityDefinition && !isNullValue) {
+
+      // (2b) update job priority definition if it already exists
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: jobPriorityDefinition,
+          properties: { priority: value }
+        }
+      });
+
+    } else if (!jobPriorityDefinition && !isNullValue) {
+
+      // (2c) create job priority definition if it does not exist
+      jobPriorityDefinition = createElement(
+        'zeebe:JobPriorityDefinition',
+        { priority: value },
+        extensionElements,
+        bpmnFactory
+      );
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: extensionElements,
+          properties: {
+            values: [ ...extensionElements.get('values'), jobPriorityDefinition ]
+          }
+        }
+      });
+    }
+
+    // (3) commit all updates
+    commandStack.execute('properties-panel.multi-command-executor', commands);
+  };
+
+  const tooltip = (
+    <div>
+      <p>{ translate('Define the priority used when activating the job for this task. Accepts a static integer or a FEEL expression. Higher priority jobs are activated first.') }</p>
+      <a href="https://docs.camunda.io/docs/components/concepts/job-workers/#job-prioritization" target="_blank" rel="noopener noreferrer">{ translate('Learn more about job prioritization') }</a>
+    </div>
+  );
+
+  return BpmnFeelEntry({
+    element,
+    id,
+    label: translate('Priority'),
+    feel: 'optional',
+    getValue,
+    setValue,
+    debounce,
+    tooltip
+  });
+}
+
+
+// helper ///////////////////////
+
+/**
+ * Job priority may be defined on a process, on service and send tasks (always
+ * job workers), and on business rule and script tasks only when they are
+ * implemented as a job worker (i.e. they carry a `zeebe:TaskDefinition`).
+ *
+ * This mirrors the `allowedIn` definition of `zeebe:JobPriorityDefinition` in
+ * the zeebe moddle.
+ */
+function hasJobPriority(element) {
+  if (is(element, 'bpmn:Process') || isAny(element, [ 'bpmn:ServiceTask', 'bpmn:SendTask' ])) {
+    return true;
+  }
+
+  return isAny(element, OPTIONAL_JOB_WORKER_ELEMENTS) && !!getTaskDefinition(element);
+}
+
+export function getJobPriorityDefinition(element) {
+  const businessObject = getBusinessObject(element);
+
+  return getExtensionElementsList(businessObject, 'zeebe:JobPriorityDefinition')[0];
+}

--- a/src/provider/zeebe/properties/index.js
+++ b/src/provider/zeebe/properties/index.js
@@ -13,6 +13,7 @@ export { FormProps } from './FormProps';
 export { HeaderProps } from './HeaderProps';
 export { InputPropagationProps } from './InputPropagationProps';
 export { InputProps } from './InputProps';
+export { JobPriorityDefinitionProps } from './JobPriorityDefinitionProps';
 export { MessageProps } from './MessageProps';
 export { MultiInstanceProps } from './MultiInstanceProps';
 export { OutputCollectionProps } from './OutputCollectionProps';

--- a/src/provider/zeebe/utils/ZeebeServiceTaskUtil.js
+++ b/src/provider/zeebe/utils/ZeebeServiceTaskUtil.js
@@ -44,9 +44,7 @@ export function isMessageThrowEvent(element) {
   return is(element, 'bpmn:IntermediateThrowEvent') && !!getMessageEventDefinition(element);
 }
 
-// helper ////////////////
-
-function getTaskDefinition(element) {
+export function getTaskDefinition(element) {
   const businessObject = getBusinessObject(element);
 
   return getExtensionElementsList(businessObject, 'zeebe:TaskDefinition')[0];

--- a/test/spec/provider/zeebe/JobPriorityDefinitionProps.bpmn
+++ b/test/spec/provider/zeebe/JobPriorityDefinitionProps.bpmn
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0sp2msp" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.8.0-rc.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:jobPriorityDefinition priority="50" />
+    </bpmn:extensionElements>
+    <bpmn:serviceTask id="ServiceTask_1" name="ServiceTask_1">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+        <zeebe:jobPriorityDefinition priority="=myPriorityValue" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_2" name="ServiceTask_2">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_3" name="ServiceTask_3" />
+    <bpmn:userTask id="UserTask_1" name="UserTask_1" />
+    <bpmn:businessRuleTask id="BusinessRuleTask_NoJobWorker" name="BusinessRuleTask_NoJobWorker" />
+    <bpmn:businessRuleTask id="BusinessRuleTask_JobWorker" name="BusinessRuleTask_JobWorker">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+    </bpmn:businessRuleTask>
+    <bpmn:endEvent id="MessageEndEvent_1" name="MessageEndEvent_1">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1" />
+    </bpmn:endEvent>
+    <bpmn:intermediateThrowEvent id="MessageThrowEvent_1" name="MessageThrowEvent_1">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_2" />
+    </bpmn:intermediateThrowEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_2_di" bpmnElement="ServiceTask_2">
+        <dc:Bounds x="280" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_3_di" bpmnElement="ServiceTask_3">
+        <dc:Bounds x="400" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_1_di" bpmnElement="UserTask_1">
+        <dc:Bounds x="520" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BusinessRuleTask_NoJobWorker_di" bpmnElement="BusinessRuleTask_NoJobWorker">
+        <dc:Bounds x="160" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BusinessRuleTask_JobWorker_di" bpmnElement="BusinessRuleTask_JobWorker">
+        <dc:Bounds x="280" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="MessageEndEvent_1_di" bpmnElement="MessageEndEvent_1">
+        <dc:Bounds x="412" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="MessageThrowEvent_1_di" bpmnElement="MessageThrowEvent_1">
+        <dc:Bounds x="512" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/zeebe/JobPriorityDefinitionProps.spec.js
+++ b/test/spec/provider/zeebe/JobPriorityDefinitionProps.spec.js
@@ -1,0 +1,366 @@
+import { expect } from 'chai';
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  act
+} from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  changeInput,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import { getJobPriorityDefinition } from 'src/provider/zeebe/properties/JobPriorityDefinitionProps';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/render';
+
+import ZeebePropertiesProvider from 'src/provider/zeebe';
+
+import BehaviorsModule from 'camunda-bpmn-js-behaviors/lib/camunda-cloud';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import diagramXML from './JobPriorityDefinitionProps.bpmn';
+import { setEditorValue } from '../../../TestHelper';
+import { getExtensionElementsList } from '../../../../src/utils/ExtensionElementsUtil';
+
+
+describe('provider/zeebe - JobPriorityDefinitionProps', function() {
+
+  const testModules = [
+    CoreModule,
+    SelectionModule,
+    ModelingModule,
+    BpmnPropertiesPanel,
+    ZeebePropertiesProvider,
+    BehaviorsModule
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    modules: testModules,
+    moddleExtensions,
+    debounceInput: false
+  }));
+
+
+  describe('display', function() {
+
+    it('should display for process', inject(async function(elementRegistry, selection) {
+
+      // given
+      const process = elementRegistry.get('Process_1');
+
+      await act(() => {
+        selection.select(process);
+      });
+
+      // when
+      const entry = domQuery('[data-entry-id="jobPriorityDefinitionPriority"]', container);
+
+      // then
+      expect(entry).to.exist;
+
+      // static number renders as number input
+      const input = domQuery('input[name=jobPriorityDefinitionPriority]', entry);
+      expect(input).to.exist;
+      expect(input.value).to.equal('50');
+    }));
+
+
+    it('should display for service task', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const entry = domQuery('[data-entry-id="jobPriorityDefinitionPriority"]', container);
+
+      // then
+      expect(entry).to.exist;
+
+      const jobPriorityDefinition = getJobPriorityDefinition(serviceTask);
+      const feelExpression = jobPriorityDefinition.get('priority').substring(1);
+
+      const input = domQuery('[role="textbox"]', entry);
+      expect(input.textContent).to.equal(feelExpression);
+    }));
+
+
+    it('should NOT display for business rule task without zeebe:TaskDefinition',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const businessRuleTask = elementRegistry.get('BusinessRuleTask_NoJobWorker');
+
+        await act(() => {
+          selection.select(businessRuleTask);
+        });
+
+        // when
+        const entry = domQuery('[data-entry-id="jobPriorityDefinitionPriority"]', container);
+
+        // then
+        expect(entry).to.not.exist;
+      })
+    );
+
+
+    it('should display for business rule task with zeebe:TaskDefinition',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const businessRuleTask = elementRegistry.get('BusinessRuleTask_JobWorker');
+
+        await act(() => {
+          selection.select(businessRuleTask);
+        });
+
+        // when
+        const entry = domQuery('[data-entry-id="jobPriorityDefinitionPriority"]', container);
+
+        // then
+        expect(entry).to.exist;
+      })
+    );
+
+
+    it('should NOT display for user task', inject(async function(elementRegistry, selection) {
+
+      // given
+      const userTask = elementRegistry.get('UserTask_1');
+
+      await act(() => {
+        selection.select(userTask);
+      });
+
+      // when
+      const entry = domQuery('[data-entry-id="jobPriorityDefinitionPriority"]', container);
+
+      // then
+      expect(entry).to.not.exist;
+    }));
+
+
+    it('should NOT display for message end event', inject(async function(elementRegistry, selection) {
+
+      // given
+      const messageEndEvent = elementRegistry.get('MessageEndEvent_1');
+
+      await act(() => {
+        selection.select(messageEndEvent);
+      });
+
+      // when
+      const entry = domQuery('[data-entry-id="jobPriorityDefinitionPriority"]', container);
+
+      // then
+      expect(entry).to.not.exist;
+    }));
+
+
+    it('should NOT display for message throw event', inject(async function(elementRegistry, selection) {
+
+      // given
+      const messageThrowEvent = elementRegistry.get('MessageThrowEvent_1');
+
+      await act(() => {
+        selection.select(messageThrowEvent);
+      });
+
+      // when
+      const entry = domQuery('[data-entry-id="jobPriorityDefinitionPriority"]', container);
+
+      // then
+      expect(entry).to.not.exist;
+    }));
+
+  });
+
+
+  describe('update', function() {
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const priorityInput = domQuery('[data-entry-id="jobPriorityDefinitionPriority"] [role="textbox"]', container);
+
+      await setEditorValue(priorityInput, '90');
+
+      // then
+      expect(getJobPriorityDefinition(serviceTask).get('priority')).to.eql('=90');
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_1');
+        const originalValue = getJobPriorityDefinition(serviceTask).get('priority');
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+        const priorityInput = domQuery('[data-entry-id="jobPriorityDefinitionPriority"] [role="textbox"]', container);
+        await setEditorValue(priorityInput, '90');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect('=' + priorityInput.textContent).to.eql(originalValue);
+      })
+    );
+
+  });
+
+
+  describe('create', function() {
+
+    it('should create job priority definition (service task)',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_2');
+
+        // assume
+        expect(getJobPriorityDefinition(serviceTask)).not.to.exist;
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+
+        // when
+        const priorityInput = domQuery('input[name=jobPriorityDefinitionPriority]', container);
+        changeInput(priorityInput, '90');
+
+        // then
+        expect(getJobPriorityDefinition(serviceTask)).to.exist;
+        expect(getJobPriorityDefinition(serviceTask).get('priority')).to.eql('90');
+      })
+    );
+
+
+    it('should create extension elements and job priority definition (service task)',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_3');
+
+        // assume
+        expect(getBusinessObject(serviceTask).get('extensionElements')).not.to.exist;
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+
+        // when
+        const priorityInput = domQuery('input[name=jobPriorityDefinitionPriority]', container);
+        changeInput(priorityInput, '90');
+
+        // then
+        expect(getBusinessObject(serviceTask).get('extensionElements')).to.exist;
+        expect(getJobPriorityDefinition(serviceTask).get('priority')).to.eql('90');
+      })
+    );
+
+
+    it('should create job priority definition (process)',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const process = elementRegistry.get('Process_1');
+
+        // remove existing definition first
+        const businessObject = getBusinessObject(process);
+        const extensionElements = businessObject.get('extensionElements');
+        extensionElements.values = extensionElements.values.filter(
+          v => v.$type !== 'zeebe:JobPriorityDefinition'
+        );
+
+        // assume
+        expect(getJobPriorityDefinition(process)).not.to.exist;
+
+        await act(() => {
+          selection.select(process);
+        });
+
+        // when
+        const priorityInput = domQuery('input[name=jobPriorityDefinitionPriority]', container);
+        changeInput(priorityInput, '50');
+
+        // then
+        expect(getJobPriorityDefinition(process)).to.exist;
+        expect(getJobPriorityDefinition(process).get('priority')).to.eql('50');
+      })
+    );
+
+  });
+
+
+  describe('remove', function() {
+
+    it('should remove job priority definition when emptied',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_1');
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+
+        // assume
+        expect(getJobPriorityDefinition(serviceTask)).to.exist;
+
+        // when
+        const priorityInput = domQuery('[data-entry-id="jobPriorityDefinitionPriority"] [role="textbox"]', container);
+        await setEditorValue(priorityInput, '');
+
+        // then
+        expect(getJobPriorityDefinition(serviceTask)).not.to.exist;
+
+        // keep other extension elements
+        expect(getExtensionElementsList(getBusinessObject(serviceTask), 'zeebe:TaskDefinition')).to.have.length(1);
+      })
+    );
+
+  });
+
+});


### PR DESCRIPTION
Adds a "Job priority" group with a single FEEL-optional `priority` field, shown on process, service task, send task, and (when implemented as a job worker) business rule task and script task.

Part of camunda/camunda-modeler#5889.

> Depends on the `zeebe:JobPriorityDefinition` moddle type (camunda/zeebe-bpmn-moddle) — needs the released moddle to build cleanly; tested here against a local overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)