### PR TITLE
feat(zeebe): add Business ID group for Call Activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ ___Note:__ Yet to be released changes appear here._
 ## 5.62.0
 
 * `FEAT`: add business ID group for Call Activities ([#1240](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1240))
+* `DEPS`: update to `zeebe-bpmn-moddle@1.17.0`
 
 ## 5.61.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+## 5.62.0
+
+* `FEAT`: add business ID group for Call Activities ([#1240](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1240))
+
 ## 5.61.0
 
 * `FEAT`: allow rendering the header into a separate container ([#1239](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1239))
@@ -114,7 +118,7 @@ _Pre-release._
 ## 5.47.0
 
 * `FIX`: change the tooltip content for the message property to be specific depens on event/task type ([#1181](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1181))
-* `DEPS`: update dependency `min-dash@5.0.0` 
+* `DEPS`: update dependency `min-dash@5.0.0`
 
 ## 5.46.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "sinon": "^22.0.0",
         "sinon-chai": "^4.0.0",
         "webpack": "^5.106.2",
-        "zeebe-bpmn-moddle": "^1.15.0"
+        "zeebe-bpmn-moddle": "^1.17.0"
       },
       "engines": {
         "node": "*"
@@ -10019,9 +10019,9 @@
       }
     },
     "node_modules/zeebe-bpmn-moddle": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.15.0.tgz",
-      "integrity": "sha512-C40qyX4q79lECM6JyEVGjBqDhgPgGf19T3waOPUtlW+ZuWXl/tvuAsrBwHhJssWbAFJAGYdJ9urPF80EijUmLg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.17.0.tgz",
+      "integrity": "sha512-b+0AKsY90Kg+ewf8fiI9gGQkHhcs/4RTkVtVpKwZMaWvq3GoeBEP91GKxbeOxan7cKD9yQinKazPFb0BSE5lew==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "sinon": "^22.0.0",
     "sinon-chai": "^4.0.0",
     "webpack": "^5.106.2",
-    "zeebe-bpmn-moddle": "^1.15.0"
+    "zeebe-bpmn-moddle": "^1.17.0"
   },
   "peerDependencies": {
     "@bpmn-io/properties-panel": ">= 3.42.0",

--- a/src/contextProvider/zeebe/TooltipProvider.js
+++ b/src/contextProvider/zeebe/TooltipProvider.js
@@ -323,6 +323,19 @@ const TooltipProvider = {
       </div>
     );
   },
+  'group-businessId': (element) => {
+    const translate = useService('translate');
+
+    return (
+      <div>
+        { translate('Control the business ID set on a child process. If left empty, no business ID will be set. ') }
+        <a href="https://docs.camunda.io/docs/components/modeler/bpmn/call-activities/#business-id-propagation" target="_blank" rel="noopener noreferrer" title={ translate('Business ID propagation documentation') }>
+          { translate('Learn more.') }
+        </a>
+      </div>
+    );
+  },
+
   'bindingType': (element) => {
 
     const translate = useService('translate');

--- a/src/provider/zeebe/ZeebePropertiesProvider.js
+++ b/src/provider/zeebe/ZeebePropertiesProvider.js
@@ -7,6 +7,7 @@ import {
   AdHocCompletionProps,
   AdHocSubProcessImplementationProps,
   AssignmentDefinitionProps,
+  BusinessIdProps,
   BusinessRuleImplementationProps,
   CalledDecisionProps,
   ConditionProps,
@@ -67,6 +68,7 @@ const ZEEBE_GROUPS = [
   ConditionGroup,
   EventConditionGroup,
   TargetGroup,
+  BusinessIdGroup,
   InputPropagationGroup,
   InputGroup,
   OutputPropagationGroup,
@@ -249,6 +251,20 @@ function TargetGroup(element, injector) {
     label: translate('Called element'),
     entries: [
       ...TargetProps({ element })
+    ],
+    component: Group
+  };
+
+  return group.entries.length ? group : null;
+}
+
+function BusinessIdGroup(element, injector) {
+  const translate = injector.get('translate');
+  const group = {
+    id: 'businessId',
+    label: translate('Business ID'),
+    entries: [
+      ...BusinessIdProps({ element })
     ],
     component: Group
   };

--- a/src/provider/zeebe/properties/BusinessIdProps.js
+++ b/src/provider/zeebe/properties/BusinessIdProps.js
@@ -1,0 +1,182 @@
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  isFeelEntryEdited,
+  isToggleSwitchEntryEdited,
+  ToggleSwitchEntry
+} from '@bpmn-io/properties-panel';
+
+import { useService } from '../../../hooks';
+
+import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
+
+import {
+  createElement
+} from '../../../utils/ElementUtil';
+
+import {
+  getBusinessId,
+  getCalledElement,
+  hasBusinessId
+} from '../utils/CalledElementUtil.js';
+
+/**
+ * Business ID configuration for a Call Activity. The child process instance
+ * either inherits the parent's Business ID (default) or overrides it with a
+ * literal value or FEEL expression.
+ */
+export function BusinessIdProps(props) {
+  const {
+    element
+  } = props;
+
+  if (!is(element, 'bpmn:CallActivity')) {
+    return [];
+  }
+
+  const entries = [
+    {
+      id: 'businessIdInherit',
+      component: InheritBusinessId,
+      isEdited: isToggleSwitchEntryEdited
+    }
+  ];
+
+  if (hasBusinessId(element)) {
+    entries.push({
+      id: 'businessId',
+      component: BusinessId,
+      isEdited: isFeelEntryEdited
+    });
+  }
+
+  return entries;
+}
+
+function InheritBusinessId(props) {
+  const {
+    element,
+    id
+  } = props;
+
+  const commandStack = useService('commandStack'),
+        bpmnFactory = useService('bpmnFactory'),
+        translate = useService('translate');
+
+  const inherit = !hasBusinessId(element);
+
+  const getValue = () => inherit;
+
+  const setValue = (value) => {
+
+    // (1) inherit -> remove override, otherwise -> add empty override (null Business ID)
+    const businessId = value ? undefined : '';
+
+    const commands = [];
+
+    const businessObject = getBusinessObject(element);
+
+    // (2) ensure extension elements
+    let extensionElements = businessObject.get('extensionElements');
+
+    if (!extensionElements) {
+      extensionElements = createElement(
+        'bpmn:ExtensionElements',
+        { values: [] },
+        businessObject,
+        bpmnFactory
+      );
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: businessObject,
+          properties: { extensionElements }
+        }
+      });
+    }
+
+    // (3) ensure zeebe:calledElement
+    let calledElement = getCalledElement(businessObject);
+
+    if (!calledElement) {
+      calledElement = createElement(
+        'zeebe:CalledElement',
+        {},
+        extensionElements,
+        bpmnFactory);
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: extensionElements,
+          properties: {
+            values: [ ...extensionElements.get('values'), calledElement ]
+          }
+        }
+      });
+    }
+
+    // (4) update businessId attribute
+    commands.push({
+      cmd: 'element.updateModdleProperties',
+      context: {
+        element,
+        moddleElement: calledElement,
+        properties: { businessId }
+      }
+    });
+
+    commandStack.execute('properties-panel.multi-command-executor', commands);
+  };
+
+  return ToggleSwitchEntry({
+    id,
+    label: translate('Inherit from parent'),
+    switcherLabel: inherit ? translate('On') : translate('Off'),
+    getValue,
+    setValue
+  });
+}
+
+function BusinessId(props) {
+  const {
+    element,
+    id
+  } = props;
+
+  const commandStack = useService('commandStack'),
+        translate = useService('translate'),
+        debounce = useService('debounceInput');
+
+  const getValue = () => getBusinessId(element);
+
+  const setValue = (value) => {
+
+    // this entry is only rendered once a Business ID override exists (cf.
+    // BusinessIdProps), so zeebe:CalledElement is guaranteed to be present
+    const calledElement = getCalledElement(getBusinessObject(element));
+
+    // keep empty string as null override, rather than removing it
+    commandStack.execute('element.updateModdleProperties', {
+      element,
+      moddleElement: calledElement,
+      properties: { businessId: value || '' }
+    });
+  };
+
+  return BpmnFeelEntry({
+    element,
+    id,
+    label: translate('Business ID'),
+    feel: 'optional',
+    getValue,
+    setValue,
+    debounce
+  });
+}

--- a/src/provider/zeebe/properties/index.js
+++ b/src/provider/zeebe/properties/index.js
@@ -2,6 +2,7 @@ export { ActiveElementsProps } from './ActiveElementsProps';
 export { AdHocCompletionProps } from './AdHocCompletionProps';
 export { AdHocSubProcessImplementationProps } from './AdHocSubProcessImplementationProps';
 export { AssignmentDefinitionProps } from './AssignmentDefinitionProps';
+export { BusinessIdProps } from './BusinessIdProps';
 export { BusinessRuleImplementationProps } from './BusinessRuleImplementationProps';
 export { CalledDecisionProps } from './CalledDecisionProps';
 export { ConditionProps } from './ConditionProps';

--- a/src/provider/zeebe/utils/CalledElementUtil.js
+++ b/src/provider/zeebe/utils/CalledElementUtil.js
@@ -31,6 +31,32 @@ export function getBindingType(element) {
   return calledElement ? calledElement.get('bindingType') : '';
 }
 
+/**
+ * Get the configured Business ID of the child process instance.
+ *
+ * @param {Object} element
+ *
+ * @returns {string|undefined} the Business ID override, or `undefined` when
+ * the Business ID is inherited from the parent
+ */
+export function getBusinessId(element) {
+  const calledElement = getCalledElement(element);
+
+  return calledElement ? calledElement.get('businessId') : undefined;
+}
+
+/**
+ * Check whether the Call Activity overrides the child's Business ID instead of
+ * inheriting it from the parent process instance.
+ *
+ * @param {Object} element
+ *
+ * @returns {boolean}
+ */
+export function hasBusinessId(element) {
+  return getBusinessId(element) !== undefined;
+}
+
 export function getCalledElement(element) {
   const calledElements = getCalledElements(element);
   return calledElements[0];

--- a/test/spec/provider/zeebe/BusinessIdProps.bpmn
+++ b/test/spec/provider/zeebe/BusinessIdProps.bpmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0businessId" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:callActivity id="CallActivity_inherit" name="CallActivity_inherit">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="someProcessId" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="CallActivity_override" name="CallActivity_override">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="someProcessId" businessId="=order.customerId" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="CallActivity_empty" name="CallActivity_empty">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="someProcessId" businessId="" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="CallActivity_literal" name="CallActivity_literal">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="someProcessId" businessId="order-42" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="CallActivity_noCalledElement" name="CallActivity_noCalledElement" />
+    <bpmn:task id="Task_1" name="Task_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="CallActivity_inherit_di" bpmnElement="CallActivity_inherit">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_override_di" bpmnElement="CallActivity_override">
+        <dc:Bounds x="160" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_empty_di" bpmnElement="CallActivity_empty">
+        <dc:Bounds x="160" y="320" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_literal_di" bpmnElement="CallActivity_literal">
+        <dc:Bounds x="160" y="440" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_noCalledElement_di" bpmnElement="CallActivity_noCalledElement">
+        <dc:Bounds x="160" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="160" y="680" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/zeebe/BusinessIdProps.spec.js
+++ b/test/spec/provider/zeebe/BusinessIdProps.spec.js
@@ -1,0 +1,300 @@
+import { expect } from 'chai';
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  act
+} from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  changeInput,
+  clickInput,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import {
+  getBusinessId,
+  hasBusinessId
+} from 'src/provider/zeebe/utils/CalledElementUtil.js';
+
+import BpmnPropertiesPanel from 'src/render';
+import CoreModule from 'bpmn-js/lib/core';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ZeebePropertiesProvider from 'src/provider/zeebe';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import diagramXML from './BusinessIdProps.bpmn';
+
+
+describe('provider/zeebe - BusinessIdProps', function() {
+
+  const testModules = [
+    BpmnPropertiesPanel,
+    CoreModule,
+    ModelingModule,
+    SelectionModule,
+    ZeebePropertiesProvider
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    modules: testModules,
+    moddleExtensions,
+    debounceInput: false
+  }));
+
+
+  describe('#businessIdInherit', function() {
+
+    it('should display for CallActivity', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_inherit');
+
+      // when
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      // then
+      const toggle = domQuery('[data-entry-id=businessIdInherit]', container);
+
+      expect(toggle).to.exist;
+    }));
+
+
+    it('should not display for non-CallActivity', inject(async function(elementRegistry, selection) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      await act(() => {
+        selection.select(task);
+      });
+
+      // then
+      const toggle = domQuery('[data-entry-id=businessIdInherit]', container);
+
+      expect(toggle).to.not.exist;
+    }));
+
+
+    it('should be on when Business ID is inherited', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_inherit');
+
+      // when
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      // then
+      const input = domQuery('#bio-properties-panel-businessIdInherit', container);
+
+      expect(input.checked).to.be.true;
+    }));
+
+
+    it('should be off when Business ID is overridden', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_override');
+
+      // when
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      // then
+      const input = domQuery('#bio-properties-panel-businessIdInherit', container);
+
+      expect(input.checked).to.be.false;
+    }));
+
+
+    it('should be off for empty (null) override', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_empty');
+
+      // when
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      // then
+      const input = domQuery('#bio-properties-panel-businessIdInherit', container);
+
+      expect(input.checked).to.be.false;
+    }));
+
+
+    it('should add empty override when toggled off', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_inherit');
+
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      // assume
+      expect(hasBusinessId(callActivity)).to.be.false;
+
+      // when
+      const slider = domQuery('[data-entry-id=businessIdInherit] .bio-properties-panel-toggle-switch__slider', container);
+
+      await act(() => {
+        clickInput(slider);
+      });
+
+      // then
+      expect(hasBusinessId(callActivity)).to.be.true;
+      expect(getBusinessId(callActivity)).to.equal('');
+    }));
+
+
+    it('should remove override when toggled on', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_override');
+
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      // assume
+      expect(hasBusinessId(callActivity)).to.be.true;
+
+      // when
+      const slider = domQuery('[data-entry-id=businessIdInherit] .bio-properties-panel-toggle-switch__slider', container);
+
+      await act(() => {
+        clickInput(slider);
+      });
+
+      // then
+      expect(hasBusinessId(callActivity)).to.be.false;
+    }));
+
+
+    it('should create zeebe:CalledElement when toggled off without one', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_noCalledElement');
+
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      // assume
+      expect(hasBusinessId(callActivity)).to.be.false;
+
+      // when
+      const slider = domQuery('[data-entry-id=businessIdInherit] .bio-properties-panel-toggle-switch__slider', container);
+
+      await act(() => {
+        clickInput(slider);
+      });
+
+      // then
+      expect(hasBusinessId(callActivity)).to.be.true;
+      expect(getBusinessId(callActivity)).to.equal('');
+    }));
+
+  });
+
+
+  describe('#businessId', function() {
+
+    it('should not display when Business ID is inherited', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_inherit');
+
+      // when
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      // then
+      const entry = domQuery('[data-entry-id=businessId]', container);
+
+      expect(entry).to.not.exist;
+    }));
+
+
+    it('should display when Business ID is overridden', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_override');
+
+      // when
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      // then
+      const entry = domQuery('[data-entry-id=businessId]', container);
+
+      expect(entry).to.exist;
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_empty');
+
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      const input = domQuery('input[name=businessId]', container);
+
+      // when
+      changeInput(input, 'order-42');
+
+      // then
+      expect(getBusinessId(callActivity)).to.equal('order-42');
+    }));
+
+
+    it('should keep empty string when cleared', inject(async function(elementRegistry, selection) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_literal');
+
+      await act(() => {
+        selection.select(callActivity);
+      });
+
+      const input = domQuery('input[name=businessId]', container);
+
+      // when
+      changeInput(input, '');
+
+      // then
+      expect(getBusinessId(callActivity)).to.equal('');
+    }));
+
+  });
+
+});


### PR DESCRIPTION
<img width="606" height="455" alt="image" src="https://github.com/user-attachments/assets/782e9de2-b801-453c-a548-4da691033eef" />
<img width="301" height="311" alt="image" src="https://github.com/user-attachments/assets/898027ee-b274-4e5c-bc3c-b58ba6dfa5f2" />

The documentation link will work for the release date.

Related to https://github.com/camunda/camunda-modeler/issues/5912

### Proposed Changes

🤖 

Adds a Business ID group to the zeebe provider for bpmn:CallActivity. An "Inherit from parent" toggle controls whether the child process instance inherits the parent's Business ID (default) or overrides it with a literal value or FEEL expression via a FEEL-optional field.

The override maps to the `businessId` attribute on zeebe:CalledElement: absent = inherit, present (incl. empty) = override.

Related to https://github.com/camunda/camunda-modeler/issues/5912

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
