### PR TITLE
feat: resolve properties panel entry IDs from model paths

### DIFF
--- a/src/provider/bpmn/BpmnPropertiesProvider.js
+++ b/src/provider/bpmn/BpmnPropertiesProvider.js
@@ -1,5 +1,7 @@
 import { Group } from '@bpmn-io/properties-panel';
 
+import { getBpmnEntryId } from './utils/EntryIdUtil';
+
 import {
   AdHocCompletionProps,
   CompensationProps,
@@ -246,6 +248,19 @@ export default class BpmnPropertiesProvider {
       groups = groups.concat(getGroups(element, this._injector));
       return groups;
     };
+  }
+
+  /**
+   * Resolve a moddle location rendered by this (standard bpmn) provider to its
+   * entry id, so consumers like linting can stay render-agnostic.
+   *
+   * @param {djs.model.Base} element
+   * @param {Array<string|number>} path moddle path, relative to the element's business object
+   *
+   * @return {string|null}
+   */
+  getEntryId(element, path) {
+    return getBpmnEntryId(element, path);
   }
 
 }

--- a/src/provider/bpmn/utils/EntryIdUtil.js
+++ b/src/provider/bpmn/utils/EntryIdUtil.js
@@ -1,0 +1,36 @@
+import { isArray } from 'min-dash';
+
+/**
+ * Resolve a moddle location on an element to the standard bpmn entry id this
+ * provider renders for it.
+ *
+ * The location is a moddle `path` (as produced by `getPath` from
+ * `@bpmn-io/moddle-utils`) rooted at the element's business object — the same
+ * shape lint rules report. Scoped to the properties the bpmn (standard)
+ * provider owns; mirrors the zeebe provider's resolver.
+ *
+ * Returns `null` when the location is not rendered by a standard bpmn entry (so
+ * the caller can defer to another provider or its own fallback).
+ *
+ * @param {djs.model.Base|ModdleElement} element
+ * @param {Array<string|number>} path
+ *
+ * @return {string|null}
+ */
+export function getBpmnEntryId(element, path) {
+  if (!element || !isArray(path) || !path.length) {
+    return null;
+  }
+
+  const property = path[ path.length - 1 ];
+
+  // element documentation (DocumentationProps). A finding points at the
+  // `documentation` property — the best-effort element-level anchor a rule
+  // emits when documentation text is missing — which the group renders as the
+  // `documentation` entry (always present, regardless of element type).
+  if (property === 'documentation') {
+    return 'documentation';
+  }
+
+  return null;
+}

--- a/src/provider/camunda-platform/CamundaPlatformPropertiesProvider.js
+++ b/src/provider/camunda-platform/CamundaPlatformPropertiesProvider.js
@@ -44,6 +44,8 @@ import {
 
 import { ExtensionPropertiesProps } from '../shared/ExtensionPropertiesProps';
 
+import { getCamundaPlatformEntryId } from './utils/EntryIdUtil';
+
 { /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
 
 const LOW_PRIORITY = 500;
@@ -138,6 +140,18 @@ export default class CamundaPlatformPropertiesProvider {
 
     // contract: if a group returns null, it should not be displayed at all
     return groups.filter(group => group !== null);
+  }
+
+  /**
+   * Resolve the id of the entry that edits the given moddle property path.
+   *
+   * @param {djs.model.Base} element
+   * @param {(string|number)[]} path moddle property path, relative to the element's business object
+   *
+   * @return {string|null}
+   */
+  getEntryId(element, path) {
+    return getCamundaPlatformEntryId(element, path);
   }
 }
 

--- a/src/provider/camunda-platform/properties/HistoryCleanupProps.js
+++ b/src/provider/camunda-platform/properties/HistoryCleanupProps.js
@@ -9,6 +9,8 @@ import {
   useService
 } from '../../../hooks';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 
 export function HistoryCleanupProps(props) {
   const {
@@ -24,7 +26,7 @@ export function HistoryCleanupProps(props) {
 
   return [
     {
-      id: 'historyTimeToLive',
+      id: getSingletonEntryId('bpmn:Process', 'historyTimeToLive'),
       component: HistoryTimeToLive,
       isEdited: isTextFieldEntryEdited
     },
@@ -56,7 +58,7 @@ function HistoryTimeToLive(props) {
 
   return TextFieldEntry({
     element,
-    id: 'historyTimeToLive',
+    id: getSingletonEntryId('bpmn:Process', 'historyTimeToLive'),
     label: translate('Time to live'),
     getValue,
     setValue,

--- a/src/provider/camunda-platform/utils/EntryIdUtil.js
+++ b/src/provider/camunda-platform/utils/EntryIdUtil.js
@@ -1,0 +1,74 @@
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import { isArray } from 'min-dash';
+
+/**
+ * Entry id schemes for moddle elements that are rendered as static
+ * (non-list) entries, keyed by moddle `$type` and moddle property name.
+ */
+const SINGLETON_ENTRY_SCHEMES = {
+  'bpmn:Process': {
+    historyTimeToLive: 'historyTimeToLive'
+  }
+};
+
+/**
+ * Resolve the id of a static (non-list) entry that edits the given moddle
+ * property. This is the single source for the id scheme: it is used both
+ * to render the entry and to resolve it.
+ *
+ * @param {string} type the moddle `$type` of the edited element
+ * @param {string} property the edited moddle property
+ *
+ * @return {string|null}
+ */
+export function getSingletonEntryId(type, property) {
+  const scheme = SINGLETON_ENTRY_SCHEMES[type];
+
+  return scheme && scheme[property] || null;
+}
+
+/**
+ * Resolve a moddle location on an element to the Camunda 7 (platform) entry id
+ * this provider renders for it.
+ *
+ * The location is a moddle `path` (as produced by `getPath` from
+ * `@bpmn-io/moddle-utils`) rooted at the element's business object — the same
+ * shape lint rules report. Scoped to the properties the camunda-platform
+ * provider owns; mirrors the zeebe and bpmn providers' resolvers.
+ *
+ * Returns `null` when the location is not rendered by a camunda-platform entry
+ * (so the caller can defer to another provider or its own fallback).
+ *
+ * @param {djs.model.Base} element
+ * @param {(string|number)[]} path
+ *
+ * @return {string|null}
+ */
+export function getCamundaPlatformEntryId(element, path) {
+  if (!element || !isArray(path) || !path.length) {
+    return null;
+  }
+
+  const field = path[path.length - 1];
+
+  if (typeof field !== 'string') {
+    return null;
+  }
+
+  let node = getBusinessObject(element);
+
+  // walk all but the last segment to the node that owns the edited property
+  // (e.g. a bpmn:Participant's `processRef` points at the bpmn:Process)
+  for (let i = 0; i < path.length - 1 && node; i++) {
+    const segment = path[i];
+
+    node = typeof segment === 'number' ? node[segment] : node.get(segment);
+  }
+
+  if (!node) {
+    return null;
+  }
+
+  return getSingletonEntryId(node.$type, field);
+}

--- a/src/provider/zeebe/properties/BusinessIdProps.js
+++ b/src/provider/zeebe/properties/BusinessIdProps.js
@@ -23,6 +23,8 @@ import {
   hasBusinessId
 } from '../utils/CalledElementUtil.js';
 
+import { getSingletonEntryId } from '../utils/EntryIdUtil';
+
 /**
  * Business ID configuration for a Call Activity. The child process instance
  * either inherits the parent's Business ID (default) or overrides it with a
@@ -47,7 +49,7 @@ export function BusinessIdProps(props) {
 
   if (hasBusinessId(element)) {
     entries.push({
-      id: 'businessId',
+      id: getSingletonEntryId('zeebe:CalledElement', 'businessId'),
       component: BusinessId,
       isEdited: isFeelEntryEdited
     });

--- a/src/provider/zeebe/utils/EntryIdUtil.js
+++ b/src/provider/zeebe/utils/EntryIdUtil.js
@@ -1,6 +1,9 @@
 import {
-  getBusinessObject
+  getBusinessObject,
+  is
 } from 'bpmn-js/lib/util/ModelUtil';
+
+import { isArray } from 'min-dash';
 
 /**
  * Entry id schemes for moddle elements that are rendered as items of a
@@ -20,9 +23,9 @@ const LIST_ENTRY_SCHEMES = {
   // path), so only resolved here — not built via getListEntryId
   'zeebe:Property': { kind: 'extensionProperty', fields: [ 'name', 'value' ] },
 
-  // forward-only (no `fields`): their entry ids are built via getListEntryId
-  // but their field suffixes are labels, not moddle properties, so they are
-  // not path-resolved
+  // listener fields are label-named (not moddle properties), so they carry no
+  // `fields`; getListEntryId builds their list-item prefix and resolveListenerEntry
+  // resolves the label suffixes (type/eventType/retries) via LISTENER_SUFFIX
   'zeebe:ExecutionListener': { kind: 'executionListener' },
   'zeebe:TaskListener': { kind: 'taskListener' }
 };
@@ -44,6 +47,7 @@ const SINGLETON_ENTRY_SCHEMES = {
   },
   'zeebe:CalledElement': {
     processId: 'targetProcessId',
+    businessId: 'businessId',
     bindingType: 'bindingType',
     versionTag: 'versionTag',
     propagateAllChildVariables: 'propagateAllChildVariables',
@@ -105,10 +109,12 @@ const SINGLETON_ENTRY_SCHEMES = {
     body: 'formConfiguration'
   },
   'bpmn:Error': {
-    errorCode: 'errorCode'
+    errorCode: 'errorCode',
+    name: 'errorName'
   },
   'bpmn:Escalation': {
-    escalationCode: 'escalationCode'
+    escalationCode: 'escalationCode',
+    name: 'escalationName'
   },
   'bpmn:Message': {
     name: 'messageName'
@@ -117,10 +123,36 @@ const SINGLETON_ENTRY_SCHEMES = {
     name: 'signalName'
   },
   'bpmn:AdHocSubProcess': {
-    completionCondition: 'completionCondition'
+    completionCondition: 'completionCondition',
+    cancelRemainingInstances: 'cancelRemainingInstances'
   },
   'bpmn:SequenceFlow': {
     conditionExpression: 'conditionExpression'
+  },
+  'bpmn:Process': {
+    isExecutable: 'isExecutable'
+  },
+
+  // event definition reference attributes; the path resolves to the event
+  // definition node itself (e.g. `[ 'eventDefinitions', 0, 'messageRef' ]`)
+  'bpmn:MessageEventDefinition': {
+    messageRef: 'messageRef'
+  },
+  'bpmn:SignalEventDefinition': {
+    signalRef: 'signalRef'
+  },
+  'bpmn:ErrorEventDefinition': {
+    errorRef: 'errorRef'
+  },
+  'bpmn:EscalationEventDefinition': {
+    escalationRef: 'escalationRef'
+  },
+  'bpmn:LinkEventDefinition': {
+    name: 'linkName'
+  },
+  'bpmn:CompensateEventDefinition': {
+    waitForCompletion: 'waitForCompletion',
+    activityRef: 'activityRef'
   }
 };
 
@@ -141,6 +173,31 @@ export const SELECTOR_ENTRY_IDS = {
   userTaskImplementation: 'userTaskImplementation',
   activeElementsCollectionValue: 'activeElements-activeElementsCollection'
 };
+
+/**
+ * Entry ids for a container (collection) rendered as a group, keyed by the
+ * container's moddle `$type` and the collection property. A finding may point
+ * at a collection rather than a single leaf (the best-effort anchor a rule
+ * emits when no concrete offending value exists), which resolves outward to
+ * the group that renders it.
+ */
+const GROUP_ENTRY_IDS = {
+  'zeebe:IoMapping': {
+    inputParameters: 'inputs',
+    outputParameters: 'outputs'
+  }
+};
+
+// moddle property -> entry id suffix for execution/task listeners; the
+// listener list-item prefix is single-sourced via getListEntryId, the suffix
+// mirrors the (label, not moddle-named) fields the listener component renders
+const LISTENER_SUFFIX = {
+  type: 'listenerType',
+  eventType: 'eventType',
+  retries: 'retries'
+};
+
+const TIMER_PROPERTIES = [ 'timeCycle', 'timeDate', 'timeDuration' ];
 
 /**
  * Build the id prefix shared by the entries of a list item (e.g.
@@ -192,7 +249,7 @@ export function getSingletonEntryId(type, property) {
  * @return {string|null}
  */
 export function getZeebeEntryId(element, path) {
-  if (!Array.isArray(path) || !path.length) {
+  if (!isArray(path) || !path.length) {
     return null;
   }
 
@@ -202,10 +259,12 @@ export function getZeebeEntryId(element, path) {
     return null;
   }
 
+  const businessObject = getBusinessObject(element);
+
   let resolved;
 
   try {
-    resolved = resolveNode(getBusinessObject(element), path);
+    resolved = resolveNode(businessObject, path);
   } catch (error) {
     return null;
   }
@@ -214,19 +273,127 @@ export function getZeebeEntryId(element, path) {
     return null;
   }
 
-  const { node, index } = resolved;
+  const { node, index, trail } = resolved;
 
-  const listScheme = LIST_ENTRY_SCHEMES[node.$type];
+  return (
+    resolveHeaderEntry(element, node, index, trail, field)
+    || resolveListenerEntry(element, node, index, field)
+    || resolveListEntry(element, node, index, field)
+    || resolveGroupEntry(node, field)
+    || resolveTimerEntry(node, field)
+    || getSingletonEntryId(node.$type, field)
+    || resolveReferenceNameEntry(businessObject, field)
+    || null
+  );
+}
 
-  if (listScheme) {
-    if (!listScheme.fields || typeof index !== 'number' || !listScheme.fields.includes(field)) {
-      return null;
-    }
 
-    return `${getListEntryId(element, node, index)}-${field}`;
+// resolver branches //////////////////
+
+// task headers and (nested) execution listener headers both render zeebe:Header
+// items; disambiguate via the resolved path so the id matches what is rendered
+function resolveHeaderEntry(element, node, index, trail, field) {
+  if (node.$type !== 'zeebe:Header' || (field !== 'key' && field !== 'value')) {
+    return null;
   }
 
-  return getSingletonEntryId(node.$type, field);
+  // a header nested inside an execution listener renders under the listener
+  // list-item prefix (`...-executionListener-<i>-headers-...`)
+  const listener = trail.find(entry => entry.node && entry.node.$type === 'zeebe:ExecutionListener');
+
+  if (listener) {
+    const listenerPrefix = getListEntryId(element, listener.node, listener.index);
+
+    return `${getListEntryId(`${listenerPrefix}-headers`, node, index)}-${field}`;
+  }
+
+  return `${getListEntryId(element, node, index)}-${field}`;
+}
+
+// execution/task listener fields render under the listener list-item prefix
+// with a label suffix that is not the moddle property name
+function resolveListenerEntry(element, node, index, field) {
+  if (node.$type !== 'zeebe:ExecutionListener' && node.$type !== 'zeebe:TaskListener') {
+    return null;
+  }
+
+  const suffix = LISTENER_SUFFIX[field];
+
+  if (!suffix || typeof index !== 'number') {
+    return null;
+  }
+
+  return `${getListEntryId(element, node, index)}-${suffix}`;
+}
+
+// io mapping parameters and extension properties render as list items keyed by
+// their moddle property (source/target, name/value)
+function resolveListEntry(element, node, index, field) {
+  if (node.$type === 'zeebe:Header') {
+    return null;
+  }
+
+  const scheme = LIST_ENTRY_SCHEMES[node.$type];
+
+  if (!scheme || !scheme.fields || typeof index !== 'number' || !scheme.fields.includes(field)) {
+    return null;
+  }
+
+  return `${getListEntryId(element, node, index)}-${field}`;
+}
+
+function resolveGroupEntry(node, field) {
+  const scheme = GROUP_ENTRY_IDS[node.$type];
+
+  return scheme && scheme[field] || null;
+}
+
+// the timer type selector has no leaf location and is deferred; the value field
+// is resolvable when the expression is present (value-not-allowed / -required)
+function resolveTimerEntry(node, field) {
+  if (node.$type !== 'bpmn:TimerEventDefinition' || !TIMER_PROPERTIES.includes(field)) {
+    return null;
+  }
+
+  return node.get(field) ? SELECTOR_ENTRY_IDS.timerEventDefinitionValue : null;
+}
+
+// findings on a referenced root's name/code, or legacy flat paths that address
+// the element itself, bottom out here — disambiguated by the element's event
+// definition (or, for a receive task, its message)
+function resolveReferenceNameEntry(businessObject, field) {
+  if (field === 'errorCode' && hasEventDefinition(businessObject, 'bpmn:ErrorEventDefinition')) {
+    return 'errorCode';
+  }
+
+  if (field === 'escalationCode' && hasEventDefinition(businessObject, 'bpmn:EscalationEventDefinition')) {
+    return 'escalationCode';
+  }
+
+  if (field === 'correlationKey') {
+    return 'messageSubscriptionCorrelationKey';
+  }
+
+  if (field === 'name') {
+    if (hasEventDefinition(businessObject, 'bpmn:MessageEventDefinition')
+      || is(businessObject, 'bpmn:ReceiveTask')) {
+      return 'messageName';
+    }
+
+    if (hasEventDefinition(businessObject, 'bpmn:SignalEventDefinition')) {
+      return 'signalName';
+    }
+
+    if (hasEventDefinition(businessObject, 'bpmn:ErrorEventDefinition')) {
+      return 'errorName';
+    }
+
+    if (hasEventDefinition(businessObject, 'bpmn:EscalationEventDefinition')) {
+      return 'escalationName';
+    }
+  }
+
+  return null;
 }
 
 
@@ -240,23 +407,45 @@ export function getZeebeEntryId(element, path) {
  * @param {ModdleElement} start
  * @param {(string|number)[]} path
  *
- * @return {{ node: ModdleElement, index: number|null }|null} the resolved
- * node, and the collection index used to reach it (if any)
+ * @return {{ node: ModdleElement, index: number|null, trail: Array<{ node: ModdleElement, index: number|null }> }|null}
+ * the resolved node, the collection index used to reach it (if any), and the
+ * trail of nodes visited along the way (for disambiguating nested locations)
  */
 function resolveNode(start, path) {
   let node = start;
-  let index = null;
+
+  const trail = [];
 
   for (let i = 0; i < path.length - 1 && node; i++) {
     const segment = path[i];
 
     if (typeof segment === 'number') {
       node = node[segment];
-      index = segment;
+
+      trail.push({ node, index: segment });
     } else {
       node = node.get(segment);
+
+      trail.push({ node, index: null });
     }
   }
 
-  return node ? { node, index } : null;
+  if (!node) {
+    return null;
+  }
+
+  const last = trail[trail.length - 1];
+
+  return { node, index: last ? last.index : null, trail };
+}
+
+/**
+ * Whether the element carries an event definition of the given type.
+ *
+ * @return {boolean}
+ */
+function hasEventDefinition(businessObject, type) {
+  const eventDefinitions = businessObject.get && businessObject.get('eventDefinitions');
+
+  return isArray(eventDefinitions) && eventDefinitions.some(definition => is(definition, type));
 }

--- a/test/spec/provider/bpmn/EntryIdRendered.spec.js
+++ b/test/spec/provider/bpmn/EntryIdRendered.spec.js
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+
+import TestContainer from 'mocha-test-container-support';
+
+import { act } from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/render';
+
+import BpmnPropertiesProvider from 'src/provider/bpmn';
+
+import documentationXML from './DocumentationProps.bpmn';
+
+
+// verify the render-agnostic contract end to end: whatever id
+// BpmnPropertiesProvider resolves for a moddle path is actually rendered as an
+// entry (or group) in the DOM - so the resolver can never drift from the UI
+describe('provider/bpmn - entry id rendered', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  function expectRenderedEntry(propertiesPanel, element, path, expectedId) {
+
+    // when
+    const entryId = propertiesPanel.getEntryId(element, path);
+
+    // then
+    expect(entryId, 'resolved entry id').to.eql(expectedId);
+
+    const rendered = domQuery(
+      `[data-entry-id="${ entryId }"], [data-group-id="group-${ entryId }"]`,
+      container
+    );
+
+    expect(rendered, `rendered entry or group "${ entryId }"`).to.exist;
+  }
+
+
+  describe('documentation', function() {
+
+    beforeEach(bootstrapPropertiesPanel(documentationXML, {
+      modules: [
+        CoreModule,
+        ModelingModule,
+        SelectionModule,
+        BpmnPropertiesPanel,
+        BpmnPropertiesProvider
+      ],
+      debounceInput: false
+    }));
+
+
+    it('should render element documentation', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      await act(() => selection.select(task));
+
+      // then
+      expectRenderedEntry(propertiesPanel, task, [ 'documentation' ], 'documentation');
+    }));
+
+  });
+
+});

--- a/test/spec/provider/bpmn/EntryIdUtil.spec.js
+++ b/test/spec/provider/bpmn/EntryIdUtil.spec.js
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+
+import { BpmnModdle } from 'bpmn-moddle';
+
+import { getBpmnEntryId } from '../../../../src/provider/bpmn/utils/EntryIdUtil';
+
+
+describe('provider/bpmn - EntryIdUtil', function() {
+
+  const moddle = new BpmnModdle();
+
+  function createElement(type, properties) {
+    return moddle.create(type, properties);
+  }
+
+
+  describe('#getBpmnEntryId', function() {
+
+    it('should resolve element documentation', function() {
+
+      // given
+      const task = createElement('bpmn:ServiceTask', { id: 'Task_1' });
+
+      // when
+      const entryId = getBpmnEntryId(task, [ 'documentation' ]);
+
+      // then
+      expect(entryId).to.eql('documentation');
+    });
+
+
+    it('should not resolve an unknown property', function() {
+
+      // given
+      const task = createElement('bpmn:ServiceTask', { id: 'Task_1' });
+
+      // when
+      const entryId = getBpmnEntryId(task, [ 'name' ]);
+
+      // then
+      expect(entryId).to.be.null;
+    });
+
+
+    it('should not resolve an empty path', function() {
+
+      // given
+      const task = createElement('bpmn:ServiceTask', { id: 'Task_1' });
+
+      // when
+      const entryId = getBpmnEntryId(task, []);
+
+      // then
+      expect(entryId).to.be.null;
+    });
+
+
+    it('should not resolve without an element', function() {
+
+      // when
+      const entryId = getBpmnEntryId(null, [ 'documentation' ]);
+
+      // then
+      expect(entryId).to.be.null;
+    });
+
+  });
+
+});

--- a/test/spec/provider/camunda-platform/EntryIdRendered.spec.js
+++ b/test/spec/provider/camunda-platform/EntryIdRendered.spec.js
@@ -1,0 +1,90 @@
+import { expect } from 'chai';
+
+import TestContainer from 'mocha-test-container-support';
+
+import { act } from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/render';
+
+import BpmnPropertiesProvider from 'src/provider/bpmn';
+import CamundaPlatformPropertiesProvider from 'src/provider/camunda-platform';
+
+import camundaModdleExtensions from 'camunda-bpmn-moddle/resources/camunda.json';
+
+import historyCleanupXML from './HistoryCleanupProps-process.bpmn';
+
+
+// verify the render-agnostic contract end to end: whatever id
+// CamundaPlatformPropertiesProvider resolves for a moddle path is actually
+// rendered as an entry (or group) in the DOM - so the resolver can never drift
+// from the UI
+describe('provider/camunda-platform - entry id rendered', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  function expectRenderedEntry(propertiesPanel, element, path, expectedId) {
+
+    // when
+    const entryId = propertiesPanel.getEntryId(element, path);
+
+    // then
+    expect(entryId, 'resolved entry id').to.eql(expectedId);
+
+    const rendered = domQuery(
+      `[data-entry-id="${ entryId }"], [data-group-id="group-${ entryId }"]`,
+      container
+    );
+
+    expect(rendered, `rendered entry or group "${ entryId }"`).to.exist;
+  }
+
+
+  describe('history cleanup', function() {
+
+    beforeEach(bootstrapPropertiesPanel(historyCleanupXML, {
+      modules: [
+        CoreModule,
+        ModelingModule,
+        SelectionModule,
+        BpmnPropertiesPanel,
+        BpmnPropertiesProvider,
+        CamundaPlatformPropertiesProvider
+      ],
+      moddleExtensions: {
+        camunda: camundaModdleExtensions
+      },
+      debounceInput: false
+    }));
+
+
+    it('should render bpmn:Process#historyTimeToLive', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const process = elementRegistry.get('Process_1');
+
+      await act(() => selection.select(process));
+
+      // then
+      expectRenderedEntry(propertiesPanel, process, [ 'historyTimeToLive' ], 'historyTimeToLive');
+    }));
+
+  });
+
+});

--- a/test/spec/provider/camunda-platform/EntryIdUtil.spec.js
+++ b/test/spec/provider/camunda-platform/EntryIdUtil.spec.js
@@ -1,0 +1,97 @@
+import { expect } from 'chai';
+
+import { BpmnModdle } from 'bpmn-moddle';
+
+import CamundaModdle from 'camunda-bpmn-moddle/resources/camunda';
+
+import { getCamundaPlatformEntryId } from '../../../../src/provider/camunda-platform/utils/EntryIdUtil';
+
+
+describe('provider/camunda-platform - EntryIdUtil', function() {
+
+  const moddle = new BpmnModdle({
+    camunda: CamundaModdle
+  });
+
+  function createElement(type, properties) {
+    return moddle.create(type, properties);
+  }
+
+
+  describe('#getCamundaPlatformEntryId', function() {
+
+    it('should resolve historyTimeToLive on a process', function() {
+
+      // given
+      const process = createElement('bpmn:Process', {
+        id: 'Process_1',
+        'camunda:historyTimeToLive': 'P5D'
+      });
+
+      // when
+      const entryId = getCamundaPlatformEntryId(process, [ 'historyTimeToLive' ]);
+
+      // then
+      expect(entryId).to.eql('historyTimeToLive');
+    });
+
+
+    it('should resolve historyTimeToLive via a participant processRef', function() {
+
+      // given
+      const process = createElement('bpmn:Process', {
+        id: 'Process_1',
+        'camunda:historyTimeToLive': 'P5D'
+      });
+
+      const participant = createElement('bpmn:Participant', {
+        id: 'Participant_1',
+        processRef: process
+      });
+
+      // when
+      const entryId = getCamundaPlatformEntryId(participant, [ 'processRef', 'historyTimeToLive' ]);
+
+      // then
+      expect(entryId).to.eql('historyTimeToLive');
+    });
+
+
+    it('should not resolve an unknown property', function() {
+
+      // given
+      const process = createElement('bpmn:Process', { id: 'Process_1' });
+
+      // when
+      const entryId = getCamundaPlatformEntryId(process, [ 'name' ]);
+
+      // then
+      expect(entryId).to.be.null;
+    });
+
+
+    it('should not resolve an empty path', function() {
+
+      // given
+      const process = createElement('bpmn:Process', { id: 'Process_1' });
+
+      // when
+      const entryId = getCamundaPlatformEntryId(process, []);
+
+      // then
+      expect(entryId).to.be.null;
+    });
+
+
+    it('should not resolve without an element', function() {
+
+      // when
+      const entryId = getCamundaPlatformEntryId(null, [ 'historyTimeToLive' ]);
+
+      // then
+      expect(entryId).to.be.null;
+    });
+
+  });
+
+});

--- a/test/spec/provider/zeebe/EntryIdRendered.spec.js
+++ b/test/spec/provider/zeebe/EntryIdRendered.spec.js
@@ -1,0 +1,216 @@
+import { expect } from 'chai';
+
+import TestContainer from 'mocha-test-container-support';
+
+import { act } from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/render';
+
+import BpmnPropertiesProvider from 'src/provider/bpmn';
+import ZeebePropertiesProvider from 'src/provider/zeebe';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import executionListenersXML from './ExecutionListenerProps.bpmn';
+import inputXML from './InputProps.bpmn';
+import businessIdXML from './BusinessIdProps.bpmn';
+
+
+// verify the render-agnostic contract end to end: whatever id
+// ZeebePropertiesProvider resolves for a moddle path is actually rendered as an
+// entry (or group) in the DOM - so the resolver can never drift from the UI
+describe('provider/zeebe - entry id rendered', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  function expectRenderedEntry(propertiesPanel, element, path, expectedId) {
+
+    // when
+    const entryId = propertiesPanel.getEntryId(element, path);
+
+    // then
+    expect(entryId, 'resolved entry id').to.eql(expectedId);
+
+    const rendered = domQuery(
+      `[data-entry-id="${ entryId }"], [data-group-id="group-${ entryId }"]`,
+      container
+    );
+
+    expect(rendered, `rendered entry or group "${ entryId }"`).to.exist;
+  }
+
+
+  describe('execution listeners', function() {
+
+    beforeEach(bootstrapPropertiesPanel(executionListenersXML, {
+      modules: [
+        CoreModule,
+        ModelingModule,
+        SelectionModule,
+        BpmnPropertiesPanel,
+        BpmnPropertiesProvider,
+        ZeebePropertiesProvider
+      ],
+      moddleExtensions: {
+        zeebe: zeebeModdleExtensions
+      },
+      debounceInput: false
+    }));
+
+
+    it('should render bpmn:Process#isExecutable', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const process = elementRegistry.get('Process');
+
+      await act(() => selection.select(process));
+
+      // then
+      expectRenderedEntry(propertiesPanel, process, [ 'isExecutable' ], 'isExecutable');
+    }));
+
+
+    it('should render an execution listener field', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const task = elementRegistry.get('Task_MultipleHeaders');
+
+      await act(() => selection.select(task));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        task,
+        [ 'extensionElements', 'values', 0, 'listeners', 0, 'retries' ],
+        'Task_MultipleHeaders-executionListener-0-retries'
+      );
+    }));
+
+
+    it('should render a nested execution listener header', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const task = elementRegistry.get('Task_MultipleHeaders');
+
+      await act(() => selection.select(task));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        task,
+        [ 'extensionElements', 'values', 0, 'listeners', 0, 'headers', 'values', 0, 'key' ],
+        'Task_MultipleHeaders-executionListener-0-headers-header-0-key'
+      );
+    }));
+
+  });
+
+
+  describe('io mapping', function() {
+
+    beforeEach(bootstrapPropertiesPanel(inputXML, {
+      modules: [
+        CoreModule,
+        ModelingModule,
+        SelectionModule,
+        BpmnPropertiesPanel,
+        BpmnPropertiesProvider,
+        ZeebePropertiesProvider
+      ],
+      moddleExtensions: {
+        zeebe: zeebeModdleExtensions
+      },
+      debounceInput: false
+    }));
+
+
+    it('should render an input parameter field', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => selection.select(serviceTask));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        serviceTask,
+        [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ],
+        'ServiceTask_1-input-0-source'
+      );
+    }));
+
+
+    it('should render the inputs group for the collection', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => selection.select(serviceTask));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        serviceTask,
+        [ 'extensionElements', 'values', 0, 'inputParameters' ],
+        'inputs'
+      );
+    }));
+
+  });
+
+
+  describe('business id', function() {
+
+    beforeEach(bootstrapPropertiesPanel(businessIdXML, {
+      modules: [
+        CoreModule,
+        ModelingModule,
+        SelectionModule,
+        BpmnPropertiesPanel,
+        BpmnPropertiesProvider,
+        ZeebePropertiesProvider
+      ],
+      moddleExtensions: {
+        zeebe: zeebeModdleExtensions
+      },
+      debounceInput: false
+    }));
+
+
+    it('should render zeebe:CalledElement#businessId', inject(async function(elementRegistry, selection, propertiesPanel) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_override');
+
+      await act(() => selection.select(callActivity));
+
+      // then
+      expectRenderedEntry(
+        propertiesPanel,
+        callActivity,
+        [ 'extensionElements', 'values', 0, 'businessId' ],
+        'businessId'
+      );
+    }));
+
+  });
+
+});

--- a/test/spec/provider/zeebe/EntryIdUtil.spec.js
+++ b/test/spec/provider/zeebe/EntryIdUtil.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { getZeebeEntryId } from '../../../src/provider/zeebe/utils/EntryIdUtil';
+import { getZeebeEntryId } from '../../../../src/provider/zeebe/utils/EntryIdUtil';
 
 import { BpmnModdle } from 'bpmn-moddle';
 
@@ -317,6 +317,26 @@ describe('provider/zeebe - EntryIdUtil', function() {
         // then
         expect(bindingTypeEntryId).to.eql('bindingType');
         expect(versionTagEntryId).to.eql('versionTag');
+      });
+
+
+      it('should resolve businessId', function() {
+
+        // given
+        const calledElement = createElement('zeebe:CalledElement', { businessId: 'foo' });
+
+        const callActivity = createElement('bpmn:CallActivity', {
+          id: 'CallActivity_1',
+          extensionElements: withExtensionElements([ calledElement ])
+        });
+
+        // when
+        const entryId = getZeebeEntryId(callActivity, [
+          'extensionElements', 'values', 0, 'businessId'
+        ]);
+
+        // then
+        expect(entryId).to.eql('businessId');
       });
 
     });
@@ -676,6 +696,375 @@ describe('provider/zeebe - EntryIdUtil', function() {
 
         // then
         expect(entryId).to.eql('signalName');
+      });
+
+    });
+
+
+    describe('zeebe:IoMapping (group)', function() {
+
+      it('should resolve inputParameters collection to the inputs group', function() {
+
+        // given
+        const ioMapping = createElement('zeebe:IoMapping', {
+          inputParameters: [ createElement('zeebe:Input', { source: '=foo', target: 'bar' }) ]
+        });
+
+        const serviceTask = createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ ioMapping ])
+        });
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'inputParameters'
+        ]);
+
+        // then
+        expect(entryId).to.eql('inputs');
+      });
+
+
+      it('should resolve outputParameters collection to the outputs group', function() {
+
+        // given
+        const ioMapping = createElement('zeebe:IoMapping', {
+          outputParameters: [ createElement('zeebe:Output', { source: '=foo', target: 'bar' }) ]
+        });
+
+        const serviceTask = createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ ioMapping ])
+        });
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'outputParameters'
+        ]);
+
+        // then
+        expect(entryId).to.eql('outputs');
+      });
+
+    });
+
+
+    describe('zeebe:ExecutionListener', function() {
+
+      function withExecutionListener(listener) {
+        const executionListeners = createElement('zeebe:ExecutionListeners', {
+          listeners: [ listener ]
+        });
+
+        return createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ executionListeners ])
+        });
+      }
+
+      it('should resolve eventType', function() {
+
+        // given
+        const listener = createElement('zeebe:ExecutionListener', {
+          eventType: 'start',
+          type: 'foo'
+        });
+
+        const serviceTask = withExecutionListener(listener);
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'listeners', 0, 'eventType'
+        ]);
+
+        // then
+        expect(entryId).to.eql('ServiceTask_1-executionListener-0-eventType');
+      });
+
+
+      it('should resolve type as the listenerType', function() {
+
+        // given
+        const listener = createElement('zeebe:ExecutionListener', {
+          eventType: 'start',
+          type: 'foo'
+        });
+
+        const serviceTask = withExecutionListener(listener);
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'listeners', 0, 'type'
+        ]);
+
+        // then
+        expect(entryId).to.eql('ServiceTask_1-executionListener-0-listenerType');
+      });
+
+
+      it('should resolve retries', function() {
+
+        // given
+        const listener = createElement('zeebe:ExecutionListener', {
+          eventType: 'start',
+          type: 'foo',
+          retries: '5'
+        });
+
+        const serviceTask = withExecutionListener(listener);
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'listeners', 0, 'retries'
+        ]);
+
+        // then
+        expect(entryId).to.eql('ServiceTask_1-executionListener-0-retries');
+      });
+
+
+      it('should resolve a nested header key', function() {
+
+        // given
+        const header = createElement('zeebe:Header', { key: 'foo', value: 'bar' });
+
+        const listener = createElement('zeebe:ExecutionListener', {
+          eventType: 'start',
+          type: 'foo',
+          headers: createElement('zeebe:TaskHeaders', { values: [ header ] })
+        });
+
+        const serviceTask = withExecutionListener(listener);
+
+        // when
+        const entryId = getZeebeEntryId(serviceTask, [
+          'extensionElements', 'values', 0, 'listeners', 0, 'headers', 'values', 0, 'key'
+        ]);
+
+        // then
+        expect(entryId).to.eql('ServiceTask_1-executionListener-0-headers-header-0-key');
+      });
+
+    });
+
+
+    describe('zeebe:TaskListener', function() {
+
+      it('should resolve eventType', function() {
+
+        // given
+        const listener = createElement('zeebe:TaskListener', {
+          eventType: 'assigning',
+          type: 'foo'
+        });
+
+        const taskListeners = createElement('zeebe:TaskListeners', {
+          listeners: [ listener ]
+        });
+
+        const userTask = createElement('bpmn:UserTask', {
+          id: 'UserTask_1',
+          extensionElements: withExtensionElements([ taskListeners ])
+        });
+
+        // when
+        const entryId = getZeebeEntryId(userTask, [
+          'extensionElements', 'values', 0, 'listeners', 0, 'eventType'
+        ]);
+
+        // then
+        expect(entryId).to.eql('UserTask_1-taskListener-0-eventType');
+      });
+
+    });
+
+
+    describe('bpmn:TimerEventDefinition', function() {
+
+      it('should resolve the value when the expression is present', function() {
+
+        // given
+        const timerEventDefinition = createElement('bpmn:TimerEventDefinition', {
+          timeDuration: createElement('bpmn:FormalExpression', { body: 'PT1H' })
+        });
+
+        const catchEvent = createElement('bpmn:IntermediateCatchEvent', {
+          id: 'IntermediateCatchEvent_1',
+          eventDefinitions: [ timerEventDefinition ]
+        });
+
+        // when
+        const entryId = getZeebeEntryId(catchEvent, [
+          'eventDefinitions', 0, 'timeDuration'
+        ]);
+
+        // then
+        expect(entryId).to.eql('timerEventDefinitionValue');
+      });
+
+
+      it('should return null when the expression is absent', function() {
+
+        // given
+        const timerEventDefinition = createElement('bpmn:TimerEventDefinition', {});
+
+        const catchEvent = createElement('bpmn:IntermediateCatchEvent', {
+          id: 'IntermediateCatchEvent_1',
+          eventDefinitions: [ timerEventDefinition ]
+        });
+
+        // when
+        const entryId = getZeebeEntryId(catchEvent, [
+          'eventDefinitions', 0, 'timeDuration'
+        ]);
+
+        // then
+        expect(entryId).to.be.null;
+      });
+
+    });
+
+
+    describe('bpmn:Process', function() {
+
+      it('should resolve isExecutable', function() {
+
+        // given
+        const process = createElement('bpmn:Process', {
+          id: 'Process_1',
+          isExecutable: true
+        });
+
+        // when
+        const entryId = getZeebeEntryId(process, [ 'isExecutable' ]);
+
+        // then
+        expect(entryId).to.eql('isExecutable');
+      });
+
+    });
+
+
+    describe('bpmn:Error (name)', function() {
+
+      it('should resolve name', function() {
+
+        // given
+        const error = createElement('bpmn:Error', { name: 'foo' });
+
+        const errorEventDefinition = createElement('bpmn:ErrorEventDefinition', { errorRef: error });
+
+        const endEvent = createElement('bpmn:EndEvent', {
+          id: 'EndEvent_1',
+          eventDefinitions: [ errorEventDefinition ]
+        });
+
+        // when
+        const entryId = getZeebeEntryId(endEvent, [
+          'eventDefinitions', 0, 'errorRef', 'name'
+        ]);
+
+        // then
+        expect(entryId).to.eql('errorName');
+      });
+
+    });
+
+
+    describe('bpmn:Escalation (name)', function() {
+
+      it('should resolve name', function() {
+
+        // given
+        const escalation = createElement('bpmn:Escalation', { name: 'foo' });
+
+        const escalationEventDefinition = createElement('bpmn:EscalationEventDefinition', {
+          escalationRef: escalation
+        });
+
+        const throwEvent = createElement('bpmn:IntermediateThrowEvent', {
+          id: 'IntermediateThrowEvent_1',
+          eventDefinitions: [ escalationEventDefinition ]
+        });
+
+        // when
+        const entryId = getZeebeEntryId(throwEvent, [
+          'eventDefinitions', 0, 'escalationRef', 'name'
+        ]);
+
+        // then
+        expect(entryId).to.eql('escalationName');
+      });
+
+    });
+
+
+    describe('bpmn:LinkEventDefinition', function() {
+
+      it('should resolve name', function() {
+
+        // given
+        const linkEventDefinition = createElement('bpmn:LinkEventDefinition', { name: 'foo' });
+
+        const throwEvent = createElement('bpmn:IntermediateThrowEvent', {
+          id: 'IntermediateThrowEvent_1',
+          eventDefinitions: [ linkEventDefinition ]
+        });
+
+        // when
+        const entryId = getZeebeEntryId(throwEvent, [
+          'eventDefinitions', 0, 'name'
+        ]);
+
+        // then
+        expect(entryId).to.eql('linkName');
+      });
+
+    });
+
+
+    describe('bpmn:CompensateEventDefinition', function() {
+
+      it('should resolve waitForCompletion and activityRef', function() {
+
+        // given
+        const compensateEventDefinition = createElement('bpmn:CompensateEventDefinition', {
+          waitForCompletion: true
+        });
+
+        const throwEvent = createElement('bpmn:IntermediateThrowEvent', {
+          id: 'IntermediateThrowEvent_1',
+          eventDefinitions: [ compensateEventDefinition ]
+        });
+
+        // then
+        expect(getZeebeEntryId(throwEvent, [
+          'eventDefinitions', 0, 'waitForCompletion'
+        ])).to.eql('waitForCompletion');
+
+        expect(getZeebeEntryId(throwEvent, [
+          'eventDefinitions', 0, 'activityRef'
+        ])).to.eql('activityRef');
+      });
+
+    });
+
+
+    describe('bpmn:AdHocSubProcess', function() {
+
+      it('should resolve cancelRemainingInstances', function() {
+
+        // given
+        const adHocSubProcess = createElement('bpmn:AdHocSubProcess', {
+          id: 'AdHocSubProcess_1',
+          cancelRemainingInstances: false
+        });
+
+        // when
+        const entryId = getZeebeEntryId(adHocSubProcess, [ 'cancelRemainingInstances' ]);
+
+        // then
+        expect(entryId).to.eql('cancelRemainingInstances');
       });
 
     });


### PR DESCRIPTION
### Proposed Changes

Via `propertiesPanel#getEntryId(element, path)` interested parties can resolve UI element IDs of displayed entries - from lint reports or variable references.

The returned ID can be fed into other properties panel APIs such as `propertiesPanel#showEntry`.

Supports established practices on [linting architecture](https://github.com/camunda/bpmnlint-plugin-camunda-compat/tree/main/docs).

Builds on top of https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1242

Related to https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/255
Related to https://github.com/bpmn-io/internal-docs/issues/1355

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
