### PR TITLE
feat: allow rendering the header into a separate container

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ const modeler = new BpmnModeler({
 
 ### API
 
-#### `BpmnPropertiesPanelRenderer#attachTo(container: HTMLElement) => void`
+#### `BpmnPropertiesPanelRenderer#attachTo(container: HTMLElement, headerContainer?: HTMLElement) => void`
 
 Attach the properties panel to a parent node.
 
@@ -121,6 +121,9 @@ Attach the properties panel to a parent node.
 const propertiesPanel = modeler.get('propertiesPanel');
 
 propertiesPanel.attachTo('#other-properties');
+
+// or attach the panel body and header to different containers
+propertiesPanel.attachTo('#properties', '#panel-header');
 ```
 
 #### `BpmnPropertiesPanelRenderer#detach() => void`

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "node": "*"
       },
       "peerDependencies": {
-        "@bpmn-io/properties-panel": ">= 3.40.6",
+        "@bpmn-io/properties-panel": ">= 3.42.0",
         "bpmn-js": ">= 11.5",
         "camunda-bpmn-js-behaviors": ">= 0.4",
         "diagram-js": ">= 11.9"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "start:cloud": "cross-env SINGLE_START=cloud npm run dev",
     "start:platform": "cross-env SINGLE_START=platform npm run dev",
     "start:bpmn": "cross-env SINGLE_START=bpmn npm run dev",
+    "start:header": "cross-env SINGLE_START=header npm run dev",
     "prepare": "run-s build"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "zeebe-bpmn-moddle": "^1.15.0"
   },
   "peerDependencies": {
-    "@bpmn-io/properties-panel": ">= 3.40.6",
+    "@bpmn-io/properties-panel": ">= 3.42.0",
     "bpmn-js": ">= 11.5",
     "camunda-bpmn-js-behaviors": ">= 0.4",
     "diagram-js": ">= 11.9"

--- a/src/render/BpmnPropertiesPanel.js
+++ b/src/render/BpmnPropertiesPanel.js
@@ -11,7 +11,9 @@ import {
   reduce
 } from 'min-dash';
 
-import { FeelLanguageContext, PropertiesPanel } from '@bpmn-io/properties-panel';
+import { createPortal } from '@bpmn-io/properties-panel/preact/compat';
+
+import { FeelLanguageContext, Header, PropertiesPanel } from '@bpmn-io/properties-panel';
 
 import {
   BpmnPropertiesPanelContext
@@ -36,6 +38,7 @@ const DEFAULT_FEEL_LANGUAGE_CONTEXT = {
  * @param {Object} props.tooltipConfig
  * @param {HTMLElement} props.feelPopupContainer
  * @param {Function} props.getFeelPopupLinks
+ * @param {HTMLElement} [props.headerParent]
  */
 export default function BpmnPropertiesPanel(props) {
   const {
@@ -46,7 +49,8 @@ export default function BpmnPropertiesPanel(props) {
     descriptionConfig,
     tooltipConfig,
     feelPopupContainer,
-    getFeelPopupLinks
+    getFeelPopupLinks,
+    headerParent
   } = props;
 
   const canvas = injector.get('canvas');
@@ -234,12 +238,18 @@ export default function BpmnPropertiesPanel(props) {
     });
   };
 
+  // (8) render header separately if a header container is provided
+  const separateHeader = !!headerParent;
+  const renderSeparateHeader = separateHeader && selectedElement && !isArray(selectedElement);
+
+  const headerProvider = PanelHeaderProvider(translate);
+
   return (
     <BpmnPropertiesPanelContext.Provider value={ bpmnPropertiesPanelContext }>
       <FeelLanguageContext.Provider value={ DEFAULT_FEEL_LANGUAGE_CONTEXT }>
         <PropertiesPanel
           element={ selectedElement }
-          headerProvider={ PanelHeaderProvider(translate) }
+          headerProvider={ separateHeader ? null : headerProvider }
           placeholderProvider={ PanelPlaceholderProvider(translate) }
           groups={ groups }
           layoutConfig={ layoutConfig }
@@ -251,6 +261,16 @@ export default function BpmnPropertiesPanel(props) {
           feelPopupContainer={ feelPopupContainer }
           getFeelPopupLinks={ getFeelPopupLinks }
           eventBus={ eventBus } />
+        {
+          renderSeparateHeader
+            ? createPortal(
+              <Header
+                element={ selectedElement }
+                headerProvider={ headerProvider } />,
+              headerParent
+            )
+            : null
+        }
       </FeelLanguageContext.Provider>
     </BpmnPropertiesPanelContext.Provider>
   );

--- a/src/render/BpmnPropertiesPanelRenderer.js
+++ b/src/render/BpmnPropertiesPanelRenderer.js
@@ -49,6 +49,12 @@ export default class BpmnPropertiesPanelRenderer {
       '<div style="height: 100%" tabindex="-1" class="bio-properties-panel-container"></div>'
     );
 
+    this._headerContainer = domify(
+      '<div style="flex: none; height: auto" class="bio-properties-panel bio-properties-panel-header-container"></div>'
+    );
+
+    this._separateHeader = false;
+
     var commandStack = injector.get('commandStack', false);
 
     commandStack && setupKeyboard(this._container, eventBus, commandStack);
@@ -74,29 +80,49 @@ export default class BpmnPropertiesPanelRenderer {
   /**
    * Attach the properties panel to a parent node.
    *
-   * @param {HTMLElement} container
+   * Pass a second container to render the header separately from the body.
+   *
+   * @param {HTMLElement} container body container
+   * @param {HTMLElement} [headerContainer] optional separate header container
    */
-  attachTo(container) {
+  attachTo(container, headerContainer) {
     if (!container) {
       throw new Error('container required');
     }
 
-    // unwrap jQuery if provided
-    if (container.get && container.constructor.prototype.jquery) {
-      container = container.get(0);
+    container = resolveContainer(container);
+
+    if (headerContainer) {
+      headerContainer = resolveContainer(headerContainer);
+
+      if (!headerContainer) {
+        throw new Error('header container not found');
+      }
     }
 
-    if (typeof container === 'string') {
-      container = domQuery(container);
-    }
+    const separateHeader = !!headerContainer;
+
+    const headerPlacementChanged = separateHeader !== this._separateHeader;
 
     // (1) detach from old parent
     this.detach();
 
-    // (2) append to parent container
+    // (2) append body to its container
     container.appendChild(this._container);
 
-    // (3) notify interested parties
+    // (3) append header to its container or render it inline
+    this._separateHeader = separateHeader;
+
+    if (headerContainer) {
+      headerContainer.appendChild(this._headerContainer);
+    }
+
+    // (4) re-render if the header placement changed
+    if (headerPlacementChanged) {
+      this._rerender();
+    }
+
+    // (5) notify interested parties
     this._eventBus.fire('propertiesPanel.attach');
   }
 
@@ -110,6 +136,12 @@ export default class BpmnPropertiesPanelRenderer {
       parentNode.removeChild(this._container);
 
       this._eventBus.fire('propertiesPanel.detach');
+    }
+
+    const headerParentNode = this._headerContainer.parentNode;
+
+    if (headerParentNode) {
+      headerParentNode.removeChild(this._headerContainer);
     }
   }
 
@@ -181,11 +213,22 @@ export default class BpmnPropertiesPanelRenderer {
         tooltipConfig={ this._tooltipConfig }
         feelPopupContainer={ this._feelPopupContainer }
         getFeelPopupLinks={ this._getFeelPopupLinks }
+        headerParent={ this._separateHeader ? this._headerContainer : null }
       />,
       this._container
     );
 
     this._eventBus.fire('propertiesPanel.rendered');
+  }
+
+  _rerender() {
+    const canvas = this._injector.get('canvas');
+
+    const rootElement = canvas.getRootElement();
+
+    if (rootElement && !isImplicitRoot(rootElement)) {
+      this._render(rootElement);
+    }
   }
 
   _destroy() {
@@ -204,6 +247,28 @@ BpmnPropertiesPanelRenderer.$inject = [ 'config.propertiesPanel', 'injector', 'e
 
 function isImplicitRoot(element) {
   return element && element.isImplicit;
+}
+
+/**
+ * Resolve a container that may be given as a jQuery object, a selector or a
+ * plain HTML element into a plain HTML element.
+ *
+ * @param {HTMLElement|string|Object} container
+ *
+ * @return {HTMLElement}
+ */
+function resolveContainer(container) {
+
+  // unwrap jQuery if provided
+  if (container.get && container.constructor.prototype.jquery) {
+    return container.get(0);
+  }
+
+  if (typeof container === 'string') {
+    return domQuery(container);
+  }
+
+  return container;
 }
 
 /**

--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -810,6 +810,179 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
   });
 
 
+  describe('separate header container', function() {
+
+    let headerContainer;
+
+    beforeEach(function() {
+      headerContainer = document.createElement('div');
+      headerContainer.classList.add('properties-header-container');
+
+      container.appendChild(headerContainer);
+    });
+
+
+    (singleStart === 'header' ? it.only : it)('should import simple process (separate header)', async function() {
+
+      // given
+      const diagramXml = require('test/fixtures/simple.bpmn').default;
+
+      propertiesContainer.remove();
+      headerContainer.remove();
+
+      const sidebar = domify(`
+        <div class="properties-container" style="display: flex; flex-direction: column;">
+          <div class="sandbox-header" style="flex: none;"></div>
+          <div class="sandbox-separator">separator</div>
+          <div class="sandbox-body" style="flex: 1; overflow: hidden;"></div>
+        </div>
+      `);
+
+      container.appendChild(sidebar);
+
+      const headerEl = domQuery('.sandbox-header', sidebar);
+      const bodyEl = domQuery('.sandbox-body', sidebar);
+
+      // when
+      const { modeler } = await createModeler(
+        diagramXml,
+        {
+          propertiesPanel: {},
+          additionalModules: [
+            ZeebeBehaviorsModule,
+            BpmnPropertiesPanel,
+            BpmnPropertiesProvider,
+            ZeebePropertiesProvider,
+            CreateAppendAnythingModule,
+            ZeebeVariableResolverModule
+          ],
+          moddleExtensions: {
+            zeebe: ZeebeModdle
+          },
+          tooltip: ZeebeTooltipProvider
+        }
+      );
+
+      const propertiesPanel = modeler.get('propertiesPanel');
+
+      await act(() => propertiesPanel.attachTo(bodyEl, headerEl));
+
+      // then
+      expect(domQuery('.bio-properties-panel-header', headerEl)).to.exist;
+    });
+
+
+    it('should render header into the separate container', async function() {
+
+      // given
+      const diagramXml = require('test/fixtures/simple.bpmn').default;
+
+      const { modeler } = await createModeler(diagramXml, {
+        propertiesPanel: {}
+      });
+
+      const propertiesPanel = modeler.get('propertiesPanel');
+
+      // when
+      await act(() => propertiesPanel.attachTo(propertiesContainer, headerContainer));
+
+      // then
+      expect(domQuery('.bio-properties-panel-header', headerContainer)).to.exist;
+      expect(domQuery('.bio-properties-panel-header', propertiesContainer)).to.not.exist;
+      expect(domQuery('.bio-properties-panel-scroll-container', propertiesContainer)).to.exist;
+    });
+
+
+    it('should render header inline without a header container', async function() {
+
+      // given
+      const diagramXml = require('test/fixtures/simple.bpmn').default;
+
+      const { modeler } = await createModeler(diagramXml, {
+        propertiesPanel: {}
+      });
+
+      const propertiesPanel = modeler.get('propertiesPanel');
+
+      // when
+      await act(() => propertiesPanel.attachTo(propertiesContainer));
+
+      // then
+      expect(domQuery('.bio-properties-panel-header', propertiesContainer)).to.exist;
+      expect(domQuery('.bio-properties-panel-header', headerContainer)).to.not.exist;
+    });
+
+
+    it('should throw if header container cannot be resolved', async function() {
+
+      // given
+      const diagramXml = require('test/fixtures/simple.bpmn').default;
+
+      const { modeler } = await createModeler(diagramXml, {
+        propertiesPanel: {}
+      });
+
+      const propertiesPanel = modeler.get('propertiesPanel');
+
+      // when
+      expect(() => propertiesPanel.attachTo(propertiesContainer, '.does-not-exist'))
+        .to.throw('header container not found');
+    });
+
+
+    it('should update separate header on selection change', async function() {
+
+      // given
+      const diagramXml = require('test/fixtures/simple.bpmn').default;
+
+      let modeler;
+      await act(async () => {
+        ({ modeler } = await createModeler(diagramXml, {
+          propertiesPanel: {}
+        }));
+      });
+
+      const propertiesPanel = modeler.get('propertiesPanel'),
+            selection = modeler.get('selection'),
+            elementRegistry = modeler.get('elementRegistry');
+
+      await act(() => propertiesPanel.attachTo(propertiesContainer, headerContainer));
+
+      // when
+      await act(() => selection.select(elementRegistry.get('StartEvent_1')));
+
+      // then
+      expect(getHeaderName(headerContainer)).to.eql('start');
+    });
+
+
+    it('should detach header container', async function() {
+
+      // given
+      const diagramXml = require('test/fixtures/simple.bpmn').default;
+
+      const { modeler } = await createModeler(diagramXml, {
+        propertiesPanel: {}
+      });
+
+      const propertiesPanel = modeler.get('propertiesPanel');
+
+      await act(() => propertiesPanel.attachTo(propertiesContainer, headerContainer));
+
+      // assume
+      expect(domQuery('.bio-properties-panel-header', headerContainer)).to.exist;
+
+      // when
+      propertiesPanel.detach();
+
+      // then
+      expect(domQuery('.bio-properties-panel-header', headerContainer)).to.not.exist;
+      expect(domQuery('.bio-properties-panel-scroll-container', propertiesContainer)).to.not.exist;
+    });
+
+  });
+
+
   it('#setLayout', async function() {
 
     // given


### PR DESCRIPTION
### Proposed Changes

Allow users to attach panel's header and body to separate containers via`attachTo(body, header)` to render panel's body and header into separate containers.

The default `attachTo(container)` still attaches everything into a single container.

Related to https://github.com/bpmn-io/internal-docs/issues/1294

### Try it

```
npm run start:header
```

<img width="334" height="284" alt="image" src="https://github.com/user-attachments/assets/381fc7bd-5e8a-40e2-8715-527853ec32e2" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
