### PR TITLE
feat: add propertiesPanel#getEntryId(element, path) API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to [bpmn-js-properties-panel](https://github.com/bpmn-io/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: add `propertiesPanel#getEntryId(element, path)` API to resolve a moddle property path to an entry id
 * `FEAT`: use `number` input for `priority` and `jobPriority` ([#1241](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1241))
 
 ## 5.62.0

--- a/README.md
+++ b/README.md
@@ -160,6 +160,19 @@ class ExamplePropertiesProvider {
 ExamplePropertiesProvider.$inject = [ 'propertiesPanel' ];
 ```
 
+#### `BpmnPropertiesPanelRenderer#getEntryId(element: djs.model.Base, path: Array<string|number>) => string|null`
+
+Resolve the id of the entry that edits the given moddle property path, relative to the element's business object. Providers may implement `getEntryId(element, path)` to resolve paths for the groups they contribute; they are asked in reverse render order, so a provider whose groups render last (e.g. one registered with a low priority to override others) is asked first.
+
+```javascript
+const propertiesPanel = modeler.get('propertiesPanel');
+
+const entryId = propertiesPanel.getEntryId(element, [
+  'extensionElements', 'values', 0, 'inputParameters', 1, 'source'
+]);
+// 'ServiceTask_1-input-1-source'
+```
+
 ## Additional Resources
 
 * [Issue tracker](https://github.com/bpmn-io/bpmn-js-properties-panel)

--- a/src/provider/bpmn/BpmnPropertiesProvider.js
+++ b/src/provider/bpmn/BpmnPropertiesProvider.js
@@ -1,5 +1,7 @@
 import { Group } from '@bpmn-io/properties-panel';
 
+import { getBpmnEntryId } from './utils/EntryIdUtil';
+
 import {
   AdHocCompletionProps,
   CompensationProps,
@@ -246,6 +248,19 @@ export default class BpmnPropertiesProvider {
       groups = groups.concat(getGroups(element, this._injector));
       return groups;
     };
+  }
+
+  /**
+   * Resolve a moddle location rendered by this (standard bpmn) provider to its
+   * entry id, so consumers like linting can stay render-agnostic.
+   *
+   * @param {djs.model.Base} element
+   * @param {Array<string|number>} path moddle path, relative to the element's business object
+   *
+   * @return {string|null}
+   */
+  getEntryId(element, path) {
+    return getBpmnEntryId(element, path);
   }
 
 }

--- a/src/provider/bpmn/utils/EntryIdUtil.js
+++ b/src/provider/bpmn/utils/EntryIdUtil.js
@@ -1,0 +1,36 @@
+import { isArray } from 'min-dash';
+
+/**
+ * Resolve a moddle location on an element to the standard bpmn entry id this
+ * provider renders for it.
+ *
+ * The location is a moddle `path` (as produced by `getPath` from
+ * `@bpmn-io/moddle-utils`) rooted at the element's business object — the same
+ * shape lint rules report. Scoped to the properties the bpmn (standard)
+ * provider owns; mirrors the zeebe provider's resolver.
+ *
+ * Returns `null` when the location is not rendered by a standard bpmn entry (so
+ * the caller can defer to another provider or its own fallback).
+ *
+ * @param {djs.model.Base|ModdleElement} element
+ * @param {Array<string|number>} path
+ *
+ * @return {string|null}
+ */
+export function getBpmnEntryId(element, path) {
+  if (!element || !isArray(path) || !path.length) {
+    return null;
+  }
+
+  const property = path[ path.length - 1 ];
+
+  // element documentation (DocumentationProps). A finding points at the
+  // `documentation` property — the best-effort element-level anchor a rule
+  // emits when documentation text is missing — which the group renders as the
+  // `documentation` entry (always present, regardless of element type).
+  if (property === 'documentation') {
+    return 'documentation';
+  }
+
+  return null;
+}

--- a/src/provider/camunda-platform/CamundaPlatformPropertiesProvider.js
+++ b/src/provider/camunda-platform/CamundaPlatformPropertiesProvider.js
@@ -44,6 +44,8 @@ import {
 
 import { ExtensionPropertiesProps } from '../shared/ExtensionPropertiesProps';
 
+import { getCamundaPlatformEntryId } from './utils/EntryIdUtil';
+
 { /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
 
 const LOW_PRIORITY = 500;
@@ -138,6 +140,18 @@ export default class CamundaPlatformPropertiesProvider {
 
     // contract: if a group returns null, it should not be displayed at all
     return groups.filter(group => group !== null);
+  }
+
+  /**
+   * Resolve the id of the entry that edits the given moddle property path.
+   *
+   * @param {djs.model.Base} element
+   * @param {(string|number)[]} path moddle property path, relative to the element's business object
+   *
+   * @return {string|null}
+   */
+  getEntryId(element, path) {
+    return getCamundaPlatformEntryId(element, path);
   }
 }
 

--- a/src/provider/camunda-platform/properties/HistoryCleanupProps.js
+++ b/src/provider/camunda-platform/properties/HistoryCleanupProps.js
@@ -9,6 +9,8 @@ import {
   useService
 } from '../../../hooks';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 
 export function HistoryCleanupProps(props) {
   const {
@@ -24,7 +26,7 @@ export function HistoryCleanupProps(props) {
 
   return [
     {
-      id: 'historyTimeToLive',
+      id: getSingletonEntryId('bpmn:Process', 'historyTimeToLive'),
       component: HistoryTimeToLive,
       isEdited: isTextFieldEntryEdited
     },
@@ -56,7 +58,7 @@ function HistoryTimeToLive(props) {
 
   return TextFieldEntry({
     element,
-    id: 'historyTimeToLive',
+    id: getSingletonEntryId('bpmn:Process', 'historyTimeToLive'),
     label: translate('Time to live'),
     getValue,
     setValue,

--- a/src/provider/camunda-platform/utils/EntryIdUtil.js
+++ b/src/provider/camunda-platform/utils/EntryIdUtil.js
@@ -1,0 +1,74 @@
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import { isArray } from 'min-dash';
+
+/**
+ * Entry id schemes for moddle elements that are rendered as static
+ * (non-list) entries, keyed by moddle `$type` and moddle property name.
+ */
+const SINGLETON_ENTRY_SCHEMES = {
+  'bpmn:Process': {
+    historyTimeToLive: 'historyTimeToLive'
+  }
+};
+
+/**
+ * Resolve the id of a static (non-list) entry that edits the given moddle
+ * property. This is the single source for the id scheme: it is used both
+ * to render the entry and to resolve it.
+ *
+ * @param {string} type the moddle `$type` of the edited element
+ * @param {string} property the edited moddle property
+ *
+ * @return {string|null}
+ */
+export function getSingletonEntryId(type, property) {
+  const scheme = SINGLETON_ENTRY_SCHEMES[type];
+
+  return scheme && scheme[property] || null;
+}
+
+/**
+ * Resolve a moddle location on an element to the Camunda 7 (platform) entry id
+ * this provider renders for it.
+ *
+ * The location is a moddle `path` (as produced by `getPath` from
+ * `@bpmn-io/moddle-utils`) rooted at the element's business object — the same
+ * shape lint rules report. Scoped to the properties the camunda-platform
+ * provider owns; mirrors the zeebe and bpmn providers' resolvers.
+ *
+ * Returns `null` when the location is not rendered by a camunda-platform entry
+ * (so the caller can defer to another provider or its own fallback).
+ *
+ * @param {djs.model.Base} element
+ * @param {(string|number)[]} path
+ *
+ * @return {string|null}
+ */
+export function getCamundaPlatformEntryId(element, path) {
+  if (!element || !isArray(path) || !path.length) {
+    return null;
+  }
+
+  const field = path[path.length - 1];
+
+  if (typeof field !== 'string') {
+    return null;
+  }
+
+  let node = getBusinessObject(element);
+
+  // walk all but the last segment to the node that owns the edited property
+  // (e.g. a bpmn:Participant's `processRef` points at the bpmn:Process)
+  for (let i = 0; i < path.length - 1 && node; i++) {
+    const segment = path[i];
+
+    node = typeof segment === 'number' ? node[segment] : node.get(segment);
+  }
+
+  if (!node) {
+    return null;
+  }
+
+  return getSingletonEntryId(node.$type, field);
+}

--- a/src/provider/zeebe/ZeebePropertiesProvider.js
+++ b/src/provider/zeebe/ZeebePropertiesProvider.js
@@ -46,6 +46,8 @@ import {
   isZeebeServiceTask
 } from './utils/ZeebeServiceTaskUtil';
 
+import { getZeebeEntryId } from './utils/EntryIdUtil';
+
 /**
  * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
@@ -115,6 +117,18 @@ export default class ZeebePropertiesProvider {
     const groups = ZEEBE_GROUPS.map(createGroup => createGroup(element, this._injector));
 
     return groups.filter(group => group !== null);
+  }
+
+  /**
+   * Resolve the id of the entry that edits the given moddle property path.
+   *
+   * @param {djs.model.Base} element
+   * @param {(string|number)[]} path moddle property path, relative to the element's business object
+   *
+   * @return {string|null}
+   */
+  getEntryId(element, path) {
+    return getZeebeEntryId(element, path);
   }
 
 }

--- a/src/provider/zeebe/properties/ActiveElementsProps.js
+++ b/src/provider/zeebe/properties/ActiveElementsProps.js
@@ -18,6 +18,8 @@ import {
 
 import { createElement } from '../../../utils/ElementUtil';
 
+import { getSingletonEntryId, SELECTOR_ENTRY_IDS } from '../utils/EntryIdUtil';
+
 export function ActiveElementsProps(props) {
   const {
     element
@@ -29,7 +31,7 @@ export function ActiveElementsProps(props) {
 
   const entries = [
     {
-      id: 'activeElementsCollection',
+      id: getSingletonEntryId('zeebe:AdHoc', 'activeElementsCollection'),
       component: ActiveElementsCollection,
       isEdited: isFeelEntryEdited
     }
@@ -58,7 +60,7 @@ function ActiveElementsCollection(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'activeElements-activeElementsCollection',
+    id: SELECTOR_ENTRY_IDS.activeElementsCollectionValue,
     label: translate('Active elements collection'),
     feel: 'required',
     getValue,

--- a/src/provider/zeebe/properties/ActiveElementsProps.js
+++ b/src/provider/zeebe/properties/ActiveElementsProps.js
@@ -18,7 +18,7 @@ import {
 
 import { createElement } from '../../../utils/ElementUtil';
 
-import { getSingletonEntryId, SELECTOR_ENTRY_IDS } from '../utils/EntryIdUtil';
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
 
 export function ActiveElementsProps(props) {
   const {
@@ -60,7 +60,7 @@ function ActiveElementsCollection(props) {
 
   return BpmnFeelEntry({
     element,
-    id: SELECTOR_ENTRY_IDS.activeElementsCollectionValue,
+    id: getSingletonEntryId('zeebe:AdHoc', 'activeElementsCollection'),
     label: translate('Active elements collection'),
     feel: 'required',
     getValue,

--- a/src/provider/zeebe/properties/AdHocCompletionProps.js
+++ b/src/provider/zeebe/properties/AdHocCompletionProps.js
@@ -8,6 +8,8 @@ import { useService } from '../../../hooks';
 import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
 import { createOrUpdateFormalExpression } from '../../../utils/FormalExpressionUtil';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 /**
  * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
@@ -24,7 +26,7 @@ export function AdHocCompletionProps(props) {
 
   return [
     {
-      id: 'completionCondition',
+      id: getSingletonEntryId('bpmn:AdHocSubProcess', 'completionCondition'),
       component: CompletionCondition,
       isEdited: isFeelEntryEdited,
     }
@@ -57,7 +59,7 @@ function CompletionCondition(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'completionCondition',
+    id: getSingletonEntryId('bpmn:AdHocSubProcess', 'completionCondition'),
     label: translate('Completion condition'),
     feel: 'required',
     getValue,

--- a/src/provider/zeebe/properties/AdHocSubProcessImplementationProps.js
+++ b/src/provider/zeebe/properties/AdHocSubProcessImplementationProps.js
@@ -20,6 +20,8 @@ import {
 
 import { useService } from '../../../hooks';
 
+import { SELECTOR_ENTRY_IDS } from '../utils/EntryIdUtil';
+
 export const BPMN_IMPLEMENTATION_OPTION = 'bpmn',
       JOB_WORKER_IMPLEMENTATION_OPTION = 'jobWorker';
 
@@ -35,7 +37,7 @@ export function AdHocSubProcessImplementationProps(props) {
 
   return [
     {
-      id: 'adHocImplementation',
+      id: SELECTOR_ENTRY_IDS.adHocImplementation,
       component: AdHocImplementation,
       isEdited: () => isAdHocImplementationEdited(element)
     }

--- a/src/provider/zeebe/properties/AssignmentDefinitionProps.js
+++ b/src/provider/zeebe/properties/AssignmentDefinitionProps.js
@@ -19,6 +19,8 @@ import {
 
 import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 
 export function AssignmentDefinitionProps(props) {
   const {
@@ -31,17 +33,17 @@ export function AssignmentDefinitionProps(props) {
 
   return [
     {
-      id: 'assignmentDefinitionAssignee',
+      id: getSingletonEntryId('zeebe:AssignmentDefinition', 'assignee'),
       component: Assignee,
       isEdited: isFeelEntryEdited
     },
     {
-      id: 'assignmentDefinitionCandidateGroups',
+      id: getSingletonEntryId('zeebe:AssignmentDefinition', 'candidateGroups'),
       component: CandidateGroups,
       isEdited: isFeelEntryEdited
     },
     {
-      id: 'assignmentDefinitionCandidateUsers',
+      id: getSingletonEntryId('zeebe:AssignmentDefinition', 'candidateUsers'),
       component: CandidateUsers,
       isEdited: isFeelEntryEdited
     }
@@ -127,7 +129,7 @@ function Assignee(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'assignmentDefinitionAssignee',
+    id: getSingletonEntryId('zeebe:AssignmentDefinition', 'assignee'),
     label: translate('Assignee'),
     feel: 'optional',
     getValue,
@@ -214,7 +216,7 @@ function CandidateGroups(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'assignmentDefinitionCandidateGroups',
+    id: getSingletonEntryId('zeebe:AssignmentDefinition', 'candidateGroups'),
     label: translate('Candidate groups'),
     feel: 'optional',
     getValue,
@@ -301,7 +303,7 @@ function CandidateUsers(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'assignmentDefinitionCandidateUsers',
+    id: getSingletonEntryId('zeebe:AssignmentDefinition', 'candidateUsers'),
     label: translate('Candidate users'),
     feel: 'optional',
     getValue,

--- a/src/provider/zeebe/properties/BusinessIdProps.js
+++ b/src/provider/zeebe/properties/BusinessIdProps.js
@@ -23,6 +23,8 @@ import {
   hasBusinessId
 } from '../utils/CalledElementUtil.js';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 /**
  * Business ID configuration for a Call Activity. The child process instance
  * either inherits the parent's Business ID (default) or overrides it with a
@@ -47,7 +49,7 @@ export function BusinessIdProps(props) {
 
   if (hasBusinessId(element)) {
     entries.push({
-      id: 'businessId',
+      id: getSingletonEntryId('zeebe:CalledElement', 'businessId'),
       component: BusinessId,
       isEdited: isFeelEntryEdited
     });

--- a/src/provider/zeebe/properties/BusinessRuleImplementationProps.js
+++ b/src/provider/zeebe/properties/BusinessRuleImplementationProps.js
@@ -24,6 +24,8 @@ import { useService } from '../../../hooks';
 
 import { without } from 'min-dash';
 
+import { SELECTOR_ENTRY_IDS } from '../utils/EntryIdUtil';
+
 { /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
 
 export const DMN_IMPLEMENTATION_OPTION = 'dmn',
@@ -42,7 +44,7 @@ export function BusinessRuleImplementationProps(props) {
 
   return [
     {
-      id: 'businessRuleImplementation',
+      id: SELECTOR_ENTRY_IDS.businessRuleImplementation,
       component: BusinessRuleImplementation,
       isEdited: () => isBusinessRuleImplementationEdited(element)
     }

--- a/src/provider/zeebe/properties/CalledDecisionProps.js
+++ b/src/provider/zeebe/properties/CalledDecisionProps.js
@@ -23,6 +23,8 @@ import {
 
 import { useService } from '../../../hooks';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
 
 import { withProps } from '../../HOCs/withProps.js';
@@ -42,12 +44,12 @@ export function CalledDecisionProps(props) {
 
   const entries = [
     {
-      id: 'decisionId',
+      id: getSingletonEntryId('zeebe:CalledDecision', 'decisionId'),
       component: DecisionID,
       isEdited: isFeelEntryEdited
     },
     {
-      id: 'bindingType',
+      id: getSingletonEntryId('zeebe:CalledDecision', 'bindingType'),
       component: CalledDecisionBinding,
       isEdited: isSelectEntryEdited
     }
@@ -55,14 +57,14 @@ export function CalledDecisionProps(props) {
 
   if (getBindingType(element, 'zeebe:CalledDecision') === 'versionTag') {
     entries.push({
-      id: 'versionTag',
+      id: getSingletonEntryId('zeebe:CalledDecision', 'versionTag'),
       component: CalledDecisionVersionTag,
       isEdited: isFeelEntryEdited
     });
   }
 
   entries.push({
-    id: 'resultVariable',
+    id: getSingletonEntryId('zeebe:CalledDecision', 'resultVariable'),
     component: ResultVariable,
     isEdited: isTextFieldEntryEdited
   });

--- a/src/provider/zeebe/properties/ConditionProps.js
+++ b/src/provider/zeebe/properties/ConditionProps.js
@@ -23,6 +23,8 @@ import { isFeelEntryEdited } from '@bpmn-io/properties-panel';
 
 import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 
 export function ConditionProps(props) {
   const {
@@ -37,7 +39,7 @@ export function ConditionProps(props) {
 
   if (isConditionalSource(element.source)) {
     conditionProps.push({
-      id: 'conditionExpression',
+      id: getSingletonEntryId('bpmn:SequenceFlow', 'conditionExpression'),
       component: ConditionExpression,
       isEdited: isFeelEntryEdited
     });
@@ -109,7 +111,7 @@ function ConditionExpression(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'conditionExpression',
+    id: getSingletonEntryId('bpmn:SequenceFlow', 'conditionExpression'),
     label: translate('Condition expression'),
     feel: 'required',
     getValue,

--- a/src/provider/zeebe/properties/ErrorProps.js
+++ b/src/provider/zeebe/properties/ErrorProps.js
@@ -15,6 +15,8 @@ import {
 
 import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 
 export function ErrorProps(props) {
   const {
@@ -28,7 +30,7 @@ export function ErrorProps(props) {
   if (error && is(element, 'bpmn:ThrowEvent')) {
     entries.push(
       {
-        id: 'errorCode',
+        id: getSingletonEntryId('bpmn:Error', 'errorCode'),
         component: ErrorCode,
         isEdited: isFeelEntryEdited
       }
@@ -67,7 +69,7 @@ function ErrorCode(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'errorCode',
+    id: getSingletonEntryId('bpmn:Error', 'errorCode'),
     label: translate('Code'),
     feel: 'optional',
     getValue,

--- a/src/provider/zeebe/properties/EscalationProps.js
+++ b/src/provider/zeebe/properties/EscalationProps.js
@@ -16,6 +16,8 @@ import {
 
 import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 
 /**
  * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
@@ -41,7 +43,7 @@ export function EscalationProps(props) {
   if (escalation) {
     entries.push(
       {
-        id: 'escalationCode',
+        id: getSingletonEntryId('bpmn:Escalation', 'escalationCode'),
         component: EscalationCode,
         isEdited: isFeelEntryEdited
       }
@@ -79,7 +81,7 @@ function EscalationCode(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'escalationCode',
+    id: getSingletonEntryId('bpmn:Escalation', 'escalationCode'),
     label: translate('Code'),
     feel: 'optional',
     getValue,

--- a/src/provider/zeebe/properties/EventConditionProps.js
+++ b/src/provider/zeebe/properties/EventConditionProps.js
@@ -27,6 +27,8 @@ import {
   setConditionalEventConditionBody
 } from '../../../utils/ConditionUtil';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 /**
  * Properties of a Conditional Start Event:
  *
@@ -44,7 +46,7 @@ export function EventConditionProps(props) {
 
   const entries = [
     {
-      id: 'condition',
+      id: getSingletonEntryId('bpmn:ConditionalEventDefinition', 'condition'),
       component: Condition,
       isEdited: isFeelEntryEdited
     }
@@ -56,7 +58,7 @@ export function EventConditionProps(props) {
     is(element, 'bpmn:BoundaryEvent'))
   {
     entries.push({
-      id: 'variableEvents',
+      id: getSingletonEntryId('zeebe:ConditionalFilter', 'variableEvents'),
       component: VariableEvents,
     });
   }
@@ -87,7 +89,7 @@ function Condition(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'condition',
+    id: getSingletonEntryId('bpmn:ConditionalEventDefinition', 'condition'),
     label: translate('Condition expression'),
     feel: 'required',
     getValue,
@@ -126,7 +128,7 @@ function VariableEvents(props) {
 
   return CheckboxGroup({
     element,
-    id: 'variableEvents',
+    id: getSingletonEntryId('zeebe:ConditionalFilter', 'variableEvents'),
     options: [
       { label: translate('Create'), value: VARIABLE_EVENTS.CREATE },
       { label: translate('Update'), value: VARIABLE_EVENTS.UPDATE }

--- a/src/provider/zeebe/properties/ExecutionListenerHeaderProps.js
+++ b/src/provider/zeebe/properties/ExecutionListenerHeaderProps.js
@@ -18,6 +18,8 @@ import {
   useService
 } from '../../../hooks';
 
+import { getListEntryId } from '../utils/EntryIdUtil';
+
 /**
  * @typedef {import('bpmn-js/lib/model/Types').ModdleElement} ModdleElement
  */
@@ -41,7 +43,7 @@ function HeaderItem(props) {
     open
   } = props;
 
-  const headerId = `${ idPrefix }-header-${ index }`;
+  const headerId = getListEntryId(idPrefix, header, index);
 
   const HeaderEntries = Header({
     idPrefix: headerId,

--- a/src/provider/zeebe/properties/ExecutionListenersProps.js
+++ b/src/provider/zeebe/properties/ExecutionListenersProps.js
@@ -20,6 +20,8 @@ import {
   getCompensateEventDefinition
 } from '../../../utils/EventDefinitionUtil';
 
+import { getListEntryId } from '../utils/EntryIdUtil';
+
 { /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
 
 
@@ -44,7 +46,7 @@ export function ExecutionListenersProps({ element, injector }) {
         translate = injector.get('translate');
 
   const items = listeners.map((listener, index) => {
-    const id = element.id + '-executionListener-' + index;
+    const id = getListEntryId(element, listener, index);
     const type = listener.get('type') || '<no type>';
 
     return {

--- a/src/provider/zeebe/properties/FormProps.js
+++ b/src/provider/zeebe/properties/FormProps.js
@@ -41,6 +41,8 @@ import {
 
 import { withProps } from '../../HOCs';
 
+import { getSingletonEntryId, SELECTOR_ENTRY_IDS } from '../utils/EntryIdUtil';
+
 { /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
 
 const FormDefinitionBinding = withProps(Binding, { type: 'zeebe:FormDefinition' }),
@@ -60,32 +62,32 @@ export function FormProps(props) {
   const formType = getFormType(element);
 
   const entries = [ {
-    id: 'formType',
+    id: SELECTOR_ENTRY_IDS.formType,
     component: FormType,
     isEdited: node => node.value !== NONE_VALUE
   } ];
 
   if (formType === FORM_TYPES.CAMUNDA_FORM_EMBEDDED) {
     entries.push({
-      id: 'formConfiguration',
+      id: getSingletonEntryId('zeebe:UserTaskForm', 'body'),
       component: FormConfiguration,
       isEdited: isTextAreaEntryEdited
     });
   } else if (formType === FORM_TYPES.CAMUNDA_FORM_LINKED) {
     entries.push({
-      id: 'formId',
+      id: getSingletonEntryId('zeebe:FormDefinition', 'formId'),
       component: FormId,
       isEdited: isTextFieldEntryEdited
     });
   } else if (formType === FORM_TYPES.CUSTOM_FORM) {
     entries.push({
-      id: 'customFormKey',
+      id: getSingletonEntryId('zeebe:FormDefinition', 'formKey'),
       component: CustomForm,
       isEdited: isTextFieldEntryEdited
     });
   } else if (formType === FORM_TYPES.EXTERNAL_REFERENCE) {
     entries.push({
-      id: 'externalReference',
+      id: getSingletonEntryId('zeebe:FormDefinition', 'externalReference'),
       component: ExternalReference,
       isEdited: isFeelEntryEdited
     });
@@ -94,14 +96,14 @@ export function FormProps(props) {
   // Binding and version tag are not supported for start events
   if (!isStartEvent && formType === FORM_TYPES.CAMUNDA_FORM_LINKED) {
     entries.push({
-      id: 'bindingType',
+      id: getSingletonEntryId('zeebe:FormDefinition', 'bindingType'),
       component: FormDefinitionBinding,
       isEdited: isSelectEntryEdited
     });
 
     if (getBindingType(element, 'zeebe:FormDefinition') === 'versionTag') {
       entries.push({
-        id: 'versionTag',
+        id: getSingletonEntryId('zeebe:FormDefinition', 'versionTag'),
         component: FormDefinitionVersionTag,
         isEdited: isTextFieldEntryEdited
       });
@@ -132,7 +134,7 @@ function FormType(props) {
 
   return SelectEntry({
     element,
-    id: 'formType',
+    id: SELECTOR_ENTRY_IDS.formType,
     label: translate('Type'),
     getValue,
     setValue,
@@ -197,7 +199,7 @@ function FormConfiguration(props) {
 
   return TextAreaEntry({
     element,
-    id: 'formConfiguration',
+    id: getSingletonEntryId('zeebe:UserTaskForm', 'body'),
     label: translate('Form JSON configuration'),
     rows: 4,
     getValue,
@@ -224,7 +226,7 @@ function FormId(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'formId',
+    id: getSingletonEntryId('zeebe:FormDefinition', 'formId'),
     label: translate('Form ID'),
     feel: 'optional',
     getValue,
@@ -251,7 +253,7 @@ function CustomForm(props) {
 
   return TextFieldEntry({
     element,
-    id: 'customFormKey',
+    id: getSingletonEntryId('zeebe:FormDefinition', 'formKey'),
     label: translate('Custom form key'),
     getValue,
     setValue,
@@ -277,7 +279,7 @@ function ExternalReference(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'externalReference',
+    id: getSingletonEntryId('zeebe:FormDefinition', 'externalReference'),
     label: translate('External form reference'),
     feel: 'optional',
     getValue,

--- a/src/provider/zeebe/properties/HeaderProps.js
+++ b/src/provider/zeebe/properties/HeaderProps.js
@@ -14,6 +14,8 @@ import {
   createElement
 } from '../../../utils/ElementUtil';
 
+import { getListEntryId } from '../utils/EntryIdUtil';
+
 import { without } from 'min-dash';
 
 
@@ -29,7 +31,7 @@ export function HeaderProps({ element, injector }) {
         commandStack = injector.get('commandStack');
 
   const items = headers.map((header, index) => {
-    const id = element.id + '-header-' + index;
+    const id = getListEntryId(element, header, index);
 
     return {
       id,

--- a/src/provider/zeebe/properties/InputPropagationProps.js
+++ b/src/provider/zeebe/properties/InputPropagationProps.js
@@ -21,6 +21,8 @@ import {
 
 import { ToggleSwitchEntry, isToggleSwitchEntryEdited } from '@bpmn-io/properties-panel';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 { /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
 
 
@@ -35,7 +37,7 @@ export function InputPropagationProps(props) {
 
   return [
     {
-      id: 'propagateAllParentVariables',
+      id: getSingletonEntryId('zeebe:CalledElement', 'propagateAllParentVariables'),
       component: PropagateAllParentVariables,
       isEdited: isToggleSwitchEntryEdited
     }
@@ -123,7 +125,7 @@ function PropagateAllParentVariables(props) {
   };
 
   return ToggleSwitchEntry({
-    id: 'propagateAllParentVariables',
+    id: getSingletonEntryId('zeebe:CalledElement', 'propagateAllParentVariables'),
     label: translate('Propagate all parent process variables'),
     switcherLabel: propagateAllParentVariables ?
       translate('On') :

--- a/src/provider/zeebe/properties/InputProps.js
+++ b/src/provider/zeebe/properties/InputProps.js
@@ -16,6 +16,8 @@ import {
   nextId
 } from '../../../utils/ElementUtil';
 
+import { getListEntryId } from '../utils/EntryIdUtil';
+
 import { without } from 'min-dash';
 
 
@@ -31,7 +33,7 @@ export function InputProps({ element, injector }) {
         commandStack = injector.get('commandStack');
 
   const items = inputParameters.map((parameter, index) => {
-    const id = element.id + '-input-' + index;
+    const id = getListEntryId(element, parameter, index);
 
     return {
       id,

--- a/src/provider/zeebe/properties/JobPriorityDefinitionProps.js
+++ b/src/provider/zeebe/properties/JobPriorityDefinitionProps.js
@@ -21,6 +21,8 @@ import { BpmnFeelNumberEntry } from '../../../entries/BpmnFeelNumberEntry';
 
 import { isZeebeServiceTask } from '../utils/ZeebeServiceTaskUtil';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 
 export function JobPriorityDefinitionProps(props) {
   const {
@@ -33,7 +35,7 @@ export function JobPriorityDefinitionProps(props) {
 
   return [
     {
-      id: 'jobPriorityDefinitionPriority',
+      id: getSingletonEntryId('zeebe:JobPriorityDefinition', 'priority'),
       component: Priority,
       isEdited: isFeelEntryEdited
     }
@@ -121,7 +123,7 @@ function Priority(props) {
 
   return BpmnFeelNumberEntry({
     element,
-    id: 'jobPriorityDefinitionPriority',
+    id: getSingletonEntryId('zeebe:JobPriorityDefinition', 'priority'),
     label: translate('Priority'),
     feel: 'optional',
     getValue,

--- a/src/provider/zeebe/properties/MessageProps.js
+++ b/src/provider/zeebe/properties/MessageProps.js
@@ -25,6 +25,8 @@ import {
 
 import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 
 export function MessageProps(props) {
   const {
@@ -38,7 +40,7 @@ export function MessageProps(props) {
   if (message) {
     entries.push(
       {
-        id: 'messageName',
+        id: getSingletonEntryId('bpmn:Message', 'name'),
         component: MessageName,
         isEdited: isFeelEntryEdited
       }
@@ -47,7 +49,7 @@ export function MessageProps(props) {
 
   if (message && canHaveSubscriptionCorrelationKey(element)) {
     entries.push({
-      id: 'messageSubscriptionCorrelationKey',
+      id: getSingletonEntryId('zeebe:Subscription', 'correlationKey'),
       component: SubscriptionCorrelationKey,
       isEdited: isFeelEntryEdited
     });
@@ -85,7 +87,7 @@ function MessageName(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'messageName',
+    id: getSingletonEntryId('bpmn:Message', 'name'),
     label: translate('Name'),
     feel: 'optional',
     getValue,
@@ -176,7 +178,7 @@ function SubscriptionCorrelationKey(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'messageSubscriptionCorrelationKey',
+    id: getSingletonEntryId('zeebe:Subscription', 'correlationKey'),
     label: translate('Subscription correlation key'),
     feel: 'required',
     getValue,

--- a/src/provider/zeebe/properties/MultiInstanceProps.js
+++ b/src/provider/zeebe/properties/MultiInstanceProps.js
@@ -20,6 +20,8 @@ import {
 
 import { useService } from '../../../hooks';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
 
 export function MultiInstanceProps(props) {
@@ -33,27 +35,27 @@ export function MultiInstanceProps(props) {
 
   return [
     {
-      id: 'multiInstance-inputCollection',
+      id: getSingletonEntryId('zeebe:LoopCharacteristics', 'inputCollection'),
       component: InputCollection,
       isEdited: isFeelEntryEdited
     },
     {
-      id: 'multiInstance-inputElement',
+      id: getSingletonEntryId('zeebe:LoopCharacteristics', 'inputElement'),
       component: InputElement,
       isEdited: isTextFieldEntryEdited
     },
     {
-      id: 'multiInstance-outputCollection',
+      id: getSingletonEntryId('zeebe:LoopCharacteristics', 'outputCollection'),
       component: OutputCollection,
       isEdited: isTextFieldEntryEdited
     },
     {
-      id: 'multiInstance-outputElement',
+      id: getSingletonEntryId('zeebe:LoopCharacteristics', 'outputElement'),
       component: OutputElement,
       isEdited: isFeelEntryEdited
     },
     {
-      id: 'multiInstance-completionCondition',
+      id: getSingletonEntryId('bpmn:MultiInstanceLoopCharacteristics', 'completionCondition'),
       component: CompletionCondition,
       isEdited: isFeelEntryEdited
     }
@@ -80,7 +82,7 @@ function InputCollection(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'multiInstance-inputCollection',
+    id: getSingletonEntryId('zeebe:LoopCharacteristics', 'inputCollection'),
     label: translate('Input collection'),
     feel: 'required',
     getValue,
@@ -109,7 +111,7 @@ function InputElement(props) {
 
   return TextFieldEntry({
     element,
-    id: 'multiInstance-inputElement',
+    id: getSingletonEntryId('zeebe:LoopCharacteristics', 'inputElement'),
     label: translate('Input element'),
     getValue,
     setValue,
@@ -137,7 +139,7 @@ function OutputCollection(props) {
 
   return TextFieldEntry({
     element,
-    id: 'multiInstance-outputCollection',
+    id: getSingletonEntryId('zeebe:LoopCharacteristics', 'outputCollection'),
     label: translate('Output collection'),
     getValue,
     setValue,
@@ -165,7 +167,7 @@ function OutputElement(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'multiInstance-outputElement',
+    id: getSingletonEntryId('zeebe:LoopCharacteristics', 'outputElement'),
     label: translate('Output element'),
     feel: 'required',
     getValue,
@@ -202,7 +204,7 @@ function CompletionCondition(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'multiInstance-completionCondition',
+    id: getSingletonEntryId('bpmn:MultiInstanceLoopCharacteristics', 'completionCondition'),
     label: translate('Completion condition'),
     feel: 'required',
     getValue,

--- a/src/provider/zeebe/properties/OutputCollectionProps.js
+++ b/src/provider/zeebe/properties/OutputCollectionProps.js
@@ -20,6 +20,8 @@ import {
 
 import { createElement } from '../../../utils/ElementUtil';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 export function OutputCollectionProps(props) {
   const {
     element
@@ -31,12 +33,12 @@ export function OutputCollectionProps(props) {
 
   const entries = [
     {
-      id: 'adHocOutputCollection',
+      id: getSingletonEntryId('zeebe:AdHoc', 'outputCollection'),
       component: OutputCollection,
       isEdited: isTextFieldEntryEdited
     },
     {
-      id: 'adHocOutputElement',
+      id: getSingletonEntryId('zeebe:AdHoc', 'outputElement'),
       component: OutputElement,
       isEdited: isFeelEntryEdited
     }

--- a/src/provider/zeebe/properties/OutputPropagationProps.js
+++ b/src/provider/zeebe/properties/OutputPropagationProps.js
@@ -23,6 +23,8 @@ import {
   useService
 } from '../../../hooks';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 import { ToggleSwitchEntry, isToggleSwitchEntryEdited } from '@bpmn-io/properties-panel';
 
 { /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
@@ -39,7 +41,7 @@ export function OutputPropagationProps(props) {
 
   return [
     {
-      id: 'propagateAllChildVariables',
+      id: getSingletonEntryId('zeebe:CalledElement', 'propagateAllChildVariables'),
       component: PropagateAllChildVariables,
       isEdited: isToggleSwitchEntryEdited
     }
@@ -127,7 +129,7 @@ function PropagateAllChildVariables(props) {
   };
 
   return ToggleSwitchEntry({
-    id: 'propagateAllChildVariables',
+    id: getSingletonEntryId('zeebe:CalledElement', 'propagateAllChildVariables'),
     label: translate('Propagate all child process variables'),
     switcherLabel: propagateAllChildVariables ?
       translate('On') :

--- a/src/provider/zeebe/properties/OutputProps.js
+++ b/src/provider/zeebe/properties/OutputProps.js
@@ -16,6 +16,8 @@ import {
   nextId
 } from '../../../utils/ElementUtil';
 
+import { getListEntryId } from '../utils/EntryIdUtil';
+
 import { without } from 'min-dash';
 
 
@@ -31,7 +33,7 @@ export function OutputProps({ element, injector }) {
         commandStack = injector.get('commandStack');
 
   const items = outputParameters.map((parameter, index) => {
-    const id = element.id + '-output-' + index;
+    const id = getListEntryId(element, parameter, index);
 
     return {
       id,

--- a/src/provider/zeebe/properties/PriorityDefinitionProps.js
+++ b/src/provider/zeebe/properties/PriorityDefinitionProps.js
@@ -19,6 +19,8 @@ import {
 
 import { BpmnFeelNumberEntry } from '../../../entries/BpmnFeelNumberEntry';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 
 export function PriorityDefinitionProps(props) {
   const {
@@ -31,7 +33,7 @@ export function PriorityDefinitionProps(props) {
 
   return [
     {
-      id: 'priorityDefinitionPriority',
+      id: getSingletonEntryId('zeebe:PriorityDefinition', 'priority'),
       component: Priority,
       isEdited: isFeelEntryEdited
     }
@@ -119,7 +121,7 @@ function Priority(props) {
 
   return BpmnFeelNumberEntry({
     element,
-    id: 'priorityDefinitionPriority',
+    id: getSingletonEntryId('zeebe:PriorityDefinition', 'priority'),
     label: translate('Priority'),
     feel: 'optional',
     getValue,

--- a/src/provider/zeebe/properties/ScriptImplementationProps.js
+++ b/src/provider/zeebe/properties/ScriptImplementationProps.js
@@ -21,6 +21,8 @@ import { useService } from '../../../hooks';
 
 import { without } from 'min-dash';
 
+import { SELECTOR_ENTRY_IDS } from '../utils/EntryIdUtil';
+
 { /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
 
 export const SCRIPT_IMPLEMENTATION_OPTION = 'script',
@@ -39,7 +41,7 @@ export function ScriptImplementationProps(props) {
 
   return [
     {
-      id: 'scriptImplementation',
+      id: SELECTOR_ENTRY_IDS.scriptImplementation,
       component: ScriptImplementation,
       isEdited: () => isScriptImplementationEdited(element)
     }

--- a/src/provider/zeebe/properties/ScriptProps.js
+++ b/src/provider/zeebe/properties/ScriptProps.js
@@ -18,6 +18,8 @@ import {
 
 import { useService } from '../../../hooks';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
 
 
@@ -33,12 +35,12 @@ export function ScriptProps(props) {
 
   return [
     {
-      id: 'resultVariable',
+      id: getSingletonEntryId('zeebe:Script', 'resultVariable'),
       component: ResultVariable,
       isEdited: isTextFieldEntryEdited
     },
     {
-      id: 'scriptExpression',
+      id: getSingletonEntryId('zeebe:Script', 'expression'),
       component: Expression,
       isEdited: isFeelEntryEdited
     }

--- a/src/provider/zeebe/properties/SignalProps.js
+++ b/src/provider/zeebe/properties/SignalProps.js
@@ -11,6 +11,8 @@ import {
   isSignalSupported
 } from '../../../utils/EventDefinitionUtil';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 /**
  * @typedef { import('@bpmn-io/properties-panel').EntryDefinition } Entry
  */
@@ -38,7 +40,7 @@ export function SignalProps(props) {
     entries = [
       ...entries,
       {
-        id: 'signalName',
+        id: getSingletonEntryId('bpmn:Signal', 'name'),
         component: SignalName,
         isEdited: isFeelEntryEdited
       },
@@ -76,7 +78,7 @@ function SignalName(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'signalName',
+    id: getSingletonEntryId('bpmn:Signal', 'name'),
     label: translate('Name'),
     feel: 'optional',
     getValue,

--- a/src/provider/zeebe/properties/TargetProps.js
+++ b/src/provider/zeebe/properties/TargetProps.js
@@ -23,6 +23,8 @@ import {
 
 import { useService } from '../../../hooks';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
 
 import { withProps } from '../../HOCs/withProps.js';
@@ -42,12 +44,12 @@ export function TargetProps(props) {
 
   const entries = [
     {
-      id: 'targetProcessId',
+      id: getSingletonEntryId('zeebe:CalledElement', 'processId'),
       component: TargetProcessId,
       isEdited: isFeelEntryEdited
     },
     {
-      id: 'bindingType',
+      id: getSingletonEntryId('zeebe:CalledElement', 'bindingType'),
       component: CalledElementBinding,
       isEdited: isSelectEntryEdited
     }
@@ -55,7 +57,7 @@ export function TargetProps(props) {
 
   if (getBindingType(element, 'zeebe:CalledElement') === 'versionTag') {
     entries.push({
-      id: 'versionTag',
+      id: getSingletonEntryId('zeebe:CalledElement', 'versionTag'),
       component: CalledElementVersionTag,
       isEdited: isTextFieldEntryEdited
     });

--- a/src/provider/zeebe/properties/TaskDefinitionProps.js
+++ b/src/provider/zeebe/properties/TaskDefinitionProps.js
@@ -18,6 +18,8 @@ import {
   isZeebeServiceTask
 } from '../utils/ZeebeServiceTaskUtil';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
 
 
@@ -32,12 +34,12 @@ export function TaskDefinitionProps(props) {
 
   return [
     {
-      id: 'taskDefinitionType',
+      id: getSingletonEntryId('zeebe:TaskDefinition', 'type'),
       component: TaskDefinitionType,
       isEdited: isFeelEntryEdited
     },
     {
-      id: 'taskDefinitionRetries',
+      id: getSingletonEntryId('zeebe:TaskDefinition', 'retries'),
       component: TaskDefinitionRetries,
       isEdited: isFeelEntryEdited
     }

--- a/src/provider/zeebe/properties/TaskListenersProps.js
+++ b/src/provider/zeebe/properties/TaskListenersProps.js
@@ -18,6 +18,8 @@ import {
 
 import { isZeebeUserTask } from '../utils/FormUtil';
 
+import { getListEntryId } from '../utils/EntryIdUtil';
+
 { /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
 
 
@@ -46,7 +48,7 @@ export function TaskListenersProps({ element, injector }) {
         translate = injector.get('translate');
 
   const items = listeners.map((listener, index) => {
-    const id = element.id + '-taskListener-' + index;
+    const id = getListEntryId(element, listener, index);
     const type = listener.get('type') || '<no type>';
     const eventType = listener.get('eventType');
     const label = translate('{eventType}: {type}', {

--- a/src/provider/zeebe/properties/TaskScheduleProps.js
+++ b/src/provider/zeebe/properties/TaskScheduleProps.js
@@ -19,6 +19,8 @@ import {
 
 import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 
 export function TaskScheduleProps(props) {
   const {
@@ -31,12 +33,12 @@ export function TaskScheduleProps(props) {
 
   return [
     {
-      id: 'taskScheduleDueDate',
+      id: getSingletonEntryId('zeebe:TaskSchedule', 'dueDate'),
       component: DueDate,
       isEdited: isFeelEntryEdited
     },
     {
-      id: 'taskScheduleFollowUpDate',
+      id: getSingletonEntryId('zeebe:TaskSchedule', 'followUpDate'),
       component: FollowUpDate,
       isEdited: isFeelEntryEdited
     }
@@ -127,7 +129,7 @@ function DueDate(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'taskScheduleDueDate',
+    id: getSingletonEntryId('zeebe:TaskSchedule', 'dueDate'),
     label: translate('Due date'),
     feel: 'optional',
     getValue,
@@ -220,7 +222,7 @@ function FollowUpDate(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'taskScheduleFollowUpDate',
+    id: getSingletonEntryId('zeebe:TaskSchedule', 'followUpDate'),
     label: translate('Follow up date'),
     feel: 'optional',
     getValue,

--- a/src/provider/zeebe/properties/TimerProps.js
+++ b/src/provider/zeebe/properties/TimerProps.js
@@ -19,6 +19,8 @@ import { BpmnFeelEntry } from '../../../entries/BpmnFeelEntry';
 
 import { isTimerExpressionTypeSupported } from '../utils/TimerUtil';
 
+import { SELECTOR_ENTRY_IDS } from '../utils/EntryIdUtil';
+
 { /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
 
 
@@ -51,7 +53,7 @@ export function TimerProps(props) {
   const entries = [];
 
   entries.push({
-    id: 'timerEventDefinitionType',
+    id: SELECTOR_ENTRY_IDS.timerEventDefinitionType,
     component: TimerEventDefinitionType,
     isEdited: isSelectEntryEdited,
     options: timerOptions
@@ -59,7 +61,7 @@ export function TimerProps(props) {
 
   if (timerEventDefinitionType) {
     entries.push({
-      id: 'timerEventDefinitionValue',
+      id: SELECTOR_ENTRY_IDS.timerEventDefinitionValue,
       component: TimerEventDefinitionValue,
       isEdited: isFeelEntryEdited,
       timerEventDefinitionType: timerEventDefinitionType || timerOptions[0].value
@@ -161,7 +163,7 @@ function TimerEventDefinitionType(props) {
 
   return SelectEntry({
     element,
-    id: 'timerEventDefinitionType',
+    id: SELECTOR_ENTRY_IDS.timerEventDefinitionType,
     label: translate('Type'),
     getValue,
     setValue,
@@ -227,7 +229,7 @@ function TimerEventDefinitionValue(props) {
 
   return BpmnFeelEntry({
     element,
-    id: 'timerEventDefinitionValue',
+    id: SELECTOR_ENTRY_IDS.timerEventDefinitionValue,
     label: label || translate('Value'),
     feel: 'optional',
     getValue,

--- a/src/provider/zeebe/properties/UserTaskImplementationProps.js
+++ b/src/provider/zeebe/properties/UserTaskImplementationProps.js
@@ -20,6 +20,8 @@ import {
 
 import { useService } from '../../../hooks';
 
+import { SELECTOR_ENTRY_IDS } from '../utils/EntryIdUtil';
+
 export const ZEEBE_USER_TASK_IMPLEMENTATION_OPTION = 'zeebeUserTask',
       JOB_WORKER_IMPLEMENTATION_OPTION = 'jobWorker';
 
@@ -35,7 +37,7 @@ export function UserTaskImplementationProps(props) {
 
   return [
     {
-      id: 'userTaskImplementation',
+      id: SELECTOR_ENTRY_IDS.userTaskImplementation,
       component: UserTaskImplementation,
       isEdited: () => isUserTaskImplementationEdited(element)
     }

--- a/src/provider/zeebe/properties/VersionTagProps.js
+++ b/src/provider/zeebe/properties/VersionTagProps.js
@@ -13,6 +13,8 @@ import { createElement } from '../../../utils/ElementUtil';
 
 import { getExtensionElementsList } from '../../../utils/ExtensionElementsUtil';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 
 export function VersionTagProps(props) {
   const {
@@ -28,7 +30,7 @@ export function VersionTagProps(props) {
 
   return [
     {
-      id: 'versionTag',
+      id: getSingletonEntryId('zeebe:VersionTag', 'value'),
       component: VersionTag,
       isEdited: isTextFieldEntryEdited
     },
@@ -115,7 +117,7 @@ function VersionTag(props) {
 
   return TextFieldEntry({
     element,
-    id: 'versionTag',
+    id: getSingletonEntryId('zeebe:VersionTag', 'value'),
     label: translate('Version tag'),
     getValue,
     setValue,

--- a/src/provider/zeebe/properties/shared/Binding.js
+++ b/src/provider/zeebe/properties/shared/Binding.js
@@ -8,6 +8,8 @@ import { useService } from '../../../../hooks';
 
 import { getExtensionElementsList } from '../../../../utils/ExtensionElementsUtil';
 
+import { getSingletonEntryId } from '../../utils/EntryIdUtil';
+
 { /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
 
 export default function Binding(props) {
@@ -96,7 +98,7 @@ export default function Binding(props) {
 
   return <SelectEntry
     element={ element }
-    id="bindingType"
+    id={ getSingletonEntryId(type, 'bindingType') }
     label={ translate('Binding') }
     getValue={ getValue }
     setValue={ setValue }

--- a/src/provider/zeebe/properties/shared/VersionTag.js
+++ b/src/provider/zeebe/properties/shared/VersionTag.js
@@ -8,6 +8,8 @@ import { useService } from '../../../../hooks';
 
 import { getExtensionElementsList } from '../../../../utils/ExtensionElementsUtil';
 
+import { getSingletonEntryId } from '../../utils/EntryIdUtil';
+
 import { BpmnFeelEntry } from '../../../../entries/BpmnFeelEntry';
 
 export default function VersionTag(props) {
@@ -93,7 +95,7 @@ export default function VersionTag(props) {
   if (feel) {
     return BpmnFeelEntry({
       element,
-      id: 'versionTag',
+      id: getSingletonEntryId(type, 'versionTag'),
       label: translate('Version tag'),
       feel,
       getValue,
@@ -104,7 +106,7 @@ export default function VersionTag(props) {
 
   return TextFieldEntry({
     element,
-    id: 'versionTag',
+    id: getSingletonEntryId(type, 'versionTag'),
     label: translate('Version tag'),
     getValue,
     setValue,

--- a/src/provider/zeebe/utils/EntryIdUtil.js
+++ b/src/provider/zeebe/utils/EntryIdUtil.js
@@ -12,6 +12,9 @@ const LIST_ENTRY_SCHEMES = {
   'zeebe:Input': { kind: 'input', fields: [ 'source', 'target' ] },
   'zeebe:Output': { kind: 'output', fields: [ 'source', 'target' ] },
   'zeebe:Header': { kind: 'header', fields: [ 'key', 'value' ] },
+
+  // rendered by the shared ExtensionPropertiesProps (also on the Camunda 7
+  // path), so only resolved here — not built via getListEntryId
   'zeebe:Property': { kind: 'extensionProperty', fields: [ 'name', 'value' ] }
 };
 
@@ -26,10 +29,14 @@ const SINGLETON_ENTRY_SCHEMES = {
   },
   'zeebe:CalledDecision': {
     decisionId: 'decisionId',
+    bindingType: 'bindingType',
+    versionTag: 'versionTag',
     resultVariable: 'resultVariable'
   },
   'zeebe:CalledElement': {
     processId: 'targetProcessId',
+    bindingType: 'bindingType',
+    versionTag: 'versionTag',
     propagateAllChildVariables: 'propagateAllChildVariables'
   },
   'zeebe:Script': {
@@ -37,6 +44,43 @@ const SINGLETON_ENTRY_SCHEMES = {
     resultVariable: 'resultVariable'
   }
 };
+
+/**
+ * Build the id prefix shared by the entries of a list item (e.g.
+ * `${element.id}-input-${index}`). This is the single source for the id
+ * scheme: it is used both to render the entries and to resolve them.
+ *
+ * @param {djs.model.Base} element
+ * @param {ModdleElement} node the moddle element rendered as the list item
+ * @param {number} index the item's index within its collection
+ *
+ * @return {string|null}
+ */
+export function getListEntryId(element, node, index) {
+  const scheme = LIST_ENTRY_SCHEMES[node.$type];
+
+  if (!scheme) {
+    return null;
+  }
+
+  return `${element.id}-${scheme.kind}-${index}`;
+}
+
+/**
+ * Resolve the id of a static (non-list) entry that edits the given moddle
+ * property. This is the single source for the id scheme: it is used both
+ * to render the entry and to resolve it.
+ *
+ * @param {string} type the moddle `$type` of the edited element
+ * @param {string} property the edited moddle property
+ *
+ * @return {string|null}
+ */
+export function getSingletonEntryId(type, property) {
+  const scheme = SINGLETON_ENTRY_SCHEMES[type];
+
+  return scheme && scheme[property] || null;
+}
 
 /**
  * Resolve the id of the properties panel entry that edits the given
@@ -79,16 +123,10 @@ export function getZeebeEntryId(element, path) {
       return null;
     }
 
-    return `${element.id}-${listScheme.kind}-${index}-${field}`;
+    return `${getListEntryId(element, node, index)}-${field}`;
   }
 
-  const singletonScheme = SINGLETON_ENTRY_SCHEMES[node.$type];
-
-  if (singletonScheme) {
-    return singletonScheme[field] || null;
-  }
-
-  return null;
+  return getSingletonEntryId(node.$type, field);
 }
 
 

--- a/src/provider/zeebe/utils/EntryIdUtil.js
+++ b/src/provider/zeebe/utils/EntryIdUtil.js
@@ -1,0 +1,124 @@
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+/**
+ * Entry id schemes for moddle elements that are rendered as items of a
+ * list group, keyed by moddle `$type`. `kind` is the fragment used in the
+ * entry id (`${element.id}-${kind}-${index}-${field}`), `fields` are the
+ * moddle properties exposed as entries.
+ */
+const LIST_ENTRY_SCHEMES = {
+  'zeebe:Input': { kind: 'input', fields: [ 'source', 'target' ] },
+  'zeebe:Output': { kind: 'output', fields: [ 'source', 'target' ] },
+  'zeebe:Header': { kind: 'header', fields: [ 'key', 'value' ] },
+  'zeebe:Property': { kind: 'extensionProperty', fields: [ 'name', 'value' ] }
+};
+
+/**
+ * Entry id schemes for moddle elements that are rendered as static
+ * (non-list) entries, keyed by moddle `$type` and moddle property name.
+ */
+const SINGLETON_ENTRY_SCHEMES = {
+  'zeebe:TaskDefinition': {
+    type: 'taskDefinitionType',
+    retries: 'taskDefinitionRetries'
+  },
+  'zeebe:CalledDecision': {
+    decisionId: 'decisionId',
+    resultVariable: 'resultVariable'
+  },
+  'zeebe:CalledElement': {
+    processId: 'targetProcessId',
+    propagateAllChildVariables: 'propagateAllChildVariables'
+  },
+  'zeebe:Script': {
+    expression: 'scriptExpression',
+    resultVariable: 'resultVariable'
+  }
+};
+
+/**
+ * Resolve the id of the properties panel entry that edits the given
+ * moddle property path, relative to the element's business object.
+ *
+ * @param {djs.model.Base} element
+ * @param {(string|number)[]} path
+ *
+ * @return {string|null}
+ */
+export function getZeebeEntryId(element, path) {
+  if (!Array.isArray(path) || !path.length) {
+    return null;
+  }
+
+  const field = path[path.length - 1];
+
+  if (typeof field !== 'string') {
+    return null;
+  }
+
+  let resolved;
+
+  try {
+    resolved = resolveNode(getBusinessObject(element), path);
+  } catch (error) {
+    return null;
+  }
+
+  if (!resolved) {
+    return null;
+  }
+
+  const { node, index } = resolved;
+
+  const listScheme = LIST_ENTRY_SCHEMES[node.$type];
+
+  if (listScheme) {
+    if (typeof index !== 'number' || !listScheme.fields.includes(field)) {
+      return null;
+    }
+
+    return `${element.id}-${listScheme.kind}-${index}-${field}`;
+  }
+
+  const singletonScheme = SINGLETON_ENTRY_SCHEMES[node.$type];
+
+  if (singletonScheme) {
+    return singletonScheme[field] || null;
+  }
+
+  return null;
+}
+
+
+// helpers //////////////////
+
+/**
+ * Walk all but the last segment of the given path, starting from
+ * <start>, resolving the moddle node that the last segment (the edited
+ * property) belongs to.
+ *
+ * @param {ModdleElement} start
+ * @param {(string|number)[]} path
+ *
+ * @return {{ node: ModdleElement, index: number|null }|null} the resolved
+ * node, and the collection index used to reach it (if any)
+ */
+function resolveNode(start, path) {
+  let node = start;
+  let index = null;
+
+  for (let i = 0; i < path.length - 1 && node; i++) {
+    const segment = path[i];
+
+    if (typeof segment === 'number') {
+      node = node[segment];
+      index = segment;
+    } else {
+      node = node.get(segment);
+    }
+  }
+
+  return node ? { node, index } : null;
+}

--- a/src/provider/zeebe/utils/EntryIdUtil.js
+++ b/src/provider/zeebe/utils/EntryIdUtil.js
@@ -5,8 +5,11 @@ import {
 /**
  * Entry id schemes for moddle elements that are rendered as items of a
  * list group, keyed by moddle `$type`. `kind` is the fragment used in the
- * entry id (`${element.id}-${kind}-${index}-${field}`), `fields` are the
- * moddle properties exposed as entries.
+ * entry id (`${element.id}-${kind}-${index}-${field}`). `fields` lists the
+ * moddle properties exposed as entries and is used for path resolution;
+ * schemes that omit it are forward-only (their field suffixes are labels,
+ * not moddle properties), so getListEntryId builds their id but
+ * getZeebeEntryId does not resolve it.
  */
 const LIST_ENTRY_SCHEMES = {
   'zeebe:Input': { kind: 'input', fields: [ 'source', 'target' ] },
@@ -15,7 +18,13 @@ const LIST_ENTRY_SCHEMES = {
 
   // rendered by the shared ExtensionPropertiesProps (also on the Camunda 7
   // path), so only resolved here — not built via getListEntryId
-  'zeebe:Property': { kind: 'extensionProperty', fields: [ 'name', 'value' ] }
+  'zeebe:Property': { kind: 'extensionProperty', fields: [ 'name', 'value' ] },
+
+  // forward-only (no `fields`): their entry ids are built via getListEntryId
+  // but their field suffixes are labels, not moddle properties, so they are
+  // not path-resolved
+  'zeebe:ExecutionListener': { kind: 'executionListener' },
+  'zeebe:TaskListener': { kind: 'taskListener' }
 };
 
 /**
@@ -37,12 +46,100 @@ const SINGLETON_ENTRY_SCHEMES = {
     processId: 'targetProcessId',
     bindingType: 'bindingType',
     versionTag: 'versionTag',
-    propagateAllChildVariables: 'propagateAllChildVariables'
+    propagateAllChildVariables: 'propagateAllChildVariables',
+    propagateAllParentVariables: 'propagateAllParentVariables'
   },
   'zeebe:Script': {
     expression: 'scriptExpression',
     resultVariable: 'resultVariable'
+  },
+  'zeebe:LoopCharacteristics': {
+    inputCollection: 'multiInstance-inputCollection',
+    inputElement: 'multiInstance-inputElement',
+    outputCollection: 'multiInstance-outputCollection',
+    outputElement: 'multiInstance-outputElement'
+  },
+  'bpmn:MultiInstanceLoopCharacteristics': {
+    completionCondition: 'multiInstance-completionCondition'
+  },
+  'zeebe:AssignmentDefinition': {
+    assignee: 'assignmentDefinitionAssignee',
+    candidateGroups: 'assignmentDefinitionCandidateGroups',
+    candidateUsers: 'assignmentDefinitionCandidateUsers'
+  },
+  'zeebe:JobPriorityDefinition': {
+    priority: 'jobPriorityDefinitionPriority'
+  },
+  'zeebe:PriorityDefinition': {
+    priority: 'priorityDefinitionPriority'
+  },
+  'zeebe:TaskSchedule': {
+    dueDate: 'taskScheduleDueDate',
+    followUpDate: 'taskScheduleFollowUpDate'
+  },
+  'zeebe:VersionTag': {
+    value: 'versionTag'
+  },
+  'zeebe:AdHoc': {
+    activeElementsCollection: 'activeElementsCollection',
+    outputCollection: 'adHocOutputCollection',
+    outputElement: 'adHocOutputElement'
+  },
+  'zeebe:ConditionalFilter': {
+    variableEvents: 'variableEvents'
+  },
+  'bpmn:ConditionalEventDefinition': {
+    condition: 'condition'
+  },
+  'zeebe:Subscription': {
+    correlationKey: 'messageSubscriptionCorrelationKey'
+  },
+  'zeebe:FormDefinition': {
+    formId: 'formId',
+    formKey: 'customFormKey',
+    externalReference: 'externalReference',
+    bindingType: 'bindingType',
+    versionTag: 'versionTag'
+  },
+  'zeebe:UserTaskForm': {
+    body: 'formConfiguration'
+  },
+  'bpmn:Error': {
+    errorCode: 'errorCode'
+  },
+  'bpmn:Escalation': {
+    escalationCode: 'escalationCode'
+  },
+  'bpmn:Message': {
+    name: 'messageName'
+  },
+  'bpmn:Signal': {
+    name: 'signalName'
+  },
+  'bpmn:AdHocSubProcess': {
+    completionCondition: 'completionCondition'
+  },
+  'bpmn:SequenceFlow': {
+    conditionExpression: 'conditionExpression'
   }
+};
+
+/**
+ * Entry ids for properties panel entries that are not backed by a single
+ * moddle property (radio/select "type" choosers, and other irregular ids).
+ * They cannot be resolved from a moddle path, so they are single-sourced as
+ * constants shared between the rendering entry definitions and their
+ * components, rather than resolved via getZeebeEntryId.
+ */
+export const SELECTOR_ENTRY_IDS = {
+  formType: 'formType',
+  timerEventDefinitionType: 'timerEventDefinitionType',
+  timerEventDefinitionValue: 'timerEventDefinitionValue',
+  adHocImplementation: 'adHocImplementation',
+  businessRuleImplementation: 'businessRuleImplementation',
+  scriptImplementation: 'scriptImplementation',
+  userTaskImplementation: 'userTaskImplementation',
+  activeElementsCollectionValue: 'activeElements-activeElementsCollection'
 };
 
 /**
@@ -50,20 +147,23 @@ const SINGLETON_ENTRY_SCHEMES = {
  * `${element.id}-input-${index}`). This is the single source for the id
  * scheme: it is used both to render the entries and to resolve them.
  *
- * @param {djs.model.Base} element
+ * @param {djs.model.Base|string} base the element (top-level lists) or a
+ * parent id prefix (nested lists, e.g. execution listener headers)
  * @param {ModdleElement} node the moddle element rendered as the list item
  * @param {number} index the item's index within its collection
  *
  * @return {string|null}
  */
-export function getListEntryId(element, node, index) {
+export function getListEntryId(base, node, index) {
   const scheme = LIST_ENTRY_SCHEMES[node.$type];
 
   if (!scheme) {
     return null;
   }
 
-  return `${element.id}-${scheme.kind}-${index}`;
+  const prefix = typeof base === 'string' ? base : base.id;
+
+  return `${prefix}-${scheme.kind}-${index}`;
 }
 
 /**
@@ -119,7 +219,7 @@ export function getZeebeEntryId(element, path) {
   const listScheme = LIST_ENTRY_SCHEMES[node.$type];
 
   if (listScheme) {
-    if (typeof index !== 'number' || !listScheme.fields.includes(field)) {
+    if (!listScheme.fields || typeof index !== 'number' || !listScheme.fields.includes(field)) {
       return null;
     }
 

--- a/src/provider/zeebe/utils/EntryIdUtil.js
+++ b/src/provider/zeebe/utils/EntryIdUtil.js
@@ -1,6 +1,9 @@
 import {
-  getBusinessObject
+  getBusinessObject,
+  is
 } from 'bpmn-js/lib/util/ModelUtil';
+
+import { isArray } from 'min-dash';
 
 /**
  * Entry id schemes for moddle elements that are rendered as items of a
@@ -20,9 +23,9 @@ const LIST_ENTRY_SCHEMES = {
   // path), so only resolved here — not built via getListEntryId
   'zeebe:Property': { kind: 'extensionProperty', fields: [ 'name', 'value' ] },
 
-  // forward-only (no `fields`): their entry ids are built via getListEntryId
-  // but their field suffixes are labels, not moddle properties, so they are
-  // not path-resolved
+  // listener fields are label-named (not moddle properties), so they carry no
+  // `fields`; getListEntryId builds their list-item prefix and resolveListenerEntry
+  // resolves the label suffixes (type/eventType/retries) via LISTENER_SUFFIX
   'zeebe:ExecutionListener': { kind: 'executionListener' },
   'zeebe:TaskListener': { kind: 'taskListener' }
 };
@@ -44,6 +47,7 @@ const SINGLETON_ENTRY_SCHEMES = {
   },
   'zeebe:CalledElement': {
     processId: 'targetProcessId',
+    businessId: 'businessId',
     bindingType: 'bindingType',
     versionTag: 'versionTag',
     propagateAllChildVariables: 'propagateAllChildVariables',
@@ -105,10 +109,12 @@ const SINGLETON_ENTRY_SCHEMES = {
     body: 'formConfiguration'
   },
   'bpmn:Error': {
-    errorCode: 'errorCode'
+    errorCode: 'errorCode',
+    name: 'errorName'
   },
   'bpmn:Escalation': {
-    escalationCode: 'escalationCode'
+    escalationCode: 'escalationCode',
+    name: 'escalationName'
   },
   'bpmn:Message': {
     name: 'messageName'
@@ -117,10 +123,36 @@ const SINGLETON_ENTRY_SCHEMES = {
     name: 'signalName'
   },
   'bpmn:AdHocSubProcess': {
-    completionCondition: 'completionCondition'
+    completionCondition: 'completionCondition',
+    cancelRemainingInstances: 'cancelRemainingInstances'
   },
   'bpmn:SequenceFlow': {
     conditionExpression: 'conditionExpression'
+  },
+  'bpmn:Process': {
+    isExecutable: 'isExecutable'
+  },
+
+  // event definition reference attributes; the path resolves to the event
+  // definition node itself (e.g. `[ 'eventDefinitions', 0, 'messageRef' ]`)
+  'bpmn:MessageEventDefinition': {
+    messageRef: 'messageRef'
+  },
+  'bpmn:SignalEventDefinition': {
+    signalRef: 'signalRef'
+  },
+  'bpmn:ErrorEventDefinition': {
+    errorRef: 'errorRef'
+  },
+  'bpmn:EscalationEventDefinition': {
+    escalationRef: 'escalationRef'
+  },
+  'bpmn:LinkEventDefinition': {
+    name: 'linkName'
+  },
+  'bpmn:CompensateEventDefinition': {
+    waitForCompletion: 'waitForCompletion',
+    activityRef: 'activityRef'
   }
 };
 
@@ -141,6 +173,31 @@ export const SELECTOR_ENTRY_IDS = {
   userTaskImplementation: 'userTaskImplementation',
   activeElementsCollectionValue: 'activeElements-activeElementsCollection'
 };
+
+/**
+ * Entry ids for a container (collection) rendered as a group, keyed by the
+ * container's moddle `$type` and the collection property. A finding may point
+ * at a collection rather than a single leaf (the best-effort anchor a rule
+ * emits when no concrete offending value exists), which resolves outward to
+ * the group that renders it.
+ */
+const GROUP_ENTRY_IDS = {
+  'zeebe:IoMapping': {
+    inputParameters: 'inputs',
+    outputParameters: 'outputs'
+  }
+};
+
+// moddle property -> entry id suffix for execution/task listeners; the
+// listener list-item prefix is single-sourced via getListEntryId, the suffix
+// mirrors the (label, not moddle-named) fields the listener component renders
+const LISTENER_SUFFIX = {
+  type: 'listenerType',
+  eventType: 'eventType',
+  retries: 'retries'
+};
+
+const TIMER_PROPERTIES = [ 'timeCycle', 'timeDate', 'timeDuration' ];
 
 /**
  * Build the id prefix shared by the entries of a list item (e.g.
@@ -192,7 +249,7 @@ export function getSingletonEntryId(type, property) {
  * @return {string|null}
  */
 export function getZeebeEntryId(element, path) {
-  if (!Array.isArray(path) || !path.length) {
+  if (!isArray(path) || !path.length) {
     return null;
   }
 
@@ -202,10 +259,12 @@ export function getZeebeEntryId(element, path) {
     return null;
   }
 
+  const businessObject = getBusinessObject(element);
+
   let resolved;
 
   try {
-    resolved = resolveNode(getBusinessObject(element), path);
+    resolved = resolveNode(businessObject, path);
   } catch (error) {
     return null;
   }
@@ -214,19 +273,127 @@ export function getZeebeEntryId(element, path) {
     return null;
   }
 
-  const { node, index } = resolved;
+  const { node, index, trail } = resolved;
 
-  const listScheme = LIST_ENTRY_SCHEMES[node.$type];
+  return (
+    resolveHeaderEntry(element, node, index, trail, field)
+    || resolveListenerEntry(element, node, index, field)
+    || resolveListEntry(element, node, index, field)
+    || resolveGroupEntry(node, field)
+    || resolveTimerEntry(node, field)
+    || getSingletonEntryId(node.$type, field)
+    || resolveReferenceNameEntry(businessObject, field)
+    || null
+  );
+}
 
-  if (listScheme) {
-    if (!listScheme.fields || typeof index !== 'number' || !listScheme.fields.includes(field)) {
-      return null;
-    }
 
-    return `${getListEntryId(element, node, index)}-${field}`;
+// resolver branches //////////////////
+
+// task headers and (nested) execution listener headers both render zeebe:Header
+// items; disambiguate via the resolved path so the id matches what is rendered
+function resolveHeaderEntry(element, node, index, trail, field) {
+  if (node.$type !== 'zeebe:Header' || (field !== 'key' && field !== 'value')) {
+    return null;
   }
 
-  return getSingletonEntryId(node.$type, field);
+  // a header nested inside an execution listener renders under the listener
+  // list-item prefix (`...-executionListener-<i>-headers-...`)
+  const listener = trail.find(entry => entry.node && entry.node.$type === 'zeebe:ExecutionListener');
+
+  if (listener) {
+    const listenerPrefix = getListEntryId(element, listener.node, listener.index);
+
+    return `${getListEntryId(`${listenerPrefix}-headers`, node, index)}-${field}`;
+  }
+
+  return `${getListEntryId(element, node, index)}-${field}`;
+}
+
+// execution/task listener fields render under the listener list-item prefix
+// with a label suffix that is not the moddle property name
+function resolveListenerEntry(element, node, index, field) {
+  if (node.$type !== 'zeebe:ExecutionListener' && node.$type !== 'zeebe:TaskListener') {
+    return null;
+  }
+
+  const suffix = LISTENER_SUFFIX[field];
+
+  if (!suffix || typeof index !== 'number') {
+    return null;
+  }
+
+  return `${getListEntryId(element, node, index)}-${suffix}`;
+}
+
+// io mapping parameters and extension properties render as list items keyed by
+// their moddle property (source/target, name/value)
+function resolveListEntry(element, node, index, field) {
+  if (node.$type === 'zeebe:Header') {
+    return null;
+  }
+
+  const scheme = LIST_ENTRY_SCHEMES[node.$type];
+
+  if (!scheme || !scheme.fields || typeof index !== 'number' || !scheme.fields.includes(field)) {
+    return null;
+  }
+
+  return `${getListEntryId(element, node, index)}-${field}`;
+}
+
+function resolveGroupEntry(node, field) {
+  const scheme = GROUP_ENTRY_IDS[node.$type];
+
+  return scheme && scheme[field] || null;
+}
+
+// the timer type selector has no leaf location and is deferred; the value field
+// is resolvable when the expression is present (value-not-allowed / -required)
+function resolveTimerEntry(node, field) {
+  if (node.$type !== 'bpmn:TimerEventDefinition' || !TIMER_PROPERTIES.includes(field)) {
+    return null;
+  }
+
+  return node.get(field) ? SELECTOR_ENTRY_IDS.timerEventDefinitionValue : null;
+}
+
+// findings on a referenced root's name/code, or legacy flat paths that address
+// the element itself, bottom out here — disambiguated by the element's event
+// definition (or, for a receive task, its message)
+function resolveReferenceNameEntry(businessObject, field) {
+  if (field === 'errorCode' && hasEventDefinition(businessObject, 'bpmn:ErrorEventDefinition')) {
+    return 'errorCode';
+  }
+
+  if (field === 'escalationCode' && hasEventDefinition(businessObject, 'bpmn:EscalationEventDefinition')) {
+    return 'escalationCode';
+  }
+
+  if (field === 'correlationKey') {
+    return 'messageSubscriptionCorrelationKey';
+  }
+
+  if (field === 'name') {
+    if (hasEventDefinition(businessObject, 'bpmn:MessageEventDefinition')
+      || is(businessObject, 'bpmn:ReceiveTask')) {
+      return 'messageName';
+    }
+
+    if (hasEventDefinition(businessObject, 'bpmn:SignalEventDefinition')) {
+      return 'signalName';
+    }
+
+    if (hasEventDefinition(businessObject, 'bpmn:ErrorEventDefinition')) {
+      return 'errorName';
+    }
+
+    if (hasEventDefinition(businessObject, 'bpmn:EscalationEventDefinition')) {
+      return 'escalationName';
+    }
+  }
+
+  return null;
 }
 
 
@@ -240,23 +407,45 @@ export function getZeebeEntryId(element, path) {
  * @param {ModdleElement} start
  * @param {(string|number)[]} path
  *
- * @return {{ node: ModdleElement, index: number|null }|null} the resolved
- * node, and the collection index used to reach it (if any)
+ * @return {{ node: ModdleElement, index: number|null, trail: Array<{ node: ModdleElement, index: number|null }> }|null}
+ * the resolved node, the collection index used to reach it (if any), and the
+ * trail of nodes visited along the way (for disambiguating nested locations)
  */
 function resolveNode(start, path) {
   let node = start;
-  let index = null;
+
+  const trail = [];
 
   for (let i = 0; i < path.length - 1 && node; i++) {
     const segment = path[i];
 
     if (typeof segment === 'number') {
       node = node[segment];
-      index = segment;
+
+      trail.push({ node, index: segment });
     } else {
       node = node.get(segment);
+
+      trail.push({ node, index: null });
     }
   }
 
-  return node ? { node, index } : null;
+  if (!node) {
+    return null;
+  }
+
+  const last = trail[trail.length - 1];
+
+  return { node, index: last ? last.index : null, trail };
+}
+
+/**
+ * Whether the element carries an event definition of the given type.
+ *
+ * @return {boolean}
+ */
+function hasEventDefinition(businessObject, type) {
+  const eventDefinitions = businessObject.get && businessObject.get('eventDefinitions');
+
+  return isArray(eventDefinitions) && eventDefinitions.some(definition => is(definition, type));
 }

--- a/src/provider/zeebe/utils/EntryIdUtil.js
+++ b/src/provider/zeebe/utils/EntryIdUtil.js
@@ -85,7 +85,7 @@ const SINGLETON_ENTRY_SCHEMES = {
     value: 'versionTag'
   },
   'zeebe:AdHoc': {
-    activeElementsCollection: 'activeElementsCollection',
+    activeElementsCollection: 'activeElements-activeElementsCollection',
     outputCollection: 'adHocOutputCollection',
     outputElement: 'adHocOutputElement'
   },
@@ -170,8 +170,7 @@ export const SELECTOR_ENTRY_IDS = {
   adHocImplementation: 'adHocImplementation',
   businessRuleImplementation: 'businessRuleImplementation',
   scriptImplementation: 'scriptImplementation',
-  userTaskImplementation: 'userTaskImplementation',
-  activeElementsCollectionValue: 'activeElements-activeElementsCollection'
+  userTaskImplementation: 'userTaskImplementation'
 };
 
 /**

--- a/src/render/BpmnPropertiesPanelRenderer.js
+++ b/src/render/BpmnPropertiesPanelRenderer.js
@@ -22,7 +22,10 @@ const DEFAULT_PRIORITY = 1000;
 /**
  * @typedef { import('@bpmn-io/properties-panel').GroupDefinition } GroupDefinition
  * @typedef { import('@bpmn-io/properties-panel').ListGroupDefinition } ListGroupDefinition
- * @typedef { { getGroups: (ModdleElement) => (Array{GroupDefinition|ListGroupDefinition}) => Array{GroupDefinition|ListGroupDefinition}) } PropertiesProvider
+ * @typedef { {
+ *   getGroups: (ModdleElement) => (Array{GroupDefinition|ListGroupDefinition}) => Array{GroupDefinition|ListGroupDefinition}),
+ *   getEntryId: ((ModdleElement, (string|number)[]) => string|null)?
+ * } } PropertiesProvider
  */
 
 export default class BpmnPropertiesPanelRenderer {
@@ -179,6 +182,35 @@ export default class BpmnPropertiesPanelRenderer {
    */
   setLayout(layout) {
     this._eventBus.fire('propertiesPanel.setLayout', { layout });
+  }
+
+  /**
+   * Resolve the id of the entry that edits the given moddle property path,
+   * asking registered providers in reverse render order (the provider whose
+   * groups render last answers first). Providers not implementing
+   * #getEntryId(element, path), or returning a falsy value, are skipped.
+   *
+   * @param {djs.model.Base} element
+   * @param {(string|number)[]} path moddle property path, relative to the element's business object
+   *
+   * @return {string|null}
+   */
+  getEntryId(element, path) {
+    const providers = this._getProviders().slice().reverse();
+
+    for (const provider of providers) {
+      if (typeof provider.getEntryId !== 'function') {
+        continue;
+      }
+
+      const entryId = provider.getEntryId(element, path);
+
+      if (entryId) {
+        return entryId;
+      }
+    }
+
+    return null;
   }
 
   _getProviders() {

--- a/src/render/BpmnPropertiesPanelRenderer.js
+++ b/src/render/BpmnPropertiesPanelRenderer.js
@@ -22,9 +22,10 @@ const DEFAULT_PRIORITY = 1000;
 /**
  * @typedef { import('@bpmn-io/properties-panel').GroupDefinition } GroupDefinition
  * @typedef { import('@bpmn-io/properties-panel').ListGroupDefinition } ListGroupDefinition
+ * @typedef { GroupDefinition | ListGroupDefinition } Group
  * @typedef { {
- *   getGroups: (ModdleElement) => (Array{GroupDefinition|ListGroupDefinition}) => Array{GroupDefinition|ListGroupDefinition}),
- *   getEntryId: ((ModdleElement, (string|number)[]) => string|null)?
+ *   getGroups: (element: djs.model.Base) => (groups: Group[]) => Group[],
+ *   getEntryId?: (element: djs.model.Base, path: (string|number)[]) => string|null
  * } } PropertiesProvider
  */
 

--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -408,6 +408,111 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
   });
 
 
+  describe('#getEntryId', function() {
+
+    const diagramXML = require('test/fixtures/simple.bpmn').default;
+
+    function inject(fn) {
+
+      return async function() {
+        const {
+          modeler
+        } = await createModeler(diagramXML, {
+          additionalModules: [
+            BpmnPropertiesPanel,
+            BpmnPropertiesProvider
+          ]
+        });
+
+        await modeler.invoke(fn);
+      };
+    }
+
+    const noopGetGroups = () => (groups) => groups;
+
+
+    it('should return null when no provider answers', inject(function(propertiesPanel, elementRegistry) {
+
+      // given
+      const element = elementRegistry.get('StartEvent_1');
+
+      // when
+      const entryId = propertiesPanel.getEntryId(element, [ 'foo' ]);
+
+      // then
+      expect(entryId).to.be.null;
+    }));
+
+
+    it('should skip providers without #getEntryId', inject(function(propertiesPanel, elementRegistry) {
+
+      // given
+      const element = elementRegistry.get('StartEvent_1');
+
+      propertiesPanel.registerProvider(2000, {
+        getGroups: noopGetGroups
+      });
+
+      // when
+      const entryId = propertiesPanel.getEntryId(element, [ 'foo' ]);
+
+      // then
+      expect(entryId).to.be.null;
+    }));
+
+
+    it('should ask providers in reverse render order', inject(function(propertiesPanel, elementRegistry) {
+
+      // given
+      const element = elementRegistry.get('StartEvent_1');
+
+      // registered at DEFAULT_PRIORITY, renders first
+      propertiesPanel.registerProvider(1000, {
+        getGroups: noopGetGroups,
+        getEntryId: () => 'early-provider-entry'
+      });
+
+      // registered at LOW_PRIORITY, renders last (i.e. overrides)
+      propertiesPanel.registerProvider(500, {
+        getGroups: noopGetGroups,
+        getEntryId: () => 'late-provider-entry'
+      });
+
+      // when
+      const entryId = propertiesPanel.getEntryId(element, [ 'foo' ]);
+
+      // then
+      expect(entryId).to.eql('late-provider-entry');
+    }));
+
+
+    it('should fall back to an earlier provider when a later one returns a falsy value', inject(
+      function(propertiesPanel, elementRegistry) {
+
+        // given
+        const element = elementRegistry.get('StartEvent_1');
+
+        propertiesPanel.registerProvider(1000, {
+          getGroups: noopGetGroups,
+          getEntryId: () => 'early-provider-entry'
+        });
+
+        propertiesPanel.registerProvider(500, {
+          getGroups: noopGetGroups,
+          getEntryId: () => null
+        });
+
+        // when
+        const entryId = propertiesPanel.getEntryId(element, [ 'foo' ]);
+
+        // then
+        expect(entryId).to.eql('early-provider-entry');
+      }
+    ));
+
+  });
+
+
   describe('integration', function() {
 
     it('should ensure creating + importing -> attaching works', async function() {
@@ -746,6 +851,38 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
 
       expect(error).to.exist;
       expect(error.textContent).to.equal('foo');
+    });
+
+
+    it('should resolve a moddle path to an entry rendered in the DOM', async function() {
+
+      // given
+      const diagramXml = require('test/spec/provider/zeebe/InputProps.bpmn').default;
+
+      let modeler;
+
+      await act(async () => {
+        const result = await createModeler(diagramXml);
+
+        modeler = result.modeler;
+      });
+
+      const elementRegistry = modeler.get('elementRegistry'),
+            selection = modeler.get('selection'),
+            propertiesPanel = modeler.get('propertiesPanel');
+
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => selection.select(serviceTask));
+
+      // when
+      const entryId = propertiesPanel.getEntryId(serviceTask, [
+        'extensionElements', 'values', 0, 'inputParameters', 1, 'source'
+      ]);
+
+      // then
+      expect(entryId).to.eql('ServiceTask_1-input-1-source');
+      expect(domQuery(`[data-entry-id="${ entryId }"]`, propertiesContainer)).to.exist;
     });
 
   });

--- a/test/spec/provider/bpmn/EntryIdRendered.spec.js
+++ b/test/spec/provider/bpmn/EntryIdRendered.spec.js
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+
+import TestContainer from 'mocha-test-container-support';
+
+import { act } from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/render';
+
+import BpmnPropertiesProvider from 'src/provider/bpmn';
+
+import documentationXML from './DocumentationProps.bpmn';
+
+
+// verify the render-agnostic contract end to end: whatever id
+// BpmnPropertiesProvider resolves for a moddle path is actually rendered as an
+// entry (or group) in the DOM - so the resolver can never drift from the UI
+describe('provider/bpmn - entry id rendered', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  function expectRenderedEntry(propertiesPanel, element, path, expectedId) {
+
+    // when
+    const entryId = propertiesPanel.getEntryId(element, path);
+
+    // then
+    expect(entryId, 'resolved entry id').to.eql(expectedId);
+
+    const rendered = domQuery(
+      `[data-entry-id="${ entryId }"], [data-group-id="group-${ entryId }"]`,
+      container
+    );
+
+    expect(rendered, `rendered entry or group "${ entryId }"`).to.exist;
+  }
+
+
+  describe('documentation', function() {
+
+    beforeEach(bootstrapPropertiesPanel(documentationXML, {
+      modules: [
+        CoreModule,
+        ModelingModule,
+        SelectionModule,
+        BpmnPropertiesPanel,
+        BpmnPropertiesProvider
+      ],
+      debounceInput: false
+    }));
+
+
+    it('should render element documentation', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      await act(() => selection.select(task));
+
+      // then
+      expectRenderedEntry(propertiesPanel, task, [ 'documentation' ], 'documentation');
+    }));
+
+  });
+
+});

--- a/test/spec/provider/bpmn/EntryIdUtil.spec.js
+++ b/test/spec/provider/bpmn/EntryIdUtil.spec.js
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+
+import { BpmnModdle } from 'bpmn-moddle';
+
+import { getBpmnEntryId } from '../../../../src/provider/bpmn/utils/EntryIdUtil';
+
+
+describe('provider/bpmn - EntryIdUtil', function() {
+
+  const moddle = new BpmnModdle();
+
+  function createElement(type, properties) {
+    return moddle.create(type, properties);
+  }
+
+
+  describe('#getBpmnEntryId', function() {
+
+    it('should resolve element documentation', function() {
+
+      // given
+      const task = createElement('bpmn:ServiceTask', { id: 'Task_1' });
+
+      // when
+      const entryId = getBpmnEntryId(task, [ 'documentation' ]);
+
+      // then
+      expect(entryId).to.eql('documentation');
+    });
+
+
+    it('should not resolve an unknown property', function() {
+
+      // given
+      const task = createElement('bpmn:ServiceTask', { id: 'Task_1' });
+
+      // when
+      const entryId = getBpmnEntryId(task, [ 'name' ]);
+
+      // then
+      expect(entryId).to.be.null;
+    });
+
+
+    it('should not resolve an empty path', function() {
+
+      // given
+      const task = createElement('bpmn:ServiceTask', { id: 'Task_1' });
+
+      // when
+      const entryId = getBpmnEntryId(task, []);
+
+      // then
+      expect(entryId).to.be.null;
+    });
+
+
+    it('should not resolve without an element', function() {
+
+      // when
+      const entryId = getBpmnEntryId(null, [ 'documentation' ]);
+
+      // then
+      expect(entryId).to.be.null;
+    });
+
+  });
+
+});

--- a/test/spec/provider/camunda-platform/EntryIdRendered.spec.js
+++ b/test/spec/provider/camunda-platform/EntryIdRendered.spec.js
@@ -1,0 +1,90 @@
+import { expect } from 'chai';
+
+import TestContainer from 'mocha-test-container-support';
+
+import { act } from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/render';
+
+import BpmnPropertiesProvider from 'src/provider/bpmn';
+import CamundaPlatformPropertiesProvider from 'src/provider/camunda-platform';
+
+import camundaModdleExtensions from 'camunda-bpmn-moddle/resources/camunda.json';
+
+import historyCleanupXML from './HistoryCleanupProps-process.bpmn';
+
+
+// verify the render-agnostic contract end to end: whatever id
+// CamundaPlatformPropertiesProvider resolves for a moddle path is actually
+// rendered as an entry (or group) in the DOM - so the resolver can never drift
+// from the UI
+describe('provider/camunda-platform - entry id rendered', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  function expectRenderedEntry(propertiesPanel, element, path, expectedId) {
+
+    // when
+    const entryId = propertiesPanel.getEntryId(element, path);
+
+    // then
+    expect(entryId, 'resolved entry id').to.eql(expectedId);
+
+    const rendered = domQuery(
+      `[data-entry-id="${ entryId }"], [data-group-id="group-${ entryId }"]`,
+      container
+    );
+
+    expect(rendered, `rendered entry or group "${ entryId }"`).to.exist;
+  }
+
+
+  describe('history cleanup', function() {
+
+    beforeEach(bootstrapPropertiesPanel(historyCleanupXML, {
+      modules: [
+        CoreModule,
+        ModelingModule,
+        SelectionModule,
+        BpmnPropertiesPanel,
+        BpmnPropertiesProvider,
+        CamundaPlatformPropertiesProvider
+      ],
+      moddleExtensions: {
+        camunda: camundaModdleExtensions
+      },
+      debounceInput: false
+    }));
+
+
+    it('should render bpmn:Process#historyTimeToLive', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const process = elementRegistry.get('Process_1');
+
+      await act(() => selection.select(process));
+
+      // then
+      expectRenderedEntry(propertiesPanel, process, [ 'historyTimeToLive' ], 'historyTimeToLive');
+    }));
+
+  });
+
+});

--- a/test/spec/provider/camunda-platform/EntryIdUtil.spec.js
+++ b/test/spec/provider/camunda-platform/EntryIdUtil.spec.js
@@ -1,0 +1,97 @@
+import { expect } from 'chai';
+
+import { BpmnModdle } from 'bpmn-moddle';
+
+import CamundaModdle from 'camunda-bpmn-moddle/resources/camunda';
+
+import { getCamundaPlatformEntryId } from '../../../../src/provider/camunda-platform/utils/EntryIdUtil';
+
+
+describe('provider/camunda-platform - EntryIdUtil', function() {
+
+  const moddle = new BpmnModdle({
+    camunda: CamundaModdle
+  });
+
+  function createElement(type, properties) {
+    return moddle.create(type, properties);
+  }
+
+
+  describe('#getCamundaPlatformEntryId', function() {
+
+    it('should resolve historyTimeToLive on a process', function() {
+
+      // given
+      const process = createElement('bpmn:Process', {
+        id: 'Process_1',
+        'camunda:historyTimeToLive': 'P5D'
+      });
+
+      // when
+      const entryId = getCamundaPlatformEntryId(process, [ 'historyTimeToLive' ]);
+
+      // then
+      expect(entryId).to.eql('historyTimeToLive');
+    });
+
+
+    it('should resolve historyTimeToLive via a participant processRef', function() {
+
+      // given
+      const process = createElement('bpmn:Process', {
+        id: 'Process_1',
+        'camunda:historyTimeToLive': 'P5D'
+      });
+
+      const participant = createElement('bpmn:Participant', {
+        id: 'Participant_1',
+        processRef: process
+      });
+
+      // when
+      const entryId = getCamundaPlatformEntryId(participant, [ 'processRef', 'historyTimeToLive' ]);
+
+      // then
+      expect(entryId).to.eql('historyTimeToLive');
+    });
+
+
+    it('should not resolve an unknown property', function() {
+
+      // given
+      const process = createElement('bpmn:Process', { id: 'Process_1' });
+
+      // when
+      const entryId = getCamundaPlatformEntryId(process, [ 'name' ]);
+
+      // then
+      expect(entryId).to.be.null;
+    });
+
+
+    it('should not resolve an empty path', function() {
+
+      // given
+      const process = createElement('bpmn:Process', { id: 'Process_1' });
+
+      // when
+      const entryId = getCamundaPlatformEntryId(process, []);
+
+      // then
+      expect(entryId).to.be.null;
+    });
+
+
+    it('should not resolve without an element', function() {
+
+      // when
+      const entryId = getCamundaPlatformEntryId(null, [ 'historyTimeToLive' ]);
+
+      // then
+      expect(entryId).to.be.null;
+    });
+
+  });
+
+});

--- a/test/spec/provider/zeebe/EntryIdRendered.spec.js
+++ b/test/spec/provider/zeebe/EntryIdRendered.spec.js
@@ -27,6 +27,35 @@ import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
 import executionListenersXML from './ExecutionListenerProps.bpmn';
 import inputXML from './InputProps.bpmn';
 import businessIdXML from './BusinessIdProps.bpmn';
+import taskDefinitionXML from './TaskDefinitionProps.bpmn';
+import targetXML from './TargetProps.bpmn';
+import scriptXML from './ScriptProps.bpmn';
+import assignmentDefinitionXML from './AssignmentDefinitionProps.bpmn';
+import taskScheduleXML from './TaskScheduleProps.bpmn';
+import priorityDefinitionXML from './PriorityDefinitionProps.bpmn';
+import activeElementsXML from './ActiveElementsCollectionProps.bpmn';
+import messageXML from './MessageProps.bpmn';
+import signalXML from './SignalProps.bpmn';
+
+
+const MODULES = [
+  CoreModule,
+  ModelingModule,
+  SelectionModule,
+  BpmnPropertiesPanel,
+  BpmnPropertiesProvider,
+  ZeebePropertiesProvider
+];
+
+function bootstrap(xml) {
+  return bootstrapPropertiesPanel(xml, {
+    modules: MODULES,
+    moddleExtensions: {
+      zeebe: zeebeModdleExtensions
+    },
+    debounceInput: false
+  });
+}
 
 
 // verify the render-agnostic contract end to end: whatever id
@@ -179,20 +208,7 @@ describe('provider/zeebe - entry id rendered', function() {
 
   describe('business id', function() {
 
-    beforeEach(bootstrapPropertiesPanel(businessIdXML, {
-      modules: [
-        CoreModule,
-        ModelingModule,
-        SelectionModule,
-        BpmnPropertiesPanel,
-        BpmnPropertiesProvider,
-        ZeebePropertiesProvider
-      ],
-      moddleExtensions: {
-        zeebe: zeebeModdleExtensions
-      },
-      debounceInput: false
-    }));
+    beforeEach(bootstrap(businessIdXML));
 
 
     it('should render zeebe:CalledElement#businessId', inject(async function(elementRegistry, selection, propertiesPanel) {
@@ -208,6 +224,243 @@ describe('provider/zeebe - entry id rendered', function() {
         callActivity,
         [ 'extensionElements', 'values', 0, 'businessId' ],
         'businessId'
+      );
+    }));
+
+  });
+
+
+  describe('task definition', function() {
+
+    beforeEach(bootstrap(taskDefinitionXML));
+
+
+    it('should render zeebe:TaskDefinition#type and #retries', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => selection.select(serviceTask));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        serviceTask,
+        [ 'extensionElements', 'values', 0, 'type' ],
+        'taskDefinitionType'
+      );
+
+      expectRenderedEntry(
+        propertiesPanel,
+        serviceTask,
+        [ 'extensionElements', 'values', 0, 'retries' ],
+        'taskDefinitionRetries'
+      );
+    }));
+
+  });
+
+
+  describe('called element target', function() {
+
+    beforeEach(bootstrap(targetXML));
+
+
+    it('should render zeebe:CalledElement#processId', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_1');
+
+      await act(() => selection.select(callActivity));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        callActivity,
+        [ 'extensionElements', 'values', 0, 'processId' ],
+        'targetProcessId'
+      );
+    }));
+
+  });
+
+
+  describe('script', function() {
+
+    beforeEach(bootstrap(scriptXML));
+
+
+    it('should render zeebe:Script#expression and #resultVariable', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const scriptTask = elementRegistry.get('ScriptTask_1');
+
+      await act(() => selection.select(scriptTask));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        scriptTask,
+        [ 'extensionElements', 'values', 0, 'expression' ],
+        'scriptExpression'
+      );
+
+      expectRenderedEntry(
+        propertiesPanel,
+        scriptTask,
+        [ 'extensionElements', 'values', 0, 'resultVariable' ],
+        'resultVariable'
+      );
+    }));
+
+  });
+
+
+  describe('assignment definition', function() {
+
+    beforeEach(bootstrap(assignmentDefinitionXML));
+
+
+    it('should render zeebe:AssignmentDefinition#assignee', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const userTask = elementRegistry.get('UserTask_1');
+
+      await act(() => selection.select(userTask));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        userTask,
+        [ 'extensionElements', 'values', 0, 'assignee' ],
+        'assignmentDefinitionAssignee'
+      );
+    }));
+
+  });
+
+
+  describe('task schedule', function() {
+
+    beforeEach(bootstrap(taskScheduleXML));
+
+
+    it('should render zeebe:TaskSchedule#dueDate', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const userTask = elementRegistry.get('UserTask_1');
+
+      await act(() => selection.select(userTask));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        userTask,
+        [ 'extensionElements', 'values', 0, 'dueDate' ],
+        'taskScheduleDueDate'
+      );
+    }));
+
+  });
+
+
+  describe('priority definition', function() {
+
+    beforeEach(bootstrap(priorityDefinitionXML));
+
+
+    it('should render zeebe:PriorityDefinition#priority', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const userTask = elementRegistry.get('UserTask_1');
+
+      await act(() => selection.select(userTask));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        userTask,
+        [ 'extensionElements', 'values', 1, 'priority' ],
+        'priorityDefinitionPriority'
+      );
+    }));
+
+  });
+
+
+  describe('active elements', function() {
+
+    beforeEach(bootstrap(activeElementsXML));
+
+
+    it('should render zeebe:AdHoc#activeElementsCollection', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const subProcess = elementRegistry.get('Subprocess_2');
+
+      await act(() => selection.select(subProcess));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        subProcess,
+        [ 'extensionElements', 'values', 0, 'activeElementsCollection' ],
+        'activeElements-activeElementsCollection'
+      );
+    }));
+
+  });
+
+
+  describe('message', function() {
+
+    beforeEach(bootstrap(messageXML));
+
+
+    it('should render bpmn:Message#name and zeebe:Subscription#correlationKey', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const catchEvent = elementRegistry.get('IntermediateEvent_1');
+
+      await act(() => selection.select(catchEvent));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        catchEvent,
+        [ 'eventDefinitions', 0, 'messageRef', 'name' ],
+        'messageName'
+      );
+
+      expectRenderedEntry(
+        propertiesPanel,
+        catchEvent,
+        [ 'eventDefinitions', 0, 'messageRef', 'extensionElements', 'values', 0, 'correlationKey' ],
+        'messageSubscriptionCorrelationKey'
+      );
+    }));
+
+  });
+
+
+  describe('signal', function() {
+
+    beforeEach(bootstrap(signalXML));
+
+
+    it('should render bpmn:Signal#name', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const throwEvent = elementRegistry.get('SignalIntermediateThrowEvent_Static');
+
+      await act(() => selection.select(throwEvent));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        throwEvent,
+        [ 'eventDefinitions', 0, 'signalRef', 'name' ],
+        'signalName'
       );
     }));
 

--- a/test/spec/provider/zeebe/EntryIdRendered.spec.js
+++ b/test/spec/provider/zeebe/EntryIdRendered.spec.js
@@ -1,0 +1,216 @@
+import { expect } from 'chai';
+
+import TestContainer from 'mocha-test-container-support';
+
+import { act } from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/render';
+
+import BpmnPropertiesProvider from 'src/provider/bpmn';
+import ZeebePropertiesProvider from 'src/provider/zeebe';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import executionListenersXML from './ExecutionListenerProps.bpmn';
+import inputXML from './InputProps.bpmn';
+import businessIdXML from './BusinessIdProps.bpmn';
+
+
+// verify the render-agnostic contract end to end: whatever id
+// ZeebePropertiesProvider resolves for a moddle path is actually rendered as an
+// entry (or group) in the DOM - so the resolver can never drift from the UI
+describe('provider/zeebe - entry id rendered', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  function expectRenderedEntry(propertiesPanel, element, path, expectedId) {
+
+    // when
+    const entryId = propertiesPanel.getEntryId(element, path);
+
+    // then
+    expect(entryId, 'resolved entry id').to.eql(expectedId);
+
+    const rendered = domQuery(
+      `[data-entry-id="${ entryId }"], [data-group-id="group-${ entryId }"]`,
+      container
+    );
+
+    expect(rendered, `rendered entry or group "${ entryId }"`).to.exist;
+  }
+
+
+  describe('execution listeners', function() {
+
+    beforeEach(bootstrapPropertiesPanel(executionListenersXML, {
+      modules: [
+        CoreModule,
+        ModelingModule,
+        SelectionModule,
+        BpmnPropertiesPanel,
+        BpmnPropertiesProvider,
+        ZeebePropertiesProvider
+      ],
+      moddleExtensions: {
+        zeebe: zeebeModdleExtensions
+      },
+      debounceInput: false
+    }));
+
+
+    it('should render bpmn:Process#isExecutable', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const process = elementRegistry.get('Process');
+
+      await act(() => selection.select(process));
+
+      // then
+      expectRenderedEntry(propertiesPanel, process, [ 'isExecutable' ], 'isExecutable');
+    }));
+
+
+    it('should render an execution listener field', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const task = elementRegistry.get('Task_MultipleHeaders');
+
+      await act(() => selection.select(task));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        task,
+        [ 'extensionElements', 'values', 0, 'listeners', 0, 'retries' ],
+        'Task_MultipleHeaders-executionListener-0-retries'
+      );
+    }));
+
+
+    it('should render a nested execution listener header', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const task = elementRegistry.get('Task_MultipleHeaders');
+
+      await act(() => selection.select(task));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        task,
+        [ 'extensionElements', 'values', 0, 'listeners', 0, 'headers', 'values', 0, 'key' ],
+        'Task_MultipleHeaders-executionListener-0-headers-header-0-key'
+      );
+    }));
+
+  });
+
+
+  describe('io mapping', function() {
+
+    beforeEach(bootstrapPropertiesPanel(inputXML, {
+      modules: [
+        CoreModule,
+        ModelingModule,
+        SelectionModule,
+        BpmnPropertiesPanel,
+        BpmnPropertiesProvider,
+        ZeebePropertiesProvider
+      ],
+      moddleExtensions: {
+        zeebe: zeebeModdleExtensions
+      },
+      debounceInput: false
+    }));
+
+
+    it('should render an input parameter field', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => selection.select(serviceTask));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        serviceTask,
+        [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ],
+        'ServiceTask_1-input-0-source'
+      );
+    }));
+
+
+    it('should render the inputs group for the collection', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => selection.select(serviceTask));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        serviceTask,
+        [ 'extensionElements', 'values', 0, 'inputParameters' ],
+        'inputs'
+      );
+    }));
+
+  });
+
+
+  describe('business id', function() {
+
+    beforeEach(bootstrapPropertiesPanel(businessIdXML, {
+      modules: [
+        CoreModule,
+        ModelingModule,
+        SelectionModule,
+        BpmnPropertiesPanel,
+        BpmnPropertiesProvider,
+        ZeebePropertiesProvider
+      ],
+      moddleExtensions: {
+        zeebe: zeebeModdleExtensions
+      },
+      debounceInput: false
+    }));
+
+
+    it('should render zeebe:CalledElement#businessId', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_override');
+
+      await act(() => selection.select(callActivity));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        callActivity,
+        [ 'extensionElements', 'values', 0, 'businessId' ],
+        'businessId'
+      );
+    }));
+
+  });
+
+});

--- a/test/spec/provider/zeebe/EntryIdUtil.spec.js
+++ b/test/spec/provider/zeebe/EntryIdUtil.spec.js
@@ -562,7 +562,7 @@ describe('provider/zeebe - EntryIdUtil', function() {
         ]);
 
         // then
-        expect(entryId).to.eql('activeElementsCollection');
+        expect(entryId).to.eql('activeElements-activeElementsCollection');
       });
 
     });

--- a/test/spec/provider/zeebe/EntryIdUtil.spec.js
+++ b/test/spec/provider/zeebe/EntryIdUtil.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { getZeebeEntryId } from '../../../src/provider/zeebe/utils/EntryIdUtil';
+import { getZeebeEntryId } from '../../../../src/provider/zeebe/utils/EntryIdUtil';
 
 import { BpmnModdle } from 'bpmn-moddle';
 
@@ -317,6 +317,26 @@ describe('provider/zeebe - EntryIdUtil', function() {
         // then
         expect(bindingTypeEntryId).to.eql('bindingType');
         expect(versionTagEntryId).to.eql('versionTag');
+      });
+
+
+      it('should resolve businessId', function() {
+
+        // given
+        const calledElement = createElement('zeebe:CalledElement', { businessId: 'foo' });
+
+        const callActivity = createElement('bpmn:CallActivity', {
+          id: 'CallActivity_1',
+          extensionElements: withExtensionElements([ calledElement ])
+        });
+
+        // when
+        const entryId = getZeebeEntryId(callActivity, [
+          'extensionElements', 'values', 0, 'businessId'
+        ]);
+
+        // then
+        expect(entryId).to.eql('businessId');
       });
 
     });
@@ -676,6 +696,375 @@ describe('provider/zeebe - EntryIdUtil', function() {
 
         // then
         expect(entryId).to.eql('signalName');
+      });
+
+    });
+
+
+    describe('zeebe:IoMapping (group)', function() {
+
+      it('should resolve inputParameters collection to the inputs group', function() {
+
+        // given
+        const ioMapping = createElement('zeebe:IoMapping', {
+          inputParameters: [ createElement('zeebe:Input', { source: '=foo', target: 'bar' }) ]
+        });
+
+        const serviceTask = createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ ioMapping ])
+        });
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'inputParameters'
+        ]);
+
+        // then
+        expect(entryId).to.eql('inputs');
+      });
+
+
+      it('should resolve outputParameters collection to the outputs group', function() {
+
+        // given
+        const ioMapping = createElement('zeebe:IoMapping', {
+          outputParameters: [ createElement('zeebe:Output', { source: '=foo', target: 'bar' }) ]
+        });
+
+        const serviceTask = createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ ioMapping ])
+        });
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'outputParameters'
+        ]);
+
+        // then
+        expect(entryId).to.eql('outputs');
+      });
+
+    });
+
+
+    describe('zeebe:ExecutionListener', function() {
+
+      function withExecutionListener(listener) {
+        const executionListeners = createElement('zeebe:ExecutionListeners', {
+          listeners: [ listener ]
+        });
+
+        return createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ executionListeners ])
+        });
+      }
+
+      it('should resolve eventType', function() {
+
+        // given
+        const listener = createElement('zeebe:ExecutionListener', {
+          eventType: 'start',
+          type: 'foo'
+        });
+
+        const serviceTask = withExecutionListener(listener);
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'listeners', 0, 'eventType'
+        ]);
+
+        // then
+        expect(entryId).to.eql('ServiceTask_1-executionListener-0-eventType');
+      });
+
+
+      it('should resolve type as the listenerType', function() {
+
+        // given
+        const listener = createElement('zeebe:ExecutionListener', {
+          eventType: 'start',
+          type: 'foo'
+        });
+
+        const serviceTask = withExecutionListener(listener);
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'listeners', 0, 'type'
+        ]);
+
+        // then
+        expect(entryId).to.eql('ServiceTask_1-executionListener-0-listenerType');
+      });
+
+
+      it('should resolve retries', function() {
+
+        // given
+        const listener = createElement('zeebe:ExecutionListener', {
+          eventType: 'start',
+          type: 'foo',
+          retries: '5'
+        });
+
+        const serviceTask = withExecutionListener(listener);
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'listeners', 0, 'retries'
+        ]);
+
+        // then
+        expect(entryId).to.eql('ServiceTask_1-executionListener-0-retries');
+      });
+
+
+      it('should resolve a nested header key', function() {
+
+        // given
+        const header = createElement('zeebe:Header', { key: 'foo', value: 'bar' });
+
+        const listener = createElement('zeebe:ExecutionListener', {
+          eventType: 'start',
+          type: 'foo',
+          headers: createElement('zeebe:TaskHeaders', { values: [ header ] })
+        });
+
+        const serviceTask = withExecutionListener(listener);
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'listeners', 0, 'headers', 'values', 0, 'key'
+        ]);
+
+        // then
+        expect(entryId).to.eql('ServiceTask_1-executionListener-0-headers-header-0-key');
+      });
+
+    });
+
+
+    describe('zeebe:TaskListener', function() {
+
+      it('should resolve eventType', function() {
+
+        // given
+        const listener = createElement('zeebe:TaskListener', {
+          eventType: 'assigning',
+          type: 'foo'
+        });
+
+        const taskListeners = createElement('zeebe:TaskListeners', {
+          listeners: [ listener ]
+        });
+
+        const userTask = createElement('bpmn:UserTask', {
+          id: 'UserTask_1',
+          extensionElements: withExtensionElements([ taskListeners ])
+        });
+
+        // when
+        const entryId = getZeebeEntryId(userTask, [
+          'extensionElements', 'values', 0, 'listeners', 0, 'eventType'
+        ]);
+
+        // then
+        expect(entryId).to.eql('UserTask_1-taskListener-0-eventType');
+      });
+
+    });
+
+
+    describe('bpmn:TimerEventDefinition', function() {
+
+      it('should resolve the value when the expression is present', function() {
+
+        // given
+        const timerEventDefinition = createElement('bpmn:TimerEventDefinition', {
+          timeDuration: createElement('bpmn:FormalExpression', { body: 'PT1H' })
+        });
+
+        const catchEvent = createElement('bpmn:IntermediateCatchEvent', {
+          id: 'IntermediateCatchEvent_1',
+          eventDefinitions: [ timerEventDefinition ]
+        });
+
+        // when
+        const entryId = getZeebeEntryId(catchEvent, [
+          'eventDefinitions', 0, 'timeDuration'
+        ]);
+
+        // then
+        expect(entryId).to.eql('timerEventDefinitionValue');
+      });
+
+
+      it('should return null when the expression is absent', function() {
+
+        // given
+        const timerEventDefinition = createElement('bpmn:TimerEventDefinition', {});
+
+        const catchEvent = createElement('bpmn:IntermediateCatchEvent', {
+          id: 'IntermediateCatchEvent_1',
+          eventDefinitions: [ timerEventDefinition ]
+        });
+
+        // when
+        const entryId = getZeebeEntryId(catchEvent, [
+          'eventDefinitions', 0, 'timeDuration'
+        ]);
+
+        // then
+        expect(entryId).to.be.null;
+      });
+
+    });
+
+
+    describe('bpmn:Process', function() {
+
+      it('should resolve isExecutable', function() {
+
+        // given
+        const process = createElement('bpmn:Process', {
+          id: 'Process_1',
+          isExecutable: true
+        });
+
+        // when
+        const entryId = getZeebeEntryId(process, [ 'isExecutable' ]);
+
+        // then
+        expect(entryId).to.eql('isExecutable');
+      });
+
+    });
+
+
+    describe('bpmn:Error (name)', function() {
+
+      it('should resolve name', function() {
+
+        // given
+        const error = createElement('bpmn:Error', { name: 'foo' });
+
+        const errorEventDefinition = createElement('bpmn:ErrorEventDefinition', { errorRef: error });
+
+        const endEvent = createElement('bpmn:EndEvent', {
+          id: 'EndEvent_1',
+          eventDefinitions: [ errorEventDefinition ]
+        });
+
+        // when
+        const entryId = getZeebeEntryId(endEvent, [
+          'eventDefinitions', 0, 'errorRef', 'name'
+        ]);
+
+        // then
+        expect(entryId).to.eql('errorName');
+      });
+
+    });
+
+
+    describe('bpmn:Escalation (name)', function() {
+
+      it('should resolve name', function() {
+
+        // given
+        const escalation = createElement('bpmn:Escalation', { name: 'foo' });
+
+        const escalationEventDefinition = createElement('bpmn:EscalationEventDefinition', {
+          escalationRef: escalation
+        });
+
+        const throwEvent = createElement('bpmn:IntermediateThrowEvent', {
+          id: 'IntermediateThrowEvent_1',
+          eventDefinitions: [ escalationEventDefinition ]
+        });
+
+        // when
+        const entryId = getZeebeEntryId(throwEvent, [
+          'eventDefinitions', 0, 'escalationRef', 'name'
+        ]);
+
+        // then
+        expect(entryId).to.eql('escalationName');
+      });
+
+    });
+
+
+    describe('bpmn:LinkEventDefinition', function() {
+
+      it('should resolve name', function() {
+
+        // given
+        const linkEventDefinition = createElement('bpmn:LinkEventDefinition', { name: 'foo' });
+
+        const throwEvent = createElement('bpmn:IntermediateThrowEvent', {
+          id: 'IntermediateThrowEvent_1',
+          eventDefinitions: [ linkEventDefinition ]
+        });
+
+        // when
+        const entryId = getZeebeEntryId(throwEvent, [
+          'eventDefinitions', 0, 'name'
+        ]);
+
+        // then
+        expect(entryId).to.eql('linkName');
+      });
+
+    });
+
+
+    describe('bpmn:CompensateEventDefinition', function() {
+
+      it('should resolve waitForCompletion and activityRef', function() {
+
+        // given
+        const compensateEventDefinition = createElement('bpmn:CompensateEventDefinition', {
+          waitForCompletion: true
+        });
+
+        const throwEvent = createElement('bpmn:IntermediateThrowEvent', {
+          id: 'IntermediateThrowEvent_1',
+          eventDefinitions: [ compensateEventDefinition ]
+        });
+
+        // then
+        expect(getZeebeEntryId(throwEvent, [
+          'eventDefinitions', 0, 'waitForCompletion'
+        ])).to.eql('waitForCompletion');
+
+        expect(getZeebeEntryId(throwEvent, [
+          'eventDefinitions', 0, 'activityRef'
+        ])).to.eql('activityRef');
+      });
+
+    });
+
+
+    describe('bpmn:AdHocSubProcess', function() {
+
+      it('should resolve cancelRemainingInstances', function() {
+
+        // given
+        const adHocSubProcess = createElement('bpmn:AdHocSubProcess', {
+          id: 'AdHocSubProcess_1',
+          cancelRemainingInstances: false
+        });
+
+        // when
+        const entryId = getZeebeEntryId(adHocSubProcess, [ 'cancelRemainingInstances' ]);
+
+        // then
+        expect(entryId).to.eql('cancelRemainingInstances');
       });
 
     });

--- a/test/spec/utils/EntryIdUtil.spec.js
+++ b/test/spec/utils/EntryIdUtil.spec.js
@@ -354,6 +354,333 @@ describe('provider/zeebe - EntryIdUtil', function() {
     });
 
 
+    describe('zeebe:AssignmentDefinition', function() {
+
+      it('should resolve assignee, candidateGroups and candidateUsers', function() {
+
+        // given
+        const assignmentDefinition = createElement('zeebe:AssignmentDefinition', {
+          assignee: 'foo',
+          candidateGroups: 'bar',
+          candidateUsers: 'baz'
+        });
+
+        const userTask = createElement('bpmn:UserTask', {
+          id: 'UserTask_1',
+          extensionElements: withExtensionElements([ assignmentDefinition ])
+        });
+
+        // when
+        const assigneeEntryId = getZeebeEntryId(userTask, [
+          'extensionElements', 'values', 0, 'assignee'
+        ]);
+
+        const candidateGroupsEntryId = getZeebeEntryId(userTask, [
+          'extensionElements', 'values', 0, 'candidateGroups'
+        ]);
+
+        const candidateUsersEntryId = getZeebeEntryId(userTask, [
+          'extensionElements', 'values', 0, 'candidateUsers'
+        ]);
+
+        // then
+        expect(assigneeEntryId).to.eql('assignmentDefinitionAssignee');
+        expect(candidateGroupsEntryId).to.eql('assignmentDefinitionCandidateGroups');
+        expect(candidateUsersEntryId).to.eql('assignmentDefinitionCandidateUsers');
+      });
+
+    });
+
+
+    describe('zeebe:TaskSchedule', function() {
+
+      it('should resolve dueDate and followUpDate', function() {
+
+        // given
+        const taskSchedule = createElement('zeebe:TaskSchedule', {
+          dueDate: '=foo',
+          followUpDate: '=bar'
+        });
+
+        const userTask = createElement('bpmn:UserTask', {
+          id: 'UserTask_1',
+          extensionElements: withExtensionElements([ taskSchedule ])
+        });
+
+        // when
+        const dueDateEntryId = getZeebeEntryId(userTask, [
+          'extensionElements', 'values', 0, 'dueDate'
+        ]);
+
+        const followUpDateEntryId = getZeebeEntryId(userTask, [
+          'extensionElements', 'values', 0, 'followUpDate'
+        ]);
+
+        // then
+        expect(dueDateEntryId).to.eql('taskScheduleDueDate');
+        expect(followUpDateEntryId).to.eql('taskScheduleFollowUpDate');
+      });
+
+    });
+
+
+    describe('zeebe:JobPriorityDefinition', function() {
+
+      it('should resolve priority', function() {
+
+        // given
+        const jobPriorityDefinition = createElement('zeebe:JobPriorityDefinition', { priority: '50' });
+
+        const serviceTask = createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ jobPriorityDefinition ])
+        });
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'priority'
+        ]);
+
+        // then
+        expect(entryId).to.eql('jobPriorityDefinitionPriority');
+      });
+
+    });
+
+
+    describe('zeebe:PriorityDefinition', function() {
+
+      it('should resolve priority', function() {
+
+        // given
+        const priorityDefinition = createElement('zeebe:PriorityDefinition', { priority: '50' });
+
+        const userTask = createElement('bpmn:UserTask', {
+          id: 'UserTask_1',
+          extensionElements: withExtensionElements([ priorityDefinition ])
+        });
+
+        // when
+        const entryId = getZeebeEntryId(userTask, [
+          'extensionElements', 'values', 0, 'priority'
+        ]);
+
+        // then
+        expect(entryId).to.eql('priorityDefinitionPriority');
+      });
+
+    });
+
+
+    describe('zeebe:VersionTag', function() {
+
+      it('should resolve value', function() {
+
+        // given
+        const versionTag = createElement('zeebe:VersionTag', { value: 'v1' });
+
+        const process = createElement('bpmn:Process', {
+          id: 'Process_1',
+          extensionElements: withExtensionElements([ versionTag ])
+        });
+
+        // when
+        const entryId = getZeebeEntryId(process, [
+          'extensionElements', 'values', 0, 'value'
+        ]);
+
+        // then
+        expect(entryId).to.eql('versionTag');
+      });
+
+    });
+
+
+    describe('zeebe:AdHoc', function() {
+
+      it('should resolve outputCollection and outputElement', function() {
+
+        // given
+        const adHoc = createElement('zeebe:AdHoc', {
+          outputCollection: '=foo',
+          outputElement: '=bar'
+        });
+
+        const adHocSubProcess = createElement('bpmn:AdHocSubProcess', {
+          id: 'AdHocSubProcess_1',
+          extensionElements: withExtensionElements([ adHoc ])
+        });
+
+        // when
+        const outputCollectionEntryId = getZeebeEntryId(adHocSubProcess, [
+          'extensionElements', 'values', 0, 'outputCollection'
+        ]);
+
+        const outputElementEntryId = getZeebeEntryId(adHocSubProcess, [
+          'extensionElements', 'values', 0, 'outputElement'
+        ]);
+
+        // then
+        expect(outputCollectionEntryId).to.eql('adHocOutputCollection');
+        expect(outputElementEntryId).to.eql('adHocOutputElement');
+      });
+
+
+      it('should resolve activeElementsCollection', function() {
+
+        // given
+        const adHoc = createElement('zeebe:AdHoc', { activeElementsCollection: '=foo' });
+
+        const adHocSubProcess = createElement('bpmn:AdHocSubProcess', {
+          id: 'AdHocSubProcess_1',
+          extensionElements: withExtensionElements([ adHoc ])
+        });
+
+        // when
+        const entryId = getZeebeEntryId(adHocSubProcess, [
+          'extensionElements', 'values', 0, 'activeElementsCollection'
+        ]);
+
+        // then
+        expect(entryId).to.eql('activeElementsCollection');
+      });
+
+    });
+
+
+    describe('bpmn:Error', function() {
+
+      it('should resolve errorCode', function() {
+
+        // given
+        const error = createElement('bpmn:Error', { errorCode: 'foo' });
+
+        const errorEventDefinition = createElement('bpmn:ErrorEventDefinition', { errorRef: error });
+
+        const endEvent = createElement('bpmn:EndEvent', {
+          id: 'EndEvent_1',
+          eventDefinitions: [ errorEventDefinition ]
+        });
+
+        // when
+        const entryId = getZeebeEntryId(endEvent, [
+          'eventDefinitions', 0, 'errorRef', 'errorCode'
+        ]);
+
+        // then
+        expect(entryId).to.eql('errorCode');
+      });
+
+    });
+
+
+    describe('bpmn:Escalation', function() {
+
+      it('should resolve escalationCode', function() {
+
+        // given
+        const escalation = createElement('bpmn:Escalation', { escalationCode: 'foo' });
+
+        const escalationEventDefinition = createElement('bpmn:EscalationEventDefinition', {
+          escalationRef: escalation
+        });
+
+        const endEvent = createElement('bpmn:EndEvent', {
+          id: 'EndEvent_1',
+          eventDefinitions: [ escalationEventDefinition ]
+        });
+
+        // when
+        const entryId = getZeebeEntryId(endEvent, [
+          'eventDefinitions', 0, 'escalationRef', 'escalationCode'
+        ]);
+
+        // then
+        expect(entryId).to.eql('escalationCode');
+      });
+
+    });
+
+
+    describe('bpmn:Message', function() {
+
+      it('should resolve name', function() {
+
+        // given
+        const message = createElement('bpmn:Message', { name: 'foo' });
+
+        const messageEventDefinition = createElement('bpmn:MessageEventDefinition', { messageRef: message });
+
+        const startEvent = createElement('bpmn:StartEvent', {
+          id: 'StartEvent_1',
+          eventDefinitions: [ messageEventDefinition ]
+        });
+
+        // when
+        const entryId = getZeebeEntryId(startEvent, [
+          'eventDefinitions', 0, 'messageRef', 'name'
+        ]);
+
+        // then
+        expect(entryId).to.eql('messageName');
+      });
+
+
+      it('should resolve subscription correlation key', function() {
+
+        // given
+        const subscription = createElement('zeebe:Subscription', { correlationKey: '=foo' });
+
+        const message = createElement('bpmn:Message', {
+          name: 'foo',
+          extensionElements: withExtensionElements([ subscription ])
+        });
+
+        const messageEventDefinition = createElement('bpmn:MessageEventDefinition', { messageRef: message });
+
+        const startEvent = createElement('bpmn:StartEvent', {
+          id: 'StartEvent_1',
+          eventDefinitions: [ messageEventDefinition ]
+        });
+
+        // when
+        const entryId = getZeebeEntryId(startEvent, [
+          'eventDefinitions', 0, 'messageRef', 'extensionElements', 'values', 0, 'correlationKey'
+        ]);
+
+        // then
+        expect(entryId).to.eql('messageSubscriptionCorrelationKey');
+      });
+
+    });
+
+
+    describe('bpmn:Signal', function() {
+
+      it('should resolve name', function() {
+
+        // given
+        const signal = createElement('bpmn:Signal', { name: 'foo' });
+
+        const signalEventDefinition = createElement('bpmn:SignalEventDefinition', { signalRef: signal });
+
+        const throwEvent = createElement('bpmn:IntermediateThrowEvent', {
+          id: 'IntermediateThrowEvent_1',
+          eventDefinitions: [ signalEventDefinition ]
+        });
+
+        // when
+        const entryId = getZeebeEntryId(throwEvent, [
+          'eventDefinitions', 0, 'signalRef', 'name'
+        ]);
+
+        // then
+        expect(entryId).to.eql('signalName');
+      });
+
+    });
+
+
     describe('unsupported paths', function() {
 
       it('should return null for an unrecognized node type', function() {

--- a/test/spec/utils/EntryIdUtil.spec.js
+++ b/test/spec/utils/EntryIdUtil.spec.js
@@ -231,6 +231,34 @@ describe('provider/zeebe - EntryIdUtil', function() {
         expect(resultVariableEntryId).to.eql('resultVariable');
       });
 
+
+      it('should resolve bindingType and versionTag', function() {
+
+        // given
+        const calledDecision = createElement('zeebe:CalledDecision', {
+          bindingType: 'versionTag',
+          versionTag: 'v1'
+        });
+
+        const businessRuleTask = createElement('bpmn:BusinessRuleTask', {
+          id: 'BusinessRuleTask_1',
+          extensionElements: withExtensionElements([ calledDecision ])
+        });
+
+        // when
+        const bindingTypeEntryId = getZeebeEntryId(businessRuleTask, [
+          'extensionElements', 'values', 0, 'bindingType'
+        ]);
+
+        const versionTagEntryId = getZeebeEntryId(businessRuleTask, [
+          'extensionElements', 'values', 0, 'versionTag'
+        ]);
+
+        // then
+        expect(bindingTypeEntryId).to.eql('bindingType');
+        expect(versionTagEntryId).to.eql('versionTag');
+      });
+
     });
 
 
@@ -261,6 +289,34 @@ describe('provider/zeebe - EntryIdUtil', function() {
         // then
         expect(processIdEntryId).to.eql('targetProcessId');
         expect(propagateEntryId).to.eql('propagateAllChildVariables');
+      });
+
+
+      it('should resolve bindingType and versionTag', function() {
+
+        // given
+        const calledElement = createElement('zeebe:CalledElement', {
+          bindingType: 'versionTag',
+          versionTag: 'v1'
+        });
+
+        const callActivity = createElement('bpmn:CallActivity', {
+          id: 'CallActivity_1',
+          extensionElements: withExtensionElements([ calledElement ])
+        });
+
+        // when
+        const bindingTypeEntryId = getZeebeEntryId(callActivity, [
+          'extensionElements', 'values', 0, 'bindingType'
+        ]);
+
+        const versionTagEntryId = getZeebeEntryId(callActivity, [
+          'extensionElements', 'values', 0, 'versionTag'
+        ]);
+
+        // then
+        expect(bindingTypeEntryId).to.eql('bindingType');
+        expect(versionTagEntryId).to.eql('versionTag');
       });
 
     });

--- a/test/spec/utils/EntryIdUtil.spec.js
+++ b/test/spec/utils/EntryIdUtil.spec.js
@@ -1,0 +1,384 @@
+import { expect } from 'chai';
+
+import { getZeebeEntryId } from '../../../src/provider/zeebe/utils/EntryIdUtil';
+
+import { BpmnModdle } from 'bpmn-moddle';
+
+import ZeebeBpmnModdle from 'zeebe-bpmn-moddle/resources/zeebe';
+
+
+describe('provider/zeebe - EntryIdUtil', function() {
+
+  const moddle = new BpmnModdle({
+    zeebe: ZeebeBpmnModdle
+  });
+
+  function createElement(type, properties) {
+    return moddle.create(type, properties);
+  }
+
+  function withExtensionElements(values) {
+    return createElement('bpmn:ExtensionElements', { values });
+  }
+
+
+  describe('#getZeebeEntryId', function() {
+
+    describe('zeebe:Input', function() {
+
+      it('should resolve source', function() {
+
+        // given
+        const input = createElement('zeebe:Input', { source: '=foo', target: 'bar' });
+
+        const ioMapping = createElement('zeebe:IoMapping', {
+          inputParameters: [ input ]
+        });
+
+        const serviceTask = createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ ioMapping ])
+        });
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'inputParameters', 0, 'source'
+        ]);
+
+        // then
+        expect(entryId).to.eql('ServiceTask_1-input-0-source');
+      });
+
+
+      it('should resolve target using the collection index', function() {
+
+        // given
+        const inputs = [
+          createElement('zeebe:Input', { source: '=1', target: 'a' }),
+          createElement('zeebe:Input', { source: '=2', target: 'b' })
+        ];
+
+        const ioMapping = createElement('zeebe:IoMapping', {
+          inputParameters: inputs
+        });
+
+        const serviceTask = createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ ioMapping ])
+        });
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'inputParameters', 1, 'target'
+        ]);
+
+        // then
+        expect(entryId).to.eql('ServiceTask_1-input-1-target');
+      });
+
+    });
+
+
+    describe('zeebe:Output', function() {
+
+      it('should resolve source', function() {
+
+        // given
+        const output = createElement('zeebe:Output', { source: '=foo', target: 'bar' });
+
+        const ioMapping = createElement('zeebe:IoMapping', {
+          outputParameters: [ output ]
+        });
+
+        const serviceTask = createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ ioMapping ])
+        });
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'outputParameters', 0, 'source'
+        ]);
+
+        // then
+        expect(entryId).to.eql('ServiceTask_1-output-0-source');
+      });
+
+    });
+
+
+    describe('zeebe:Header', function() {
+
+      it('should resolve key and value', function() {
+
+        // given
+        const header = createElement('zeebe:Header', { key: 'foo', value: 'bar' });
+
+        const taskHeaders = createElement('zeebe:TaskHeaders', {
+          values: [ header ]
+        });
+
+        const task = createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ taskHeaders ])
+        });
+
+        // when
+        const keyEntryId = getZeebeEntryId(task, [
+          'extensionElements', 'values', 0, 'values', 0, 'key'
+        ]);
+
+        const valueEntryId = getZeebeEntryId(task, [
+          'extensionElements', 'values', 0, 'values', 0, 'value'
+        ]);
+
+        // then
+        expect(keyEntryId).to.eql('ServiceTask_1-header-0-key');
+        expect(valueEntryId).to.eql('ServiceTask_1-header-0-value');
+      });
+
+    });
+
+
+    describe('zeebe:Property', function() {
+
+      it('should resolve name and value', function() {
+
+        // given
+        const property = createElement('zeebe:Property', { name: 'foo', value: 'bar' });
+
+        const properties = createElement('zeebe:Properties', {
+          properties: [ property ]
+        });
+
+        const task = createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ properties ])
+        });
+
+        // when
+        const nameEntryId = getZeebeEntryId(task, [
+          'extensionElements', 'values', 0, 'properties', 0, 'name'
+        ]);
+
+        const valueEntryId = getZeebeEntryId(task, [
+          'extensionElements', 'values', 0, 'properties', 0, 'value'
+        ]);
+
+        // then
+        expect(nameEntryId).to.eql('ServiceTask_1-extensionProperty-0-name');
+        expect(valueEntryId).to.eql('ServiceTask_1-extensionProperty-0-value');
+      });
+
+    });
+
+
+    describe('zeebe:TaskDefinition', function() {
+
+      it('should resolve type and retries', function() {
+
+        // given
+        const taskDefinition = createElement('zeebe:TaskDefinition', { type: 'foo', retries: '3' });
+
+        const task = createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ taskDefinition ])
+        });
+
+        // when
+        const typeEntryId = getZeebeEntryId(task, [
+          'extensionElements', 'values', 0, 'type'
+        ]);
+
+        const retriesEntryId = getZeebeEntryId(task, [
+          'extensionElements', 'values', 0, 'retries'
+        ]);
+
+        // then
+        expect(typeEntryId).to.eql('taskDefinitionType');
+        expect(retriesEntryId).to.eql('taskDefinitionRetries');
+      });
+
+    });
+
+
+    describe('zeebe:CalledDecision', function() {
+
+      it('should resolve decisionId and resultVariable', function() {
+
+        // given
+        const calledDecision = createElement('zeebe:CalledDecision', {
+          decisionId: 'foo',
+          resultVariable: 'bar'
+        });
+
+        const businessRuleTask = createElement('bpmn:BusinessRuleTask', {
+          id: 'BusinessRuleTask_1',
+          extensionElements: withExtensionElements([ calledDecision ])
+        });
+
+        // when
+        const decisionIdEntryId = getZeebeEntryId(businessRuleTask, [
+          'extensionElements', 'values', 0, 'decisionId'
+        ]);
+
+        const resultVariableEntryId = getZeebeEntryId(businessRuleTask, [
+          'extensionElements', 'values', 0, 'resultVariable'
+        ]);
+
+        // then
+        expect(decisionIdEntryId).to.eql('decisionId');
+        expect(resultVariableEntryId).to.eql('resultVariable');
+      });
+
+    });
+
+
+    describe('zeebe:CalledElement', function() {
+
+      it('should resolve processId and propagateAllChildVariables', function() {
+
+        // given
+        const calledElement = createElement('zeebe:CalledElement', {
+          processId: 'foo',
+          propagateAllChildVariables: false
+        });
+
+        const callActivity = createElement('bpmn:CallActivity', {
+          id: 'CallActivity_1',
+          extensionElements: withExtensionElements([ calledElement ])
+        });
+
+        // when
+        const processIdEntryId = getZeebeEntryId(callActivity, [
+          'extensionElements', 'values', 0, 'processId'
+        ]);
+
+        const propagateEntryId = getZeebeEntryId(callActivity, [
+          'extensionElements', 'values', 0, 'propagateAllChildVariables'
+        ]);
+
+        // then
+        expect(processIdEntryId).to.eql('targetProcessId');
+        expect(propagateEntryId).to.eql('propagateAllChildVariables');
+      });
+
+    });
+
+
+    describe('zeebe:Script', function() {
+
+      it('should resolve expression and resultVariable', function() {
+
+        // given
+        const script = createElement('zeebe:Script', {
+          expression: '=foo',
+          resultVariable: 'bar'
+        });
+
+        const scriptTask = createElement('bpmn:ScriptTask', {
+          id: 'ScriptTask_1',
+          extensionElements: withExtensionElements([ script ])
+        });
+
+        // when
+        const expressionEntryId = getZeebeEntryId(scriptTask, [
+          'extensionElements', 'values', 0, 'expression'
+        ]);
+
+        const resultVariableEntryId = getZeebeEntryId(scriptTask, [
+          'extensionElements', 'values', 0, 'resultVariable'
+        ]);
+
+        // then
+        expect(expressionEntryId).to.eql('scriptExpression');
+        expect(resultVariableEntryId).to.eql('resultVariable');
+      });
+
+    });
+
+
+    describe('unsupported paths', function() {
+
+      it('should return null for an unrecognized node type', function() {
+
+        // given
+        const task = createElement('bpmn:ServiceTask', { id: 'ServiceTask_1', name: 'foo' });
+
+        // when
+        const entryId = getZeebeEntryId(task, [ 'name' ]);
+
+        // then
+        expect(entryId).to.be.null;
+      });
+
+
+      it('should return null for an unrecognized field on a known node type', function() {
+
+        // given
+        const input = createElement('zeebe:Input', { source: '=foo', target: 'bar' });
+
+        const ioMapping = createElement('zeebe:IoMapping', {
+          inputParameters: [ input ]
+        });
+
+        const serviceTask = createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ ioMapping ])
+        });
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'inputParameters', 0, 'unknownField'
+        ]);
+
+        // then
+        expect(entryId).to.be.null;
+      });
+
+
+      it('should return null for a path pointing to a missing property', function() {
+
+        // given
+        const serviceTask = createElement('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'inputParameters', 0, 'source'
+        ]);
+
+        // then
+        expect(entryId).to.be.null;
+      });
+
+
+      it('should return null for an empty path', function() {
+
+        // given
+        const serviceTask = createElement('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, []);
+
+        // then
+        expect(entryId).to.be.null;
+      });
+
+
+      it('should return null when the path is not an array', function() {
+
+        // given
+        const serviceTask = createElement('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, null);
+
+        // then
+        expect(entryId).to.be.null;
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
## What

Adds a public `propertiesPanel.getEntryId(element, path)` API that resolves a moddle property path (relative to the element's business object) to the id of the properties-panel entry that edits it. The returned id can be fed into other properties-panel APIs such as `propertiesPanel.showEntry`, so interested parties (lint reports, variable references) can reveal the entry that owns a given model location.

Providers contribute the resolution by implementing an optional `getEntryId(element, path)`, mirroring the existing `getGroups` middleware. Providers are asked in **reverse render order**, so a provider whose groups render last (registered with low priority to override others, e.g. element templates) answers first and can shadow standard entries by returning a truthy id — or defer with `null`. Unrecognized paths resolve to `null` (graceful degradation for consumers with a legacy fallback).

Resolvers are implemented for the **bpmn**, **camunda-platform** and **zeebe** providers, single-sourcing the entry-id scheme so the rendered entry and the resolver can never drift. Coverage includes:

* **bpmn**: element documentation
* **camunda-platform**: `camunda:historyTimeToLive` (incl. `bpmn:Participant` → `bpmn:Process` walk)
* **zeebe**:
  * `zeebe:Input` / `zeebe:Output` parameters, `zeebe:Header`, `zeebe:Property` list entries
  * execution/task listeners, incl. nested execution-listener headers
  * `zeebe:TaskDefinition`, `zeebe:CalledDecision`, `zeebe:CalledElement`, `zeebe:Script`
  * assignment / task schedule / priority / job priority definitions, multi-instance, ad-hoc, forms, binding type / version tag
  * message / signal / error / escalation names, message subscription correlation key, timer expression value, sequence-flow condition, `bpmn:Process#isExecutable`
  * io mapping input/output collections resolve outward to their group

## Why

Entry-id resolution for lint findings today lives in `@camunda/linting` as a large switch that *reconstructs* entry ids owned by the render layer — fragile, duplicated (`variable-outline` grew its own copy), and blind to element templates replacing a field. Moving resolution into the panel, contributed by the providers that author the ids, makes rules render-agnostic: navigation is derived, never authored. Supports the established practices on [linting architecture](https://github.com/camunda/bpmnlint-plugin-camunda-compat/tree/main/docs).

## Test coverage

* Unit specs for each provider's path resolver (pure moddle fixtures, incl. null/edge cases)
* Renderer specs for provider aggregation (reverse render order, defer/fallback, providers without a resolver)
* Integration specs asserting each resolved id matches an entry actually rendered in the DOM — pins the resolver to the real id scheme so drift fails CI

## Notes

Incorporates the follow-up work from #1245 (remaining zeebe groups and the bpmn / camunda-platform resolvers), so this branch now carries the complete first per-repo increment. Follow-ups tracked separately: element-templates resolver and the `@camunda/linting` consumer (with the existing switch as fallback).

Related to https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/255
Related to https://github.com/bpmn-io/internal-docs/issues/1355