### PR TITLE
feat: use number entry for priority and job priority

### DIFF
--- a/src/entries/BpmnFeelNumberEntry.js
+++ b/src/entries/BpmnFeelNumberEntry.js
@@ -1,0 +1,4 @@
+import { FeelNumberEntry } from '@bpmn-io/properties-panel';
+import { withTooltipContainer, withVariableContext } from '../provider/HOCs';
+
+export const BpmnFeelNumberEntry = withVariableContext(withTooltipContainer(FeelNumberEntry));

--- a/src/provider/zeebe/properties/JobPriorityDefinitionProps.js
+++ b/src/provider/zeebe/properties/JobPriorityDefinitionProps.js
@@ -17,7 +17,7 @@ import {
   useService
 } from '../../../hooks';
 
-import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
+import { BpmnFeelNumberEntry } from '../../../entries/BpmnFeelNumberEntry';
 
 import { isZeebeServiceTask } from '../utils/ZeebeServiceTaskUtil';
 
@@ -56,6 +56,8 @@ function Priority(props) {
 
   const setValue = (value) => {
     const commands = [];
+
+    const priority = typeof value === 'number' ? String(value) : value;
 
     const businessObject = getElementBusinessObject(element);
 
@@ -109,7 +111,7 @@ function Priority(props) {
       context: {
         element,
         moddleElement: jobPriorityDefinition,
-        properties: { priority: value }
+        properties: { priority }
       }
     });
 
@@ -117,7 +119,7 @@ function Priority(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return BpmnFeelEntry({
+  return BpmnFeelNumberEntry({
     element,
     id: 'jobPriorityDefinitionPriority',
     label: translate('Priority'),

--- a/src/provider/zeebe/properties/PriorityDefinitionProps.js
+++ b/src/provider/zeebe/properties/PriorityDefinitionProps.js
@@ -17,7 +17,7 @@ import {
   useService
 } from '../../../hooks';
 
-import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
+import { BpmnFeelNumberEntry } from '../../../entries/BpmnFeelNumberEntry';
 
 
 export function PriorityDefinitionProps(props) {
@@ -59,9 +59,11 @@ function Priority(props) {
 
     let extensionElements = businessObject.get('extensionElements');
 
+    const priority = typeof value === 'number' ? String(value) : value;
+
     // (1) ensure PriorityDefinition
     let priorityDefinition = getPriorityDefinition(element);
-    const isNullValue = value === null || value === '' || value === undefined;
+    const isNullValue = priority === null || priority === '' || priority === undefined;
 
     if (priorityDefinition && isNullValue) {
 
@@ -85,7 +87,7 @@ function Priority(props) {
         context: {
           element,
           moddleElement: priorityDefinition,
-          properties: { priority: value }
+          properties: { priority }
         }
       });
 
@@ -94,7 +96,7 @@ function Priority(props) {
       // (2c) create priority definition if it does not exist
       priorityDefinition = createElement(
         'zeebe:PriorityDefinition',
-        { priority: value },
+        { priority },
         extensionElements,
         bpmnFactory
       );
@@ -115,7 +117,7 @@ function Priority(props) {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  return BpmnFeelEntry({
+  return BpmnFeelNumberEntry({
     element,
     id: 'priorityDefinitionPriority',
     label: translate('Priority'),

--- a/test/spec/provider/zeebe/JobPriorityDefinitionProps.spec.js
+++ b/test/spec/provider/zeebe/JobPriorityDefinitionProps.spec.js
@@ -109,6 +109,26 @@ describe('provider/zeebe - JobPriorityDefinitionProps', function() {
     }));
 
 
+    it('should display number input for service task without FEEL expression', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('NoPriorityDefinition');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const entry = domQuery('[data-entry-id="jobPriorityDefinitionPriority"]', container);
+
+      // then
+      expect(entry).to.exist;
+
+      const input = domQuery('input[type="number"]', entry);
+      expect(input).to.exist;
+    }));
+
+
     it('should display for process', inject(async function(canvas, selection) {
 
       // given
@@ -183,7 +203,7 @@ describe('provider/zeebe - JobPriorityDefinitionProps', function() {
 
         // when
         const priorityInput = domQuery('input[name=jobPriorityDefinitionPriority]', container);
-        changeInput(priorityInput, 'newValue');
+        changeInput(priorityInput, '50');
 
         // then
         const jobPriorityDefinitionElement = getExtensionElementsList(getBusinessObject(serviceTask), 'zeebe:JobPriorityDefinition')[0];
@@ -207,11 +227,11 @@ describe('provider/zeebe - JobPriorityDefinitionProps', function() {
 
         // when
         const priorityInput = domQuery('input[name=jobPriorityDefinitionPriority]', container);
-        changeInput(priorityInput, 'newValue');
+        changeInput(priorityInput, '50');
 
         // then
         expect(getBusinessObject(process).get('extensionElements')).to.exist;
-        expect(getJobPriorityDefinition(process).get('priority')).to.eql('newValue');
+        expect(getJobPriorityDefinition(process).get('priority')).to.eql('50');
       })
     );
 
@@ -233,11 +253,11 @@ describe('provider/zeebe - JobPriorityDefinitionProps', function() {
 
         // when
         const priorityInput = domQuery('input[name=jobPriorityDefinitionPriority]', container);
-        changeInput(priorityInput, 'newValue');
+        changeInput(priorityInput, '50');
 
         // then
         const extensionElements = getBusinessObject(serviceTask).get('extensionElements');
-        expect(getJobPriorityDefinition(serviceTask).get('priority')).to.eql('newValue');
+        expect(getJobPriorityDefinition(serviceTask).get('priority')).to.eql('50');
         expect(extensionElements.values).to.have.length(initialExtensionElementsLength + 1);
       })
     );

--- a/test/spec/provider/zeebe/PriorityDefinitionProps.bpmn
+++ b/test/spec/provider/zeebe/PriorityDefinitionProps.bpmn
@@ -26,6 +26,12 @@
         <zeebe:priorityDefinition priority="=myPriorityValue" />
       </bpmn:extensionElements>
     </bpmn:userTask>
+    <bpmn:userTask id="UserTask_5" name="UserTask_5">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:priorityDefinition priority="myPriorityValue" />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_08jq0zy">
@@ -47,6 +53,10 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0zxgguv_di" bpmnElement="UserTask_4">
         <dc:Bounds x="280" y="180" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_03zg0n3_di" bpmnElement="UserTask_5">
+        <dc:Bounds x="400" y="180" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/spec/provider/zeebe/PriorityDefinitionProps.spec.js
+++ b/test/spec/provider/zeebe/PriorityDefinitionProps.spec.js
@@ -148,6 +148,24 @@ describe('provider/zeebe - PriorityDefinitionProps', function() {
     }));
 
 
+    it('should display empty number input for incorrect text priority', inject(async function(elementRegistry, selection) {
+
+      // given
+      const userTask = elementRegistry.get('UserTask_5');
+
+      await act(() => {
+        selection.select(userTask);
+      });
+
+      // when
+      const input = domQuery('[data-entry-id="priorityDefinitionPriority"] input[type="number"]', container);
+
+      // then
+      expect(input).to.exist;
+      expect(input.value).to.equal('');
+    }));
+
+
     it('should update', inject(async function(elementRegistry, selection) {
 
       // given

--- a/test/spec/provider/zeebe/PriorityDefinitionProps.spec.js
+++ b/test/spec/provider/zeebe/PriorityDefinitionProps.spec.js
@@ -128,6 +128,26 @@ describe('provider/zeebe - PriorityDefinitionProps', function() {
     }));
 
 
+    it('should display number input for user task without FEEL expression', inject(async function(elementRegistry, selection) {
+
+      // given
+      const userTask = elementRegistry.get('UserTask_2');
+
+      await act(() => {
+        selection.select(userTask);
+      });
+
+      // when
+      const entry = domQuery('[data-entry-id="priorityDefinitionPriority"]', container);
+
+      // then
+      expect(entry).to.exist;
+
+      const input = domQuery('input[type="number"]', entry);
+      expect(input).to.exist;
+    }));
+
+
     it('should update', inject(async function(elementRegistry, selection) {
 
       // given
@@ -187,7 +207,7 @@ describe('provider/zeebe - PriorityDefinitionProps', function() {
 
         // when
         const priorityInput = domQuery('input[name=priorityDefinitionPriority]', container);
-        changeInput(priorityInput, 'newValue');
+        changeInput(priorityInput, '50');
 
         // then
         const priorityDefinitionElement = getExtensionElementsList(getBusinessObject(userTask), 'zeebe:PriorityDefinition')[0];
@@ -212,11 +232,11 @@ describe('provider/zeebe - PriorityDefinitionProps', function() {
 
         // when
         const priorityInput = domQuery('input[name=priorityDefinitionPriority]', container);
-        changeInput(priorityInput, 'newValue');
+        changeInput(priorityInput, '50');
 
         // then
         const extensionElements = getBusinessObject(userTask).get('extensionElements');
-        expect(getPriorityDefinition(userTask).get('priority')).to.eql('newValue');
+        expect(getPriorityDefinition(userTask).get('priority')).to.eql('50');
         expect(extensionElements.values).to.have.length(3);
       })
     );


### PR DESCRIPTION
### Proposed Changes

This PR changes the user task priority and job priority entries to use number input with optional FEEL. A plain string input is never correct, so there's no good reason to allow the users to type it.

https://github.com/user-attachments/assets/a3e6d9aa-0cda-491c-82d5-f64bd42c23a1



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
